### PR TITLE
Fix compile by including stdexcept

### DIFF
--- a/src/PVRIptvData.cpp
+++ b/src/PVRIptvData.cpp
@@ -26,6 +26,7 @@
 #include <string>
 #include <fstream>
 #include <map>
+#include <stdexcept>
 #include "zlib.h"
 #include "rapidxml/rapidxml.hpp"
 #include "PVRIptvData.h"


### PR DESCRIPTION
Fixes

    src/PVRIptvData.cpp: In function 'bool SafeString2Int(const string&, int&)':
    src/PVRIptvData.cpp:501:10: error: expected type-specifier
    src/PVRIptvData.cpp:501:31: error: expected unqualified-id before '&' token
    src/PVRIptvData.cpp:501:31: error: expected ')' before '&' token
    src/PVRIptvData.cpp:501:31: error: expected '{' before '&' token
    src/PVRIptvData.cpp:501:32: error: expected primary-expression before ')' token
    src/PVRIptvData.cpp:501:32: error: expected ';' before ')' token
    src/PVRIptvData.cpp:505:3: error: expected primary-expression before 'catch'
    src/PVRIptvData.cpp:505:3: error: expected ';' before 'catch'
    make[2]: *** [CMakeFiles/pvr.iptvsimple.dir/src/PVRIptvData.cpp.o] Error 1

on Ubuntu Precise.
