### PR TITLE
Fix build after #6

### DIFF
--- a/src/PVRIptvData.cpp
+++ b/src/PVRIptvData.cpp
@@ -30,7 +30,7 @@
 #include "zlib.h"
 #include "rapidxml/rapidxml.hpp"
 #include "PVRIptvData.h"
-#include "util/StringUtils.h"
+#include "kodi/util/StringUtils.h"
 
 #define M3U_START_MARKER        "#EXTM3U"
 #define M3U_INFO_MARKER         "#EXTINF"


### PR DESCRIPTION
[ 50%] [100%] Building CXX object CMakeFiles/pvr.iptvsimple.dir/src/PVRIptvData.cpp.o
Building CXX object CMakeFiles/pvr.iptvsimple.dir/src/client.cpp.o
/home/br/br3/output/build/kodi-pvr-iptvsimple-5193f5e1fddfe66f46b80fb3b73101b26c1b60a5/src/PVRIptvData.cpp:33:30: fatal error: util/StringUtils.h: No such file or directory
 #include "util/StringUtils.h"
                              ^