### PR TITLE
Minimal support for PVR Addon API 1.9.7

### DIFF
--- a/pvr.iptvsimple/addon.xml
+++ b/pvr.iptvsimple/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="1.11.3"
+  version="1.12.0"
   name="PVR IPTV Simple Client"
   provider-name="nightik">
   <requires>

--- a/pvr.iptvsimple/addon.xml
+++ b/pvr.iptvsimple/addon.xml
@@ -6,7 +6,7 @@
   provider-name="nightik">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="1.9.6"/>
+    <import addon="xbmc.pvr" version="1.9.7"/>
   </requires>
   <extension
     point="xbmc.pvrclient"

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v1.12.0
+- updated to API v1.9.7
+
 v1.11.3
 - updated language files from Transifex
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -466,10 +466,11 @@ PVR_ERROR SetRecordingPlayCount(const PVR_RECORDING &recording, int count) { ret
 PVR_ERROR SetRecordingLastPlayedPosition(const PVR_RECORDING &recording, int lastplayedposition) { return PVR_ERROR_NOT_IMPLEMENTED; }
 int GetRecordingLastPlayedPosition(const PVR_RECORDING &recording) { return -1; }
 PVR_ERROR GetRecordingEdl(const PVR_RECORDING&, PVR_EDL_ENTRY[], int*) { return PVR_ERROR_NOT_IMPLEMENTED; };
+PVR_ERROR GetTimerTypes(PVR_TIMER_TYPE types[], int *size) { return PVR_ERROR_NOT_IMPLEMENTED; }
 int GetTimersAmount(void) { return -1; }
 PVR_ERROR GetTimers(ADDON_HANDLE handle) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR AddTimer(const PVR_TIMER &timer) { return PVR_ERROR_NOT_IMPLEMENTED; }
-PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete, bool bDeleteScheduled) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR UpdateTimer(const PVR_TIMER &timer) { return PVR_ERROR_NOT_IMPLEMENTED; }
 void DemuxAbort(void) {}
 DemuxPacket* DemuxRead(void) { return NULL; }


### PR DESCRIPTION
For, J**** PVR Addon API will be bumped to version 1.9.7 to introduce a couple of new features and enhancements for timers (esp. official series recording support). => https://github.com/xbmc/xbmc/pull/7079

This PR will ensure compatibility with and add minimalistic support for PVR addon API 1.9.7. Even if the maintainers of this addon will do nothing except merging this PR and bump the addon version in Kodi, the addon will still be usable in J**** and not loose any functionality compared to Isengard, but it will not profit from the new features. For the latter, every addon maintainer must do the respective changes on his own.