### PR TITLE
Change to Add-on API 2 library type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ cmake_minimum_required(VERSION 2.6)
 
 enable_language(CXX)
 
+set(USE_KODI_API_LEVEL 2)
+
 find_package(kodi REQUIRED)
 find_package(kodiplatform REQUIRED)
 find_package(p8-platform REQUIRED)
@@ -16,7 +18,8 @@ include_directories(${kodiplatform_INCLUDE_DIRS}
                     ${PROJECT_SOURCE_DIR}/lib)
 
 set(DEPLIBS ${p8-platform_LIBRARIES}
-            ${ZLIB_LIBRARIES})
+            ${ZLIB_LIBRARIES}
+            ${kodi-addon-sharedlibrary_LIBRARIES})
 
 message(STATUS "ZLIB_LIBRARIES: ${ZLIB_LIBRARIES}")
 

--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -6,7 +6,6 @@
   provider-name="nightik">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="5.2.0"/>
   </requires>
   <extension
     point="xbmc.pvrclient"

--- a/src/PVRIptvData.h
+++ b/src/PVRIptvData.h
@@ -24,8 +24,8 @@
  */
 
 #include <vector>
+#include <kodi/api2/pvr/General.hpp>
 #include "p8-platform/util/StdString.h"
-#include "client.h"
 #include "p8-platform/threads/threads.h"
 
 struct PVRIptvEpgEntry

--- a/src/client.h
+++ b/src/client.h
@@ -23,8 +23,7 @@
  *
  */
 
-#include "kodi/libXBMC_addon.h"
-#include "kodi/libXBMC_pvr.h"
+#include <string>
 
 #define M3U_FILE_NAME          "iptv.m3u.cache"
 #define TVG_FILE_NAME          "xmltv.xml.cache"
@@ -35,11 +34,9 @@
 #define PVR_STRCPY(dest, source) do { strncpy(dest, source, sizeof(dest)-1); dest[sizeof(dest)-1] = '\0'; } while(0)
 #define PVR_STRCLR(dest) memset(dest, 0, sizeof(dest))
 
-extern bool                          m_bCreated;
-extern std::string                   g_strUserPath;
-extern std::string                   g_strClientPath;
-extern ADDON::CHelper_libXBMC_addon *XBMC;
-extern CHelper_libXBMC_pvr          *PVR;
+extern bool        m_bCreated;
+extern std::string g_strUserPath;
+extern std::string g_strClientPath;
 
 extern std::string g_strM3UPath;
 extern std::string g_strTvgPath;


### PR DESCRIPTION
This are the changes for the add-on to use API level 2 system.

The rework for Kodi is visible here: https://github.com/xbmc/xbmc/pull/9368

Add-on tested here on Linux and works OK.
