### PR TITLE
Support multiple groups per channel

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="3.2.0"
+  version="3.2.1"
   name="PVR IPTV Simple Client"
   provider-name="nightik">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v3.2.1
+- Added support for multiple groups per channel, separated by semicolon
+
 v3.2.0
 - Updated to PVR addon API v5.5.0
 


### PR DESCRIPTION
This PR adds support for multiple groups per channel, separated by semicolon.

Example:
`group-title="EN;IPTV;News"`