### PR TITLE
Backport: Added support for multiple groups per channel, separated by…

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="2.4.13"
+  version="2.4.14"
   name="PVR IPTV Simple Client"
   provider-name="nightik">
   <requires>

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v2.4.14
+- Backport: Added support for multiple groups per channel, separated by semicolon
+
 v2.4.13
 - fixed install path in the Debian package
 - remove line size limitation when parsing M3U files

--- a/src/PVRIptvData.cpp
+++ b/src/PVRIptvData.cpp
@@ -316,9 +316,9 @@ bool PVRIptvData::LoadPlayList(void)
 
   int iChannelIndex     = 0;
   int iUniqueGroupId    = 0;
-  int iCurrentGroupId   = 0;
   int iChannelNum       = g_iStartNumber;
   int iEPGTimeShift     = 0;
+  std::vector<int> iCurrentGroupId;
 
   PVRIptvChannel tmpChannel;
   tmpChannel.strTvgId       = "";
@@ -428,23 +428,31 @@ bool PVRIptvData::LoadPlayList(void)
 
         if (!strGroupName.empty())
         {
-          strGroupName = XBMC->UnknownToUTF8(strGroupName.c_str());
+          std::stringstream streamGroups(strGroupName);
 
           PVRIptvChannelGroup * pGroup;
-          if ((pGroup = FindGroup(strGroupName)) == NULL)
-          {
-            PVRIptvChannelGroup group;
-            group.strGroupName = strGroupName;
-            group.iGroupId = ++iUniqueGroupId;
-            group.bRadio = bRadio;
+          iCurrentGroupId.clear();
 
-            m_groups.push_back(group);
-            iCurrentGroupId = iUniqueGroupId;
-          }
-          else
+          while(std::getline(streamGroups, strGroupName, ';'))
           {
-            iCurrentGroupId = pGroup->iGroupId;
+            strGroupName = XBMC->UnknownToUTF8(strGroupName.c_str());
+
+            if ((pGroup = FindGroup(strGroupName)) == NULL)
+            {
+              PVRIptvChannelGroup group;
+              group.strGroupName = strGroupName;
+              group.iGroupId = ++iUniqueGroupId;
+              group.bRadio = bRadio;
+
+              m_groups.push_back(group);
+              iCurrentGroupId.push_back(iUniqueGroupId);
+            }
+            else
+            {
+              iCurrentGroupId.push_back(pGroup->iGroupId);
+            }
           }
+
         }
       }
     }
@@ -468,10 +476,11 @@ bool PVRIptvData::LoadPlayList(void)
 
       iChannelNum++;
 
-      if (iCurrentGroupId > 0) 
+      std::vector<int>::iterator it;
+      for (auto it = iCurrentGroupId.begin(); it != iCurrentGroupId.end(); ++it)
       {
-        channel.bRadio = m_groups.at(iCurrentGroupId - 1).bRadio;
-        m_groups.at(iCurrentGroupId - 1).members.push_back(iChannelIndex);
+        channel.bRadio = m_groups.at(*it - 1).bRadio;
+        m_groups.at(*it - 1).members.push_back(iChannelIndex);
       }
 
       m_channels.push_back(channel);


### PR DESCRIPTION
… semicolon

It is a backport of: #117 

All credits to @mttronc 

Backport was requested within the discussion of the original PR and here, to make maintance of a public channel list easier (german): https://github.com/jnk22/kodinerds-iptv/issues/47

[Testing]
I compiled and runtime tested it with Kodi 17.3 on linux. For me, with this patch, it is possible to assign multiple groups to a single channel (semicolon separated) as with the v18 patch.