### PR TITLE
Add XMLTV Plot Outline field for episode name

### DIFF
--- a/src/PVRIptvData.cpp
+++ b/src/PVRIptvData.cpp
@@ -280,6 +280,7 @@ bool PVRIptvData::LoadEPG(time_t iStart, time_t iEnd)
     GetNodeValue(pChannelNode, "title", entry.strTitle);
     GetNodeValue(pChannelNode, "desc", entry.strPlot);
     GetNodeValue(pChannelNode, "category", entry.strGenreString);
+    GetNodeValue(pChannelNode, "sub-title", entry.strPlotOutline);
 
     xml_node<> *pIconNode = pChannelNode->first_node("icon");
     if (pIconNode == NULL || !GetAttributeValue(pIconNode, "src", entry.strIconPath))


### PR DESCRIPTION
Schedules Direct provides episode names for a lot of it's listings, can the PlotOutline field supported by Kodi be used for this?