### PR TITLE
Add support for #EXT-X-PLAYLIST-TYPE in M3U

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="3.5.1"
+  version="3.5.2"
   name="PVR IPTV Simple Client"
   provider-name="nightik">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v3.5.2
+- Add support for #EXT-X-PLAYLIST-TYPE in M3U
+
 v3.5.1
 - Updated to PVR addon API v5.10.1
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -338,16 +338,14 @@ PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL* channel, PVR_NAMED_VALUE
   if (!channel || !properties || !iPropertiesCount)
     return PVR_ERROR_SERVER_ERROR;
 
-  if (*iPropertiesCount < 2)
+  if (*iPropertiesCount < 1)
     return PVR_ERROR_INVALID_PARAMETERS;
 
   if (m_data && m_data->GetChannel(*channel, m_currentChannel))
   {
     strncpy(properties[0].strName, PVR_STREAM_PROPERTY_STREAMURL, sizeof(properties[0].strName) - 1);
     strncpy(properties[0].strValue, m_currentChannel.strStreamURL.c_str(), sizeof(properties[0].strValue) - 1);
-    strncpy(properties[1].strName, PVR_STREAM_PROPERTY_ISREALTIMESTREAM, sizeof(properties[1].strName) - 1);
-    strncpy(properties[1].strValue, "true", sizeof(properties[1].strValue) - 1);
-    *iPropertiesCount = 2;
+    *iPropertiesCount = 1;
     if (!m_currentChannel.properties.empty())
     {
       for (auto& prop : m_currentChannel.properties)


### PR DESCRIPTION
If we find a line #EXT-X-PLAYLIST-TYPE:VOD somewhere
before the stream definition, we do not flag the
item as realtime.
If nothing is stated or the line is #EXT-X-PLAYLIST-TYPE:EVENT
we flag the channel as realtime.