### PR TITLE
Fix build version shown in Kodi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,9 @@ set(IPTV_SOURCES src/client.cpp
 set(IPTV_HEADERS src/client.h
                  src/PVRIptvData.h)
 
+addon_version(pvr.iptvsimple IPTV)
+add_definitions(-DIPTV_VERSION=${IPTV_VERSION})
+
 build_addon(pvr.iptvsimple IPTV DEPLIBS)
 
 include(CPack)

--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="3.5.5"
+  version="3.5.6"
   name="PVR IPTV Simple Client"
   provider-name="nightik">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v3.5.6
+- Correctly show build version in Kodi
+
 v3.5.5
 - Bump zlib to version 1.2.11
 


### PR DESCRIPTION
from `Version: IPTV_VERSION`
to `Version: 3.5.5`
fixes #205 