### PR TITLE
Update of German terms

### DIFF
--- a/pvr.iptvsimple/resources/language/resource.language.de_de/strings.po
+++ b/pvr.iptvsimple/resources/language/resource.language.de_de/strings.po
@@ -34,11 +34,11 @@ msgstr "Allgemein"
 
 msgctxt "#30011"
 msgid "M3U Play List Path"
-msgstr "M3U Wiedergabelistenpfad"
+msgstr "M3U-Wiedergabelistenpfad"
 
 msgctxt "#30012"
 msgid "M3U Play List URL"
-msgstr "M3U Wiedergabelisten-URL"
+msgstr "M3U-Wiedergabelisten-URL"
 
 msgctxt "#30013"
 msgid "Numbering channels starts at"
@@ -54,15 +54,15 @@ msgstr "XMLTV-Pfad"
 
 msgctxt "#30022"
 msgid "XMLTV URL"
-msgstr "XMLTV URL"
+msgstr "XMLTV-URL"
 
 msgctxt "#30023"
 msgid "Apply Time Shift To All Channels"
-msgstr "Zeitversetzung für alle Kanäle übernehmen"
+msgstr "Zeitversatz für alle Kanäle übernehmen"
 
 msgctxt "#30024"
 msgid "EPG Time Shift (hours)"
-msgstr "EPG Zeitversetzung (Stunden)"
+msgstr "EPG-Zeitversatz (Stunden)"
 
 msgctxt "#30025"
 msgid "Cache m3u at local storage"
@@ -86,7 +86,7 @@ msgstr "Basis-URL der Senderlogos"
 
 msgctxt "#30040"
 msgid "XMLTV Logos Options"
-msgstr "Einstellungen für XMLTV Logos"
+msgstr "Einstellungen für XMLTV-Logos"
 
 msgctxt "#30041"
 msgid "Channels Logos from XMLTV"


### PR DESCRIPTION
- In German, we say "Versatz" instead of "Versetzung" (Usually "Versetzung" is used in a different context. I would even recommend "Zeitverschiebung" or "Zeitunterschied".)
- According to offical German spelling rules, we have to put a "-" between constructed/combined nouns.