### PR TITLE
[cmake] remove usage of kodi-platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,13 +7,11 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 enable_language(CXX)
 
 find_package(Kodi REQUIRED)
-find_package(kodiplatform REQUIRED)
 find_package(p8-platform REQUIRED)
 find_package(Rapidxml REQUIRED)
 find_package(ZLIB REQUIRED)
 
-include_directories(${kodiplatform_INCLUDE_DIRS}
-                    ${p8-platform_INCLUDE_DIRS}
+include_directories(${p8-platform_INCLUDE_DIRS}
                     ${KODI_INCLUDE_DIR}
                     ${RAPIDXML_INCLUDE_DIRS}
                     ${ZLIB_INCLUDE_DIRS})

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: kodi-pvr-iptvsimple
 Priority: extra
 Maintainer: Anton Fedchin <anightik@gmail.com>
-Build-Depends: debhelper (>= 9.0.0), cmake, libkodiplatform-dev (>= 16.0.0),
+Build-Depends: debhelper (>= 9.0.0), cmake, libp8-platform-dev,
                kodi-addon-dev, librapidxml-dev, zlib1g-dev
 Standards-Version: 3.9.4
 Section: libs


### PR DESCRIPTION
The pvr.iptvsimple binary addon does not use kodi-platform.
Remove existing references from CMakeLists.txt and debian/control.