### PR TITLE
PVRIptvData: Fix considering DST in timestamp conversion

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="4.0.0"
+  version="4.0.1"
   name="PVR IPTV Simple Client"
   provider-name="nightik">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v4.0.1
+- Fix considering DST in timestamp conversion
+
 v4.0.0
 - Update to PVR addon API v6.0.0
 


### PR DESCRIPTION
1. Don't use the undocumented tm_gmtoff attribute (implementation specific)
2. Unify the logic for all platforms
3. Consider the diff between UTC and local time at the the particular
timestamp