### PR TITLE
Support multiple credits elements, firstAired, year, star rating, episode-num in epg entry, readme update, multiple display-names's and matching channels, plus bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ My default the addon will read the first `<category>` element of a `programme` a
 * **XMLTV Path**: If location is `Local Path` this setting should contain a valid path.
 * **XMLTV URL**: If location is `Remote Path` this setting should contain a valid URL.
 * **Cache XMLTV at local storage**: If location is `Remote path` select whether or not the the XMLTV file should be cached locally.
-* **EPG Time Shift (hours)**: Adjust the EPG times by this value in minutes, range is from -720 mins to +720 mins (+/- 12 hours).
+* **EPG Time Shift (hours)**: Adjust the EPG times by this value in minutes, range is from -12 hours to +14 hours.
 * **Apply Time Shift To All Channels**: Whether or not to override the time shift for all channels with `EPG time shift`. If not enabled `EPG time shift` plus the individual time shift per channel (if available) will be used.
 
 ### Channel Logos

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 IPTV Live TV and Radio PVR client addon for [Kodi](https://kodi.tv)
 
+For a listing of the supported M3U and XMLTV elements see the appendix [here](#supported-m3u-and-xmltv-elements)
+
 ## Build instructions
 
 ### Linux
@@ -49,7 +51,180 @@ If you would prefer to run the rebuild steps manually instead of using the above
 * [Kodi's PVR user support](http://forum.kodi.tv/forumdisplay.php?fid=167)
 * [Kodi's PVR development support](http://forum.kodi.tv/forumdisplay.php?fid=136)
 
+## Settings
+
+### General
+General settings required for the addon to function.
+
+* **Location**: Select where to find the M3U resource. The options are:
+    - `Local path` - A path to an M3U file whether it be on the device or the local network.
+    - `Remote path` - A URL specifying the location of the M3U file.
+* **M3U Play List path**: If location is `Local path` this setting must contain a valid path for the addon to function.
+* **M3U Play List URL**: If location is `Remote path` this setting must contain a valid URL for the addon to function.
+* **Cache M3U at local storage**: If location is `Remote path` select whether or not the the M3U file should be cached locally.
+* **Numbering channel starts at**: The number to start numbering channels from.
+
+### EPG Settings
+Settings related to the EPG.
+
+My default the addon will read the first `<category>` element of a `programme` and use this as the genre string. It is also possible to supply a mapping file to convert the genre string to a genre ID, allowing colour coding of the EPG. Please see: [Using a mapping file for Genres](#using-a-mapping-file-for-genres) in the Appendix for details on how to set this up.
+
+* **Location**: Select where to find the XMLTV resource. The options are:
+    - `Local path` - A path to an XMLTV file whether it be on the device or the local network.
+    - `Remote path` - A URL specifying the location of the XMLTV file.
+* **XMLTV Path**: If location is `Local Path` this setting should contain a valid path.
+* **XMLTV URL**: If location is `Remote Path` this setting should contain a valid URL.
+* **Cache XMLTV at local storage**: If location is `Remote path` select whether or not the the XMLTV file should be cached locally.
+* **EPG Time Shift (hours)**: Adjust the EPG times by this value in minutes, range is from -720 mins to +720 mins (+/- 12 hours).
+* **Apply Time Shift To All Channels**: Whether or not to override the time shift for all channels with `EPG time shift`. If not enabled `EPG time shift` plus the individual time shift per channel (if available) will be used.
+
+### Channel Logos
+Settings realted to Channel Logos.
+
+* **Location**: Select where to find the channel logos. The options are:
+    - `Local path` - A path to a folder whether it be on the device or the local network.
+    - `Remote path ` - A base URL specifying the location of the logos.
+* **Channel Logos Folder**: If location is `Local Path` this setting should contain a valid folder.
+* **Channel Logos Base URL**: If location is `Remote Path` this setting should contain a valid base URL.
+* **Channel Logos from XMLTV**: Preference on how to handle channel logos. The options are:
+    - `Ignore` - Don't use channel logos from an XMLTV file.
+    - `Prefer M3U` - Use the channel logo from the M3U if available otherwise use the XMLTV logo.
+    - `Prefer XMLTV` - Use the channel logo from the XMLTV file if available otherwise use the M3U logo.
+
 ## Appendix
+
+### Using a mapping file for Genres
+
+Users can create there own genre mapping files to map their genre strings to genre IDs. This allows the EPG UI to be colour coded per genre.
+
+Kodi uses the following standard for it's genre IDs: https://www.etsi.org/deliver/etsi_en/300400_300499/300468/01.11.01_60/en_300468v011101p.pdf
+
+The file created must be called `genres.xml` and be located here: `userdata/addon_data/pvr.iptvsimple`.
+
+Here is an exmaple of the file:
+
+```
+<genres>
+  <name>My Streams Genres Mappings</name>
+  <genre type="16" subtype="0">General Movie/Drama</genre> <!-- General Movie/Drama - 0x10 in DVB hex-->
+  <genre type="54" subtype="0">TV Show</genre>             <!-- Show/Game Show - 0x30 in DVB hex-->
+  <genre type="54" subtype="0">Game Show</genre>           <!-- Show/Game Show - 0x30 in DVB hex-->
+  <genre type="54" subtype="0">Show/Game Show</genre>      <!-- Show/Game Show - 0x30 in DVB hex-->
+  <genre type="160" subtype="0">Show/Game Show</genre>     <!-- Leisure/Hobbies - 0xA0 in DVB hex-->
+</genres>
+```
+
+- `<name>`: There should be a single `<name>` element. The value should denote the purpose of this genre mapping file.
+- `<genre>`: There can be many `genre` elements. The `type` attribute can contain a values ranging from 16 to 240 in multiples of 16 (would be 0x10 to 0xF0 if in hex) and the `subtype` attributes can contain a value from 0 to 15 (would be 0x00 to 0x0F if in hex). `subtype` is optional. The value of the `<genre>` element is what is used to map from in order to get the genre IDs. Many mapping values are allowed to map to the same IDs.
+
+Note: Once mapped to genre IDs the text displayed will be the DVB standard text and not the genre string text supplied in the XML.
+
+### Supported M3U and XMLTV elements
+
+#### M3U format elemnents:
+
+```
+#EXTM3U tvg-shift="-4.5"
+#EXTINF:0 tvg-id="channel-x" tvg-name="Channel_X" group-title="Entertainment" tvg-chno="10" tvg-logo="http://path-to-icons/channel-x.png" radio="true" tvg-shift="-3.5",Channel X
+#EXTVLCOPT:program=745
+#KODIPROP:key=val
+http://path-to-stream/live/channel-x.ts
+#EXTINF:0 tvg-id="channel-x" tvg-name="Channel-X-HD" group-title="Entertainment;HD Channels",Channel X HD
+http://path-to-stream/live/channel-x-hd.ts
+#EXTINF:0 tvg-id="channel-y" tvg-name="Channel_Y",Channel Y
+#EXTGRP:Entertainment
+http://path-to-stream/live/channel-y.ts
+#EXTINF:0,Channel Z
+http://path-to-stream/live/channel-z.ts
+```
+
+Note: The minimum required for a channel/stream is an `#EXTINF` line with a channel name and the `URL` line. E.g. a minimal version of the exmaple file above would be:
+
+```
+#EXTM3U
+#EXTINF:0,Channel X
+http://path-to-stream/live/channel-x.ts
+#EXTINF:0,Channel X HD
+http://path-to-stream/live/channel-x-hd.ts
+#EXTINF:0,Channel Y
+http://path-to-stream/live/channel-y.ts
+#EXTINF:0,Channel Z
+http://path-to-stream/live/channel-z.ts
+```
+
+- `#EXTM3U`: Marker for the start of an M3U file. Has an optional `tvg-shift` value that will be used for all channels if a `tvg-shift` value is not supplied per channel.
+- `#EXTINF`: Contains a set of values, ending with a comma followed by the `channel name`.
+  - `tvg-id`: A unique identifier for this channel used to map to the EPG XMLTV data.
+  - `tvg-name`: A name for this channel in the EPG XMLTV data.
+  - `group-title`: A semi-colon separted list of channel groups that this channel belongs to.
+  - `tvg-chno`: The number to be used for this channel.
+  - `tvg-logo`: A URL pointing to the logo for this channel.
+  - `radio`: If the value matches "true" (case insensitive) this is a radio channel.
+  - `tvg-shift`: Channel specific shift value in hours.
+- `#EXTGRP`: A semi-colon separted list of channel groups that this channel belongs to.
+- `#KODIPROP`: A single property in the format `key=value` that can be passed to Kodi. Multiple can be passed.
+- `#EXTVLCOPT`: A single property in the format `key=value` that can be passed to Kodi. Multiple can be passed.
+- `#EXT-X-PLAYLIST-TYPE`: If this element is present with a value of `VOD` (Video on Demand) the stream is marked as not being live.
+- `URL`: The final line in each channel stanza is the URL used for the stream. Appending `|User-Agent=<agent-name>` will change the user agent.
+
+When processing an XMLTV file the addon will attempt to find a channel loaded from the M3U that matches the EPG channel. It will cycle through the full set of M3U channels checking for one condition on each pass. The first channel found to match is the channel chosen for this EPG channel data.
+
+ - *1st pass*: Does the`id` attribute of the `<channel>` element from the XMLTV match the `tvg-id` from the M3U channel. If yes we have a match, don't continue.
+  - *Before the second pass*: Was a <display-name> value provided, if not skip this channels EPG data.
+ - *2nd pass*: Does the <display-name> as it is or with spaces replaced with '_''s match `tvg-name` from the M3U channel. If yes we have a match, don't continue.
+ - *3rd pass*: Does the <display-name> match the M3U `channel name`. If yes we have a match, phew, eventually found a match.
+
+#### XMLTV format elemnents:
+
+General information on the XMLTV format can be found [here](http://wiki.xmltv.org/index.php/XMLTVFormat). There is also the [DTD](https://github.com/XMLTV/xmltv/blob/master/xmltv.dtd).
+
+**Channel elements**
+```
+<channel id="channel-x">
+  <display-name>Channel X</display-name>
+  <display-name>Channel X HD</display-name>
+  <icon src="http://path-to-icons/channel-x.png"/>
+</channel>
+```
+
+- When matching against M3U channels the `id` attribute will be used first, followed by each `display-name`.
+- If multiple `icon` elements are provided only the first will be used.
+
+**Programme elements**
+```
+  <programme start="20080715003000 -0600" stop="20080715010000 -0600" channel="channel-x">
+    <title>My Show</title>
+    <desc>Description of My Show</desc>
+    <category>Drama</category>
+    <category>Mystery</category>
+    <sub-title>Episode name for My Show</sub-title>
+    <date>20080711</date>
+    <star-rating>
+      <value>6/10</value>
+    </star-rating>
+    <episode-num system="xmltv_ns">0.1.0/1</episode-num>
+    <episode-num system="onscreen">S01E02</episode-num>
+    <credits>
+      <director>Director One</director>
+      <writer>Writer One</writer>
+      <actor>Actor One</actor>
+    </credits>
+    <icon src="http://path-to-icons/my-show.png"/>
+  </programme>
+```
+The `programme` element supports the attributes `start`/`stop` in the format `YYYmmddHHMMSS +/-HHMM` and the attribute `channel` which needs to match the `channel` element's attribute `id`.
+
+- `title`: The title of the prgramme.
+- `desc`: A descption of the programme.
+- `category`: If multiple elements are provided only the first will be used to populate the genre.
+- `sub-title`: Used to populate episode name.
+- `date`: Used to populate year and first aired date.
+- `star-rating`: If multiple elements are provided only the first will be used. The value will be converted to a scale of 10 if required.
+- `episode-num`: The`xmltv_ns`system will be preferred over `onscreen` and the first successfully parsed element will be used.
+  - For `episode-num` elements using the `xmltv_ns` system at least season and episode must be supplied, i.e. `0.1` (season 1, episode 2). If the 3rd element episode part number is supplied it must contain both the part number and the total number of parts, i.e. `0.1.0/2` (season 1, episode 2, part 1 of 2).
+  - For `episode-num` elements using the `onscreen` system only the `S01E02` format is supported.
+- `credits`: Only director, writer and actor are supported (multiple of each can be supplied).
+- `icon`: If multiple elements are provided only the first will be used.
 
 ### Manual Steps to rebuild the addon on MacOSX
 

--- a/build-install-mac.sh
+++ b/build-install-mac.sh
@@ -16,7 +16,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 if [[ "$1" = /* ]]
 then
   #absolute path
-  SCRIPT_DIR=""  
+  SCRIPT_DIR=""
 else
   #relative
   SCRIPT_DIR="$SCRIPT_DIR/"
@@ -54,4 +54,6 @@ make
 
 XBMC_BUILD_ADDON_INSTALL_DIR=$(cd "$SCRIPT_DIR$1/addons/$ADDON_NAME" 2> /dev/null && pwd -P)
 rm -rf "$KODI_ADDONS_DIR/$ADDON_NAME"
+echo "Removed previous addon build from: $KODI_ADDONS_DIR"
 cp -rf "$XBMC_BUILD_ADDON_INSTALL_DIR" "$KODI_ADDONS_DIR"
+echo "Copied new addon build to: $KODI_ADDONS_DIR"

--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="3.7.2"
+  version="3.8.0"
   name="PVR IPTV Simple Client"
   provider-name="nightik">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,18 @@
+v3.8.0
+- Support multiple display-names and case insensitive tvg-id is always first, next tvg-name and then channel name find order
+- Support full timeshift range of -12 to +14 hours
+- Some providers incorrectly use tvg-ID instead of tvg-id
+- Channel groups not being clared when reading next channel
+- support episode-num for both xmltv_ns and onscreen systems in epg entry
+- Update readme for settings, supported M3U and XMLTV formats and genres
+- support star rating in epg entry
+- support firstAired and year in epg entry
+- Update OSX build scripts
+- support multiple actor/director/writers elements in epg entry
+- URLEncode and append .png ext for remote logos built from channel name
+- Timing for Playlist and EPG load
+- Removed channels loaded popup
+
 v3.7.2
 - Update build system version
 - Change header include way

--- a/pvr.iptvsimple/resources/settings.xml
+++ b/pvr.iptvsimple/resources/settings.xml
@@ -2,7 +2,7 @@
 <settings>
   <!-- M3U -->
   <category label="30010">
-    <setting id="sep1" label="30010" type="lsep"/> 
+    <setting id="sep1" label="30010" type="lsep"/>
     <setting id="m3uPathType" type="enum" label="30000" lvalues="30001|30002" default="1" />
     <setting id="m3uPath" type="file" label="30011" default="" visible="eq(-1,0)"/>
     <setting id="m3uUrl" type="text" label="30012" default="" visible="eq(-2,1)"/>
@@ -17,7 +17,7 @@
     <setting id="epgPath" type="file" label="30021" default="" visible="eq(-1,0)"/>
     <setting id="epgUrl" type="text" label="30022" default="" visible="eq(-2,1)"/>
     <setting id="epgCache" type="bool" label="30026" default="true" visible="eq(-3,1)"/>
-    <setting id="epgTimeShift" type="slider" label="30024" default="0" range="-12,.5,12" option="float"/>
+    <setting id="epgTimeShift" type="slider" label="30024" default="0" range="-12,.5,14" option="float"/>
     <setting id="epgTSOverride" type="bool" label="30023" default="false"/>
   </category>
 

--- a/src/PVRIptvData.cpp
+++ b/src/PVRIptvData.cpp
@@ -593,6 +593,8 @@ bool PVRIptvData::LoadPlayList(void)
       std::string strGroupName = "";
       std::string strRadio     = "";
 
+      iCurrentGroupId.clear();
+
       // parse line
       int iColon = (int)strLine.find(':');
       int iComma = (int)strLine.rfind(',');
@@ -649,7 +651,6 @@ bool PVRIptvData::LoadPlayList(void)
         {
           std::stringstream streamGroups(strGroupName);
           PVRIptvChannelGroup * pGroup;
-          iCurrentGroupId.clear();
 
           while(std::getline(streamGroups, strGroupName, ';'))
           {

--- a/src/PVRIptvData.cpp
+++ b/src/PVRIptvData.cpp
@@ -211,8 +211,7 @@ PVRIptvData::PVRIptvData(void)
   m_epg.clear();
   m_genres.clear();
 
-  if (LoadPlayList())
-    XBMC->QueueNotification(QUEUE_INFO, "%d channels loaded.", m_channels.size());
+  LoadPlayList();
 }
 
 void *PVRIptvData::Process(void)

--- a/src/PVRIptvData.cpp
+++ b/src/PVRIptvData.cpp
@@ -77,8 +77,7 @@ inline bool GetNodeValue(const xml_node<Ch> * pRootNode, const char* strTag, std
 template<class Ch>
 inline bool GetJoinedNodeValues(const xml_node<Ch>* pRootNode, const char* strTag, std::string& strStringValue)
 {
-  xml_node<Ch>* pChildNode = nullptr;
-  for (pChildNode = pRootNode->first_node(strTag); pChildNode; pChildNode = pChildNode->next_sibling(strTag))
+  for (xml_node<Ch>* pChildNode = pRootNode->first_node(strTag); pChildNode; pChildNode = pChildNode->next_sibling(strTag))
   {
     if (pChildNode)
     {
@@ -327,7 +326,7 @@ bool PVRIptvData::LoadEPG(time_t iStart, time_t iEnd)
       continue;
 
     bool foundChannel = false;
-    for (xml_node<> *pDisplayNameNode = pChannelNode->first_node("display-name"); pDisplayNameNode; pDisplayNameNode = pDisplayNameNode->next_sibling("display-name"))
+    for (xml_node<>* pDisplayNameNode = pChannelNode->first_node("display-name"); pDisplayNameNode; pDisplayNameNode = pDisplayNameNode->next_sibling("display-name"))
     {
       const std::string strName = pDisplayNameNode->value();
       if (FindChannel(epgChannel.strId, strName))

--- a/src/PVRIptvData.cpp
+++ b/src/PVRIptvData.cpp
@@ -23,6 +23,7 @@
  */
 
 #include <cctype>
+#include <chrono>
 #include <cmath>
 #include <ctime>
 #include <fstream>
@@ -229,6 +230,9 @@ PVRIptvData::~PVRIptvData(void)
 
 bool PVRIptvData::LoadEPG(time_t iStart, time_t iEnd)
 {
+  auto started = std::chrono::high_resolution_clock::now();
+  XBMC->Log(LOG_DEBUG, "%s EPG Load Start", __FUNCTION__);
+
   if (m_strXMLTVUrl.empty())
   {
     XBMC->Log(LOG_NOTICE, "EPG file path is not configured. EPG not loaded.");
@@ -460,12 +464,16 @@ bool PVRIptvData::LoadEPG(time_t iStart, time_t iEnd)
   }
 
   xmlDoc.clear();
-  LoadGenres();
 
-  XBMC->Log(LOG_NOTICE, "EPG Loaded.");
+  LoadGenres();
 
   if (g_iEPGLogos > 0)
     ApplyChannelsLogosFromEPG();
+
+  int milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(
+                      std::chrono::high_resolution_clock::now() - started).count();
+
+  XBMC->Log(LOG_NOTICE, "%s EPG Loaded - %d (ms)", __FUNCTION__, milliseconds);
 
   return true;
 }
@@ -547,6 +555,9 @@ bool PVRIptvData::ParseOnScreenEpisodeNumberInfo(const std::string& episodeNumbe
 
 bool PVRIptvData::LoadPlayList(void)
 {
+  auto started = std::chrono::high_resolution_clock::now();
+  XBMC->Log(LOG_DEBUG, "%s PlayList Load Start", __FUNCTION__);
+
   if (m_strM3uUrl.empty())
   {
     XBMC->Log(LOG_NOTICE, "Playlist file path is not configured. Channels not loaded.");
@@ -793,6 +804,11 @@ bool PVRIptvData::LoadPlayList(void)
   }
 
   stream.clear();
+
+  int milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(
+                      std::chrono::high_resolution_clock::now() - started).count();
+
+  XBMC->Log(LOG_NOTICE, "%s PlayList Loaded - %d (ms)", __FUNCTION__, milliseconds);
 
   if (m_channels.size() == 0)
   {

--- a/src/PVRIptvData.cpp
+++ b/src/PVRIptvData.cpp
@@ -67,6 +67,23 @@ inline bool GetNodeValue(const xml_node<Ch> * pRootNode, const char* strTag, std
 }
 
 template<class Ch>
+inline bool GetJoinedNodeValues(const xml_node<Ch>* pRootNode, const char* strTag, std::string& strStringValue)
+{
+  xml_node<Ch>* pChildNode = nullptr;
+  for (pChildNode = pRootNode->first_node(strTag); pChildNode; pChildNode = pChildNode->next_sibling(strTag))
+  {
+    if (pChildNode)
+    {
+      if (!strStringValue.empty())
+        strStringValue += ",";
+      strStringValue += pChildNode->value();
+    }
+  }
+
+  return !strStringValue.empty();
+}
+
+template<class Ch>
 inline bool GetAttributeValue(const xml_node<Ch> * pNode, const char* strAttributeName, std::string& strStringValue)
 {
   xml_attribute<Ch> *pAttribute = pNode->first_attribute(strAttributeName);
@@ -335,11 +352,12 @@ bool PVRIptvData::LoadEPG(time_t iStart, time_t iEnd)
     GetNodeValue(pChannelNode, "category", entry.strGenreString);
     GetNodeValue(pChannelNode, "sub-title", entry.strEpisodeName);
 
-    xml_node<> *pCreditsNode = pChannelNode->first_node("credits");
-    if (pCreditsNode != NULL) {
-        GetNodeValue(pCreditsNode, "actor", entry.strCast);
-        GetNodeValue(pCreditsNode, "director", entry.strDirector);
-        GetNodeValue(pCreditsNode, "writer", entry.strWriter);
+    xml_node<>* pCreditsNode = pChannelNode->first_node("credits");
+    if (pCreditsNode)
+    {
+      GetJoinedNodeValues(pCreditsNode, "actor", entry.strCast);
+      GetJoinedNodeValues(pCreditsNode, "director", entry.strDirector);
+      GetJoinedNodeValues(pCreditsNode, "writer", entry.strWriter);
     }
 
     xml_node<> *pIconNode = pChannelNode->first_node("icon");

--- a/src/PVRIptvData.cpp
+++ b/src/PVRIptvData.cpp
@@ -40,6 +40,7 @@
 #define M3U_START_MARKER        "#EXTM3U"
 #define M3U_INFO_MARKER         "#EXTINF"
 #define TVG_INFO_ID_MARKER      "tvg-id="
+#define TVG_INFO_ID_MARKER_UC   "tvg-ID=" //some providers incorrecty use an uppercase ID.
 #define TVG_INFO_NAME_MARKER    "tvg-name="
 #define TVG_INFO_LOGO_MARKER    "tvg-logo="
 #define TVG_INFO_SHIFT_MARKER   "tvg-shift="
@@ -618,6 +619,9 @@ bool PVRIptvData::LoadPlayList(void)
         strGroupName  = ReadMarkerValue(strInfoLine, GROUP_NAME_MARKER);
         strRadio      = ReadMarkerValue(strInfoLine, RADIO_MARKER);
         strTvgShift   = ReadMarkerValue(strInfoLine, TVG_INFO_SHIFT_MARKER);
+
+        if (strTvgId.empty())
+          ReadMarkerValue(strInfoLine, TVG_INFO_ID_MARKER_UC);
 
         if (strTvgId.empty())
         {

--- a/src/PVRIptvData.h
+++ b/src/PVRIptvData.h
@@ -35,8 +35,10 @@ struct PVRIptvEpgEntry
   int         iChannelId;
   int         iGenreType;
   int         iGenreSubType;
+  int         iYear;
   time_t      startTime;
   time_t      endTime;
+  time_t      firstAired;
   std::string strTitle;
   std::string strEpisodeName;
   std::string strPlotOutline;
@@ -115,7 +117,7 @@ protected:
   virtual PVRIptvEpgChannel*   FindEpgForChannel(PVRIptvChannel &channel);
   virtual bool                 FindEpgGenre(const std::string& strGenre, int& iType, int& iSubType);
   virtual bool                 GzipInflate( const std::string &compressedBytes, std::string &uncompressedBytes);
-  virtual int                  GetCachedFileContents(const std::string &strCachedName, const std::string &strFilePath, 
+  virtual int                  GetCachedFileContents(const std::string &strCachedName, const std::string &strFilePath,
                                                      std::string &strContent, const bool bUseCache = false);
   virtual void                 ApplyChannelsLogos();
   virtual void                 ApplyChannelsLogosFromEPG();

--- a/src/PVRIptvData.h
+++ b/src/PVRIptvData.h
@@ -36,6 +36,7 @@ struct PVRIptvEpgEntry
   int         iGenreType;
   int         iGenreSubType;
   int         iYear;
+  int         iStarRating;
   time_t      startTime;
   time_t      endTime;
   time_t      firstAired;

--- a/src/PVRIptvData.h
+++ b/src/PVRIptvData.h
@@ -57,7 +57,7 @@ struct PVRIptvEpgEntry
 struct PVRIptvEpgChannel
 {
   std::string                  strId;
-  std::string                  strName;
+  std::vector<std::string>     strNames;
   std::string                  strIcon;
   std::vector<PVRIptvEpgEntry> epg;
 };

--- a/src/PVRIptvData.h
+++ b/src/PVRIptvData.h
@@ -37,6 +37,9 @@ struct PVRIptvEpgEntry
   int         iGenreSubType;
   int         iYear;
   int         iStarRating;
+  int         iEpisodeNumber;
+  int         iEpisodePartNumber;
+  int         iSeasonNumber;
   time_t      startTime;
   time_t      endTime;
   time_t      firstAired;
@@ -129,6 +132,10 @@ protected:
   virtual void *Process(void);
 
 private:
+  static bool ParseEpisodeNumberInfo(const std::vector<std::pair<std::string, std::string>>& episodeNumbersList, PVRIptvEpgEntry& entry);
+  static bool ParseXmltvNsEpisodeNumberInfo(const std::string& episodeNumberString, PVRIptvEpgEntry& entry);
+  static bool ParseOnScreenEpisodeNumberInfo(const std::string& episodeNumberString, PVRIptvEpgEntry& entry);
+
   bool                              m_bTSOverride;
   int                               m_iEPGTimeShift;
   int                               m_iLastStart;

--- a/src/PVRIptvData.h
+++ b/src/PVRIptvData.h
@@ -143,6 +143,7 @@ private:
   std::string                       m_strXMLTVUrl;
   std::string                       m_strM3uUrl;
   std::string                       m_strLogoPath;
+  int                               m_logoPathType;
   std::vector<PVRIptvChannelGroup>  m_groups;
   std::vector<PVRIptvChannel>       m_channels;
   std::vector<PVRIptvEpgChannel>    m_epg;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -57,6 +57,7 @@ CHelper_libXBMC_pvr   *PVR  = NULL;
 std::string g_strTvgPath    = "";
 std::string g_strM3UPath    = "";
 std::string g_strLogoPath   = "";
+int         g_logoPathType  = 0;
 int         g_iEPGTimeShift = 0;
 int         g_iStartNumber  = 1;
 bool        g_bTSOverride   = true;
@@ -68,11 +69,11 @@ extern std::string PathCombine(const std::string &strPath, const std::string &st
 {
   std::string strResult = strPath;
   if (strResult.at(strResult.size() - 1) == '\\' ||
-      strResult.at(strResult.size() - 1) == '/') 
+      strResult.at(strResult.size() - 1) == '/')
   {
     strResult.append(strFileName);
   }
-  else 
+  else
   {
     strResult.append("/");
     strResult.append(strFileName);
@@ -97,13 +98,13 @@ void ADDON_ReadSettings(void)
 {
   char buffer[1024];
   int iPathType = 0;
-  if (!XBMC->GetSetting("m3uPathType", &iPathType)) 
+  if (!XBMC->GetSetting("m3uPathType", &iPathType))
   {
     iPathType = 1;
   }
   if (iPathType)
   {
-    if (XBMC->GetSetting("m3uUrl", &buffer)) 
+    if (XBMC->GetSetting("m3uUrl", &buffer))
     {
       g_strM3UPath = buffer;
     }
@@ -114,23 +115,23 @@ void ADDON_ReadSettings(void)
   }
   else
   {
-    if (XBMC->GetSetting("m3uPath", &buffer)) 
+    if (XBMC->GetSetting("m3uPath", &buffer))
     {
       g_strM3UPath = buffer;
     }
     g_bCacheM3U = false;
   }
-  if (!XBMC->GetSetting("startNum", &g_iStartNumber)) 
+  if (!XBMC->GetSetting("startNum", &g_iStartNumber))
   {
     g_iStartNumber = 1;
   }
-  if (!XBMC->GetSetting("epgPathType", &iPathType)) 
+  if (!XBMC->GetSetting("epgPathType", &iPathType))
   {
     iPathType = 1;
   }
   if (iPathType)
   {
-    if (XBMC->GetSetting("epgUrl", &buffer)) 
+    if (XBMC->GetSetting("epgUrl", &buffer))
     {
       g_strTvgPath = buffer;
     }
@@ -141,7 +142,7 @@ void ADDON_ReadSettings(void)
   }
   else
   {
-    if (XBMC->GetSetting("epgPath", &buffer)) 
+    if (XBMC->GetSetting("epgPath", &buffer))
     {
       g_strTvgPath = buffer;
     }
@@ -156,11 +157,12 @@ void ADDON_ReadSettings(void)
   {
     g_bTSOverride = true;
   }
-  if (!XBMC->GetSetting("logoPathType", &iPathType)) 
+  if (!XBMC->GetSetting("logoPathType", &iPathType))
   {
     iPathType = 1;
   }
-  if (XBMC->GetSetting(iPathType ? "logoBaseUrl" : "logoPath", &buffer)) 
+  g_logoPathType = iPathType;
+  if (XBMC->GetSetting(iPathType ? "logoBaseUrl" : "logoPath", &buffer))
   {
     g_strLogoPath = buffer;
   }
@@ -228,7 +230,7 @@ void ADDON_Destroy()
 
 ADDON_STATUS ADDON_SetSetting(const char *settingName, const void *settingValue)
 {
-  // reset cache and restart addon 
+  // reset cache and restart addon
 
   std::string strFile = GetUserFilePath(M3U_FILE_NAME);
   if (XBMC->FileExists(strFile.c_str(), false))

--- a/src/client.h
+++ b/src/client.h
@@ -44,6 +44,7 @@ extern CHelper_libXBMC_pvr          *PVR;
 extern std::string g_strM3UPath;
 extern std::string g_strTvgPath;
 extern std::string g_strLogoPath;
+extern int         g_logoPathType;
 extern int         g_iEPGTimeShift;
 extern int         g_iStartNumber;
 extern bool        g_bTSOverride;


### PR DESCRIPTION
v3.8.0
- Support multiple display-names and case insensitive tvg-id is always first, next tvg-name and then channel name find order
- Support full timeshift range of -12 to +14 hours
- Some providers incorrectly use tvg-ID instead of tvg-id
- Channel groups not being clared when reading next channel
- support episode-num for both xmltv_ns and onscreen systems in epg entry
- Update readme for settings, supported M3U and XMLTV formats and genres
- support star rating in epg entry
- support firstAired and year in epg entry
- Update OSX build scripts
- support multiple actor/director/writers elements in epg entry
- URLEncode and append .png ext for remote logos built from channel name
- Added: Timing for Playlist and EPG load