### PR TITLE
Support multiple credits elements, firstAired, year, star rating, episode-num in epg entry, readme update, multiple display-names's and matching channels, plus bugfixes - Matrix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,8 @@ set(IPTV_SOURCES src/client.cpp
                  src/iptvsimple/data/EpgEntry.cpp
                  src/iptvsimple/data/EpgGenre.cpp
                  src/iptvsimple/utilities/FileUtils.cpp
-                 src/iptvsimple/utilities/Logger.cpp)
+                 src/iptvsimple/utilities/Logger.cpp
+                 src/iptvsimple/utilities/WebUtils.cpp)
 
 set(IPTV_HEADERS src/client.h
                  src/PVRIptvData.h
@@ -47,6 +48,7 @@ set(IPTV_HEADERS src/client.h
                  src/iptvsimple/data/EpgGenre.h
                  src/iptvsimple/utilities/FileUtils.h
                  src/iptvsimple/utilities/Logger.h
+                 src/iptvsimple/utilities/WebUtils.h
                  src/iptvsimple/utilities/XMLUtils.h)
 
 addon_version(pvr.iptvsimple IPTV)

--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ General settings required for the addon to function.
 * **Cache M3U at local storage**: If location is `Remote path` select whether or not the the M3U file should be cached locally.
 * **Start channel number**: The number to start numbering channels from.
 
-### EPG Settings
+### EPG
 Settings related to the EPG.
 
-My default the addon will read the first `<category>` element of a `programme` and use this as the genre string. It is also possible to supply a mapping file to convert the genre string to a genre ID, allowing colour coding of the EPG. Please see: [Using a mapping file for Genres](#using-a-mapping-file-for-genres) in the Appendix for details on how to set this up.
+For settings related to genres please see the next section.
 
 * **Location**: Select where to find the XMLTV resource. The options are:
     - `Local path` - A path to an XMLTV file whether it be on the device or the local network.
@@ -78,6 +78,18 @@ My default the addon will read the first `<category>` element of a `programme` a
 * **Cache XMLTV at local storage**: If location is `Remote path` select whether or not the the XMLTV file should be cached locally.
 * **EPG time shift**: Adjust the EPG times by this value in minutes, range is from -720 mins to +840 mins (- 12 hours to +14 hours).
 * **Apply time shift to all channels**: Whether or not to override the time shift for all channels with `EPG time shift`. If not enabled `EPG time shift` plus the individual time shift per channel (if available) will be used.
+
+### Genres
+Settings related to genres.
+
+The addon will read all the `<category>` elements of a `programme` and use this as the genre string. It is also possible to supply a mapping file to convert the genre string to a genre ID, allowing colour coding of the EPG. When using a mapping file each category will be checked in order until a match is found. Please see: [Using a mapping file for Genres](#using-a-mapping-file-for-genres) in the Appendix for details on how to set this up.
+
+* **Use genre text from XMLTV when mapping genres**: If enabled, and a genre mapping file is used to get a genre type and sub type use the EPG's genre text (i.e. 'category' text) for the genre instead of the kodi default text. Only the genre type (and not the sub type) will be used if a mapping is found.
+* **Location**: Select where to find the genres XML resource. The options are:
+    - `Local path` - A path to a gernes XML file whether it be on the device or the local network.
+    - `Remote path` - A URL specifying the location of the genres XML file.
+* **Genres path**: If location is `Local Path` this setting should contain a valid path.
+* **Genres URL**: If location is `Remote Path` this setting should contain a valid URL.
 
 ### Channel Logos
 Settings realted to Channel Logos.
@@ -94,7 +106,15 @@ Settings realted to Channel Logos.
 
 ## Appendix
 
-### Supported M3U and XMLTV elements
+The various config files have examples allowing users to create their own, making it possible to support custom config, currently regarding genres. The best way to learn about them is to read the config files themselves. Each contains details of how the config file works.
+
+All of the files listed below are overwritten each time the addon starts (excluding genres.xml). Therefore if you are customising files please create new copies with different file names. Note: that only the files below are overwritten any new files you create will not be touched.
+
+After adding and selecting new config files you will need to clear the EPG cache `Settings->PVR & Live TV->Guide->Clear cache` for it to take effect in the case of EPG relatd config and for channel related config will need to clear the full cache `Settings->PVR & Live TV->General->Clear cache`.
+
+If you would like to support other formats/languages please raise an issue at the github project https://github.com/kodi-pvr/pvr.iptvsimple, where you can either create a PR or request your new configs be shipped with the addon.
+
+There is one config file located here: `userdata/addon_data/pvr.iptvsimple/genres/kodiDvbGenres.xml`. This simply contains the DVB genre IDs that Kodi supports and uses hex for the IDs. Can be a useful reference if creating your own configs. There is also `userdata/addon_data/pvr.iptvsimple/genres/kodiDvbGenresTypeSubtype.xml`, which uses two decimal values instead of hex. This file is also overwritten each time the addon restarts.
 
 ### Using a mapping file for Genres
 
@@ -102,24 +122,68 @@ Users can create there own genre mapping files to map their genre strings to gen
 
 Kodi uses the following standard for it's genre IDs: https://www.etsi.org/deliver/etsi_en/300400_300499/300468/01.11.01_60/en_300468v011101p.pdf
 
-The file created must be called `genres.xml` and be located here: `userdata/addon_data/pvr.iptvsimple`.
+By default the addon will try to load a file called `genres.xml` and expect it to be here: `userdata/addon_data/pvr.iptvsimple/genres/genreTextMappings/`. However any genres file can be chosen in the addon settings.
 
-Here is an exmaple of the file:
+The following files are currently available with the addon (this file uses hexadeciaml genreId's):
+    - `Rytec-UK-Ireland.xml`
+
+The file can specify either a hexadecimal `genreId` attribute (recommended) or separate integer values for `type` and `subType`. Mathematically `genreId` is equals to the logical OR or `type` and `subType`, i.e. `genreId = type | subType`.
+
+Note: Once mapped to genre IDs the text displayed can either be the DVB standard text or the genre string text supplied in the XML. If using the text supplied in the XML only the genre type will be passed and each value will correspond to a category and colour (depedning on skin) on the UI. Here are the categories (all examples have 0 for the sub type). It's imortant you map correctly as genres can be used for search.
+
+```
+- 0x10: General Movie / Drama
+- 0x20: News / Current Affairs
+- 0x30: Show / Game Show
+- 0x40: Sports
+- 0x50: Children's / Youth Programmes
+- 0x60: Music / Ballet / Dance
+- 0x70: Arts / Culture
+- 0x80: Social / Political / Economics
+- 0x90: Education / Science / Factual
+- 0xA0: Leisure / Hobbies
+- 0xB0: Special Characteristics
+```
+
+- `<name>`: There should be a single `<name>` element. The value should denote the purpose of this genre mapping file.
+- The value of the `<genre>` element is what is used to map from in order to get the genre IDs. Many mapping values are allowed to map to the same IDs.
+
+**Example using hexadecimal `genreId` attributes (recommended)**:
 
 ```
 <genres>
   <name>My Streams Genres Mappings</name>
-  <genre type="1" subtype="0">General Movie/Drama</genre> <!-- General Movie/Drama - 0x10 in DVB hex-->
-  <genre type="3" subtype="0">TV Show</genre>             <!-- Show/Game Show - 0x30 in DVB hex-->
-  <genre type="3" subtype="0">Game Show</genre>           <!-- Show/Game Show - 0x30 in DVB hex-->
-  <genre type="3" subtype="0">Show/Game Show</genre>      <!-- Show/Game Show - 0x30 in DVB hex-->
-  <genre type="10" subtype="0">Show/Game Show</genre>     <!-- Leisure/Hobbies - 0xA0 in DVB hex-->
+  <genre genreId="0x10">Movie</genre>               <!-- General Movie/Drama - 0x10 in DVB hex-->
+  <genre genreId="0x10">Movie - Comedy</genre>      <!-- General Movie/Drama - 0x10 in DVB hex-->
+  <genre genreId="0x10">Movie - Romance</genre>     <!-- General Movie/Drama - 0x10 in DVB hex-->
+  <genre genreId="0x30">TV Show</genre>             <!-- Show/Game Show - 0x30 in DVB hex-->
+  <genre genreId="0x30">Game Show</genre>           <!-- Show/Game Show - 0x30 in DVB hex-->
+  <genre genreId="0x30">Talk Show</genre>           <!-- Show/Game Show - 0x30 in DVB hex-->
+  <genre genreId="0xA0">Leisure</genre>             <!-- Leisure/Hobbies - 0xA0 in DVB hex-->
 </genres>
 ```
 
-- `<name>`: There should be a single `<name>` element. The value should denote the purpose of this genre mapping file.
-- `<genre>`: There can be many `genre` elements. Both the `type` and `subtype` attributes can contain a value from 0 to 15 (would be 0x0 to 0xF if in DVB hex). `subtype` is optional. The value of the `<genre>` element is what is used to map from in order to get the genre IDs. Many mapping values are allowed to map to the same IDs.
-Note: Once mapped to genre IDs the text displayed will be the DVB standard text and not the genre string text supplied in the XML.
+- The `genreId` attribute is a single hex value ranging from 0x10 to 0xFF.
+
+**Example using integer `type` and `subtype` attributes**:
+
+```
+<genres>
+  <name>My Streams Genres Mappings</name>
+  <genre type="16" subtype="0">Movie</genre>               <!-- General Movie/Drama - 0x10 in DVB hex-->
+  <genre type="16" subtype="0">Movie - Comedy</genre>      <!-- General Movie/Drama - 0x10 in DVB hex-->
+  <genre type="16" subtype="0">Movie - Romance</genre>     <!-- General Movie/Drama - 0x10 in DVB hex-->
+  <genre type="54" subtype="0">TV Show</genre>             <!-- Show/Game Show - 0x30 in DVB hex-->
+  <genre type="54" subtype="0">Game Show</genre>           <!-- Show/Game Show - 0x30 in DVB hex-->
+  <genre type="54" subtype="0">Talk Show</genre>           <!-- Show/Game Show - 0x30 in DVB hex-->
+  <genre type="160" subtype="0">Leisure</genre>            <!-- Leisure/Hobbies - 0xA0 in DVB hex-->
+</genres>
+```
+
+- The `type` attribute can contain a values ranging from 16 to 240 in multiples of 16 (would be 0x10 to 0xF0 if in hex) and the `subtype` attributes can contain a value from 0 to 15 (would be 0x00 to 0x0F if in hex). `subtype` is optional.
+
+
+### Supported M3U and XMLTV elements
 
 #### M3U format elemnents:
 
@@ -233,7 +297,7 @@ The following steps can be followed manually instead of using the `build-install
 **To rebuild the addon after changes**
 
 1. `rm tools/depends/target/binary-addons/.installed-macosx*`
-2. `make -j$(getconf _NPROCESSORS_ONLN) -C tools/depends/target/binary-addons ADDONS="pvr.vuplus" ADDON_SRC_PREFIX=$HOME`
+2. `make -j$(getconf _NPROCESSORS_ONLN) -C tools/depends/target/binary-addons ADDONS="pvr.iptvsimple" ADDON_SRC_PREFIX=$HOME`
 
 or
 
@@ -242,5 +306,5 @@ or
 
 **Copy the addon to the Kodi addon directory on Mac**
 
-1. `rm -rf "$HOME/Library/Application Support/Kodi/addons/pvr.vuplus"`
-2. `cp -rf $HOME/xbmc-addon/addons/pvr.vuplus "$HOME/Library/Application Support/Kodi/addons"`
+1. `rm -rf "$HOME/Library/Application Support/Kodi/addons/pvr.iptvsimple"`
+2. `cp -rf $HOME/xbmc-addon/addons/pvr.iptvsimple "$HOME/Library/Application Support/Kodi/addons"`

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ General settings required for the addon to function.
 * **M3U play list URL**: If location is `Remote path` this setting must contain a valid URL for the addon to function.
 * **Cache M3U at local storage**: If location is `Remote path` select whether or not the the M3U file should be cached locally.
 * **Start channel number**: The number to start numbering channels from.
+* **Only number by channel order in M3U**: Ignore any 'tvg-chno' tags and only number channels by the order in the M3U starting at 'Start channel number'.
 
 ### EPG
 Settings related to the EPG.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 IPTV Live TV and Radio PVR client addon for [Kodi](https://kodi.tv)
 
+For a listing of the supported M3U and XMLTV elements see the appendix [here](#supported-m3u-and-xmltv-elements)
+
 ## Build instructions
 
 ### Linux
@@ -66,6 +68,8 @@ General settings required for the addon to function.
 ### EPG Settings
 Settings related to the EPG.
 
+My default the addon will read the first `<category>` element of a `programme` and use this as the genre string. It is also possible to supply a mapping file to convert the genre string to a genre ID, allowing colour coding of the EPG. Please see: [Using a mapping file for Genres](#using-a-mapping-file-for-genres) in the Appendix for details on how to set this up.
+
 * **Location**: Select where to find the XMLTV resource. The options are:
     - `Local path` - A path to an XMLTV file whether it be on the device or the local network.
     - `Remote path` - A URL specifying the location of the XMLTV file.
@@ -89,6 +93,138 @@ Settings realted to Channel Logos.
     - `Prefer XMLTV` - Use the channel logo from the XMLTV file if available otherwise use the M3U logo.
 
 ## Appendix
+
+### Supported M3U and XMLTV elements
+
+### Using a mapping file for Genres
+
+Users can create there own genre mapping files to map their genre strings to genre IDs. This allows the EPG UI to be colour coded per genre.
+
+Kodi uses the following standard for it's genre IDs: https://www.etsi.org/deliver/etsi_en/300400_300499/300468/01.11.01_60/en_300468v011101p.pdf
+
+The file created must be called `genres.xml` and be located here: `userdata/addon_data/pvr.iptvsimple`.
+
+Here is an exmaple of the file:
+
+```
+<genres>
+  <name>My Streams Genres Mappings</name>
+  <genre type="1" subtype="0">General Movie/Drama</genre> <!-- General Movie/Drama - 0x10 in DVB hex-->
+  <genre type="3" subtype="0">TV Show</genre>             <!-- Show/Game Show - 0x30 in DVB hex-->
+  <genre type="3" subtype="0">Game Show</genre>           <!-- Show/Game Show - 0x30 in DVB hex-->
+  <genre type="3" subtype="0">Show/Game Show</genre>      <!-- Show/Game Show - 0x30 in DVB hex-->
+  <genre type="10" subtype="0">Show/Game Show</genre>     <!-- Leisure/Hobbies - 0xA0 in DVB hex-->
+</genres>
+```
+
+- `<name>`: There should be a single `<name>` element. The value should denote the purpose of this genre mapping file.
+- `<genre>`: There can be many `genre` elements. Both the `type` and `subtype` attributes can contain a value from 0 to 15 (would be 0x0 to 0xF if in DVB hex). `subtype` is optional. The value of the `<genre>` element is what is used to map from in order to get the genre IDs. Many mapping values are allowed to map to the same IDs.
+Note: Once mapped to genre IDs the text displayed will be the DVB standard text and not the genre string text supplied in the XML.
+
+#### M3U format elemnents:
+
+```
+#EXTM3U tvg-shift="-4.5"
+#EXTINF:0 tvg-id="channel-x" tvg-name="Channel_X" group-title="Entertainment" tvg-chno="10" tvg-logo="http://path-to-icons/channel-x.png" radio="true" tvg-shift="-3.5",Channel X
+#EXTVLCOPT:program=745
+#KODIPROP:key=val
+http://path-to-stream/live/channel-x.ts
+#EXTINF:0 tvg-id="channel-x" tvg-name="Channel-X-HD" group-title="Entertainment;HD Channels",Channel X HD
+http://path-to-stream/live/channel-x-hd.ts
+#EXTINF:0 tvg-id="channel-y" tvg-name="Channel_Y",Channel Y
+#EXTGRP:Entertainment
+http://path-to-stream/live/channel-y.ts
+#EXTINF:0,Channel Z
+http://path-to-stream/live/channel-z.ts
+```
+
+Note: The minimum required for a channel/stream is an `#EXTINF` line with a channel name and the `URL` line. E.g. a minimal version of the exmaple file above would be:
+
+```
+#EXTM3U
+#EXTINF:0,Channel X
+http://path-to-stream/live/channel-x.ts
+#EXTINF:0,Channel X HD
+http://path-to-stream/live/channel-x-hd.ts
+#EXTINF:0,Channel Y
+http://path-to-stream/live/channel-y.ts
+#EXTINF:0,Channel Z
+http://path-to-stream/live/channel-z.ts
+```
+
+- `#EXTM3U`: Marker for the start of an M3U file. Has an optional `tvg-shift` value that will be used for all channels if a `tvg-shift` value is not supplied per channel.
+- `#EXTINF`: Contains a set of values, ending with a comma followed by the `channel name`.
+  - `tvg-id`: A unique identifier for this channel used to map to the EPG XMLTV data.
+  - `tvg-name`: A name for this channel in the EPG XMLTV data.
+  - `group-title`: A semi-colon separted list of channel groups that this channel belongs to.
+  - `tvg-chno`: The number to be used for this channel.
+  - `tvg-logo`: A URL pointing to the logo for this channel.
+  - `radio`: If the value matches "true" (case insensitive) this is a radio channel.
+  - `tvg-shift`: Channel specific shift value in hours.
+- `#EXTGRP`: A semi-colon separted list of channel groups that this channel belongs to.
+- `#KODIPROP`: A single property in the format `key=value` that can be passed to Kodi. Multiple can be passed.
+- `#EXTVLCOPT`: A single property in the format `key=value` that can be passed to Kodi. Multiple can be passed.
+- `#EXT-X-PLAYLIST-TYPE`: If this element is present with a value of `VOD` (Video on Demand) the stream is marked as not being live.
+- `URL`: The final line in each channel stanza is the URL used for the stream. Appending `|User-Agent=<agent-name>` will change the user agent.
+
+When processing an XMLTV file the addon will attempt to find a channel loaded from the M3U that matches the EPG channel. It will cycle through the full set of M3U channels checking for one condition on each pass. The first channel found to match is the channel chosen for this EPG channel data.
+
+ - *1st pass*: Does the`id` attribute of the `<channel>` element from the XMLTV match the `tvg-id` from the M3U channel. If yes we have a match, don't continue.
+  - *Before the second pass*: Was a <display-name> value provided, if not skip this channels EPG data.
+ - *2nd pass*: Does the <display-name> as it is or with spaces replaced with '_''s match `tvg-name` from the M3U channel. If yes we have a match, don't continue.
+ - *3rd pass*: Does the <display-name> match the M3U `channel name`. If yes we have a match, phew, eventually found a match.
+
+#### XMLTV format elemnents:
+
+General information on the XMLTV format can be found [here](http://wiki.xmltv.org/index.php/XMLTVFormat). There is also the [DTD](https://github.com/XMLTV/xmltv/blob/master/xmltv.dtd).
+
+**Channel elements**
+```
+<channel id="channel-x">
+  <display-name>Channel X</display-name>
+  <display-name>Channel X HD</display-name>
+  <icon src="http://path-to-icons/channel-x.png"/>
+</channel>
+```
+
+- When matching against M3U channels the `id` attribute will be used first, followed by each `display-name`.
+- If multiple `icon` elements are provided only the first will be used.
+
+**Programme elements**
+```
+  <programme start="20080715003000 -0600" stop="20080715010000 -0600" channel="channel-x">
+    <title>My Show</title>
+    <desc>Description of My Show</desc>
+    <category>Drama</category>
+    <category>Mystery</category>
+    <sub-title>Episode name for My Show</sub-title>
+    <date>20080711</date>
+    <star-rating>
+      <value>6/10</value>
+    </star-rating>
+    <episode-num system="xmltv_ns">0.1.0/1</episode-num>
+    <episode-num system="onscreen">S01E02</episode-num>
+    <credits>
+      <director>Director One</director>
+      <writer>Writer One</writer>
+      <actor>Actor One</actor>
+    </credits>
+    <icon src="http://path-to-icons/my-show.png"/>
+  </programme>
+```
+The `programme` element supports the attributes `start`/`stop` in the format `YYYmmddHHMMSS +/-HHMM` and the attribute `channel` which needs to match the `channel` element's attribute `id`.
+
+- `title`: The title of the prgramme.
+- `desc`: A descption of the programme.
+- `category`: If multiple elements are provided only the first will be used to populate the genre.
+- `sub-title`: Used to populate episode name.
+- `date`: Used to populate year and first aired date.
+- `star-rating`: If multiple elements are provided only the first will be used. The value will be converted to a scale of 10 if required.
+- `episode-num`: The`xmltv_ns`system will be preferred over `onscreen` and the first successfully parsed element will be used.
+  - For `episode-num` elements using the `xmltv_ns` system at least season and episode must be supplied, i.e. `0.1` (season 1, episode 2). If the 3rd element episode part number is supplied it must contain both the part number and the total number of parts, i.e. `0.1.0/2` (season 1, episode 2, part 1 of 2).
+  - For `episode-num` elements using the `onscreen` system only the `S01E02` format is supported.
+- `credits`: Only director, writer and actor are supported (multiple of each can be supplied).
+- `icon`: If multiple elements are provided only the first will be used.
 
 ### Manual Steps to rebuild the addon on MacOSX
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ My default the addon will read the first `<category>` element of a `programme` a
 * **XMLTV path**: If location is `Local Path` this setting should contain a valid path.
 * **XMLTV URL**: If location is `Remote Path` this setting should contain a valid URL.
 * **Cache XMLTV at local storage**: If location is `Remote path` select whether or not the the XMLTV file should be cached locally.
-* **EPG time shift**: Adjust the EPG times by this value in minutes, range is from -720 mins to +720 mins (+/- 12 hours).
+* **EPG time shift**: Adjust the EPG times by this value in minutes, range is from -720 mins to +840 mins (- 12 hours to +14 hours).
 * **Apply time shift to all channels**: Whether or not to override the time shift for all channels with `EPG time shift`. If not enabled `EPG time shift` plus the individual time shift per channel (if available) will be used.
 
 ### Channel Logos

--- a/build-install-mac.sh
+++ b/build-install-mac.sh
@@ -54,4 +54,6 @@ make
 
 XBMC_BUILD_ADDON_INSTALL_DIR=$(cd "$SCRIPT_DIR$1/addons/$ADDON_NAME" 2> /dev/null && pwd -P)
 rm -rf "$KODI_ADDONS_DIR/$ADDON_NAME"
+echo "Removed previous addon build from: $KODI_ADDONS_DIR"
 cp -rf "$XBMC_BUILD_ADDON_INSTALL_DIR" "$KODI_ADDONS_DIR"
+echo "Copied new addon build to: $KODI_ADDONS_DIR"

--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="4.4.0"
+  version="4.5.0"
   name="PVR IPTV Simple Client"
   provider-name="nightik">
   <requires>@ADDON_DEPENDS@</requires>
@@ -19,7 +19,7 @@
     <summary lang="de_DE">Kodi PVR Addon für IPTV Unterstützung. https://github.com/afedchin/Kodi-addon-iptvsimple/wiki/IPTV-Simple-Home</summary>
     <summary lang="el_GR">Πρόσθετο του Kodi για PVR, με υποστήριξη IPTV. Για λεπτομέρειες επισκεφθείτε το: https://github.com/afedchin/Kodi-addon-iptvsimple/wiki/IPTV-Simple-Home</summary>
     <summary lang="en_AU">Kodi PVR addon for IPTV support. https://github.com/afedchin/Kodi-addon-iptvsimple/wiki/IPTV-Simple-Home</summary>
-    <summary lang="en_GB">Kodi PVR addon for IPTV support. https://github.com/afedchin/Kodi-addon-iptvsimple/wiki/IPTV-Simple-Home</summary>
+    <summary lang="en_GB">Kodi PVR addon for IPTV support.</summary>
     <summary lang="en_NZ">Kodi PVR addon for IPTV support. https://github.com/afedchin/Kodi-addon-iptvsimple/wiki/IPTV-Simple-Home</summary>
     <summary lang="en_US">Kodi PVR addon for IPTV support. https://github.com/afedchin/Kodi-addon-iptvsimple/wiki/IPTV-Simple-Home</summary>
     <summary lang="es_AR">Addon Kodi PVR  para soporte IPTV. https://github.com/afedchin/Kodi-addon-iptvsimple/wiki/IPTV-Simple-Home</summary>
@@ -69,7 +69,7 @@
     <description lang="de_DE">IPTV Simple PVR Client unterstützt m3u Wiedergabelisten, Streaming von Live TV für Multicast/Unicast Quellen, Radiosender und EPG.</description>
     <description lang="el_GR">Απλός Πελάτης PVR του IPTV, με υποστήριξη λιστών αναπαραγωγής m3u, αναπαραγωγή ροών Live TV για πηγές πολλαπλής/μοναδικής διανομής, ακρόαση ραδιοφωνικών καναλιών και EPG.</description>
     <description lang="en_AU">IPTV Simple PVR Client support m3u playlists, streaming of Live TV for multicast/unicast sources, listening to Radio channels and EPG.</description>
-    <description lang="en_GB">IPTV Simple PVR Client support m3u playlists, streaming of Live TV for multicast/unicast sources, listening to Radio channels and EPG.</description>
+    <description lang="en_GB">IPTV Simple PVR Client support m3u playlists, streaming of Live TV for multicast/unicast sources, listening to Radio channels and EPG.&#10;    &#10;For documentation visit: https://github.com/kodi-pvr/pvr.iptvsimple/blob/master/README.md&#10;    </description>
     <description lang="en_NZ">IPTV Simple PVR Client support m3u playlists, streaming of Live TV for multicast/unicast sources, listening to Radio channels and EPG.</description>
     <description lang="en_US">IPTV Simple PVR Client support m3u playlists, streaming of Live TV for multicast/unicast sources, listening to Radio channels and EPG.</description>
     <description lang="es_AR">Cliente simple PVR IPTV.  Reproduce de TV en Vivo multicast/unicast y listas m3u8&#10; . reproduce tambien canales de radio y GEP</description>
@@ -158,5 +158,58 @@
     <disclaimer lang="zh_CN">这是不稳定版的软件！作者不对录像失败、错误定时造成时间浪费或其它不良影响负责。</disclaimer>
     <disclaimer lang="zh_TW">這是測試中的軟體！原創作者無法針對以下情況負責：包括播放失敗，不正確的電子節目表，多餘的時數，或任何不可預期的不良影響。</disclaimer>
     <platform>@PLATFORM@</platform>
+    <news>
+v4.5.0
+- Fixed: Support full timeshift range of -12 to +14 hours
+- Fixed: Some providers incorrectly use tvg-ID instead of tvg-id
+- Fixed: Support multiple display-names and case insensitive tvg-id is always first, next tvg-name and then channel name find order
+- Added: support episode-num for both xmltv_ns and onscreen systems in epg entry
+- Added: Update readme for supported M3U and XMLTV formats and genres
+- Added: support star rating in epg entry
+- Added: support firstAired and year in epg entry
+- Added: Update OSX build script
+- Added: support multiple actor/director/writers elements in epg entry
+- Added: URLEncode and append .png ext for remote logos built from channel name
+- Added: Support for mapping by genre hex ID and added example files and settings
+- Added: Timing for Playlist and EPG Load
+- Added: Option to number channels by M3U order only
+- Update: Debug logging
+- Added: Channel group member order set to M3U order
+- Fixed: Fix segfault for compressed EPG files
+- Added: Add ordering for groups as per PVR API 6.1.0
+
+v4.4.0
+- Update: Recompile for 6.1.0 PVR Addon API compatibility
+
+v4.3.0
+- Added: Auto reload channels, groups and EPG on settings change
+- Added: Support for #EXTGRP tag in M3U file
+- Fixed: Channel with no groups inherit previous channels groups
+- Added: update new file kodi headers to start with kodi/
+
+v4.2.2
+- Update build system version
+- Change header include way
+- Add AppVeyor for Windows related build tests
+
+v4.2.1
+- Fix nullptr initialisation
+
+v4.2.0
+- Add support for sub-title/actor/director/writer in XML
+
+v4.1.0
+- Support EXTVCOPT in m3u8
+- Build helper script for OSX
+
+v4.0.2
+- Fix wrong EPG times due to DST on Windows
+
+v4.0.1
+- Remove channels loaded notification
+
+v4.0.0
+- Update to PVR addon API v6.0.0
+    </news>
   </extension>
 </addon>

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,22 @@
+v4.5.0
+- Fixed: Support full timeshift range of -12 to +14 hours
+- Fixed: Some providers incorrectly use tvg-ID instead of tvg-id
+- Fixed: Support multiple display-names and case insensitive tvg-id is always first, next tvg-name and then channel name find order
+- Added: support episode-num for both xmltv_ns and onscreen systems in epg entry
+- Added: Update readme for supported M3U and XMLTV formats and genres
+- Added: support star rating in epg entry
+- Added: support firstAired and year in epg entry
+- Added: Update OSX build script
+- Added: support multiple actor/director/writers elements in epg entry
+- Added: URLEncode and append .png ext for remote logos built from channel name
+- Added: Support for mapping by genre hex ID and added example files and settings
+- Added: Timing for Playlist and EPG Load
+- Added: Option to number channels by M3U order only
+- Update: Debug logging
+- Added: Channel group member order set to M3U order
+- Fixed: Fix segfault for compressed EPG files
+- Added: Add ordering for groups as per PVR API 6.1.0
+
 v4.4.0
 - Update: Recompile for 6.1.0 PVR Addon API compatibility
 

--- a/pvr.iptvsimple/resources/data/genres.xml
+++ b/pvr.iptvsimple/resources/data/genres.xml
@@ -1,0 +1,9 @@
+<!--
+This file can be changed and will not be overwritten, it only forms as a placeholder.
+-->
+
+<genres>
+  <name>Placeholder Genres File</name>
+
+  <!-- <genre genreId="0x10">Some text</genre> --> <!-- 0x10 Movie/Drama -->
+</genres>

--- a/pvr.iptvsimple/resources/data/genres/genreTextMappings/Rytec-UK-Ireland.xml
+++ b/pvr.iptvsimple/resources/data/genres/genreTextMappings/Rytec-UK-Ireland.xml
@@ -1,0 +1,134 @@
+<!--
+Note: the first 4 bits is genre and last is sub genre
+
+Kodi DVB Genres can be found here: usersdata/genres/kodiDVBGenres.xml
+
+Mapping Rytec Text Genres:
+ - The end result is to map to one of the DVB Genres for Kodi PVR.
+ - This enables Kodi PVR to colour the EPG entries accordingly.
+ - If a mapping cannot be found the text will be used but there will be no colouring (Genre Description only)
+ - All text will be matched in lowercase
+
+If you are creating yoru own text mappings make a copy of this file in the same directory so it's not overwritten and start from there.
+
+NOTE: IF YOU MODIFY THIS FILE IT WILL BE OVERWRITTEN NEXT TIME THE ADDON IS STARTED
+
+If you have changes either create a PR containing the changes or an issue with details at:
+  https://github.com/kodi-pvr/pvr.iptvsimple
+-->
+
+<genres>
+  <name>Rytec UK/Ireland</name>
+  <!-- MOVIE/DRAMA -->
+  <genre genreId="0x10">General Movie/Drama</genre> <!-- 0x10 Movie/Drama -->
+  <genre genreId="0x10">Film</genre> <!-- 0x10 Movie/Drama -->
+  <genre genreId="0x10">Animated Movie/Drama</genre> <!-- 0x10 Movie/Drama -->
+  <genre genreId="0x11">Thriller</genre> <!-- 0x11 Detective/Thriller -->
+  <genre genreId="0x11">Detective/Thriller</genre> <!-- 0x11 Detective/Thriller -->
+  <genre genreId="0x12">Action</genre> <!-- 0x12 Adventure/Western/War -->
+  <genre genreId="0x12">Adventure</genre> <!-- 0x12 Adventure/Western/War -->
+  <genre genreId="0x12">Adventure/War</genre> <!-- 0x12 Adventure/Western/War -->
+  <genre genreId="0x12">Western</genre> <!-- 0x12 Adventure/Western/War -->
+  <genre genreId="0x12">Gangster</genre> <!-- 0x12 Adventure/Western/War -->
+  <genre genreId="0x13">Fantasy</genre> <!-- 0x13 Science Fiction/Fantasy/Horror -->
+  <genre genreId="0x13">Science Fiction</genre> <!-- 0x13 Science Fiction/Fantasy/Horror -->
+  <genre genreId="0x14">Family</genre> <!-- 0x14 Comedy -->
+  <genre genreId="0x14">Sitcom</genre> <!-- 0x14 Comedy -->
+  <genre genreId="0x14">Comedy</genre> <!-- 0x14 Comedy -->
+  <genre genreId="0x14">TV Drama. Comedy</genre> <!-- 0x14 Comedy -->
+  <genre genreId="0x15">Drama</genre> <!-- 0x15 Soap/Melodrama/Folkloric -->
+  <genre genreId="0x15">Soap/Melodrama/Folkloric</genre> <!-- 0x15 Soap/Melodrama/Folkloric -->
+  <genre genreId="0x15">TV Drama</genre> <!-- 0x15 Soap/Melodrama/Folkloric -->
+  <genre genreId="0x15">TV Drama. Melodrama</genre> <!-- 0x15 Soap/Melodrama/Folkloric -->
+  <genre genreId="0x15">TV Drama. Factual</genre> <!-- 0x15 Soap/Melodrama/Folkloric -->
+  <genre genreId="0x15">TV Drama. Crime</genre> <!-- 0x15 Soap/Melodrama/Folkloric -->
+  <genre genreId="0x15">TV Drama. Period</genre> <!-- 0x15 Soap/Melodrama/Folkloric -->
+  <genre genreId="0x15">Medical Drama</genre> <!-- 0x15 Soap/Melodrama/Folkloric -->
+  <genre genreId="0x16">Romance</genre> <!-- 0x16 Romance -->
+  <genre genreId="0x17">Crime drama</genre> <!-- 0x17 Serious/Classical/Religious/Historical Movie/Drama -->
+  <genre genreId="0x17">Historical/Period Drama</genre> <!-- 0x17 Serious/Classical/Religious/Historical Movie/Drama -->
+  <genre genreId="0x17">Police/Crime Drama</genre> <!-- 0x17 Serious/Classical/Religious/Historical Movie/Drama -->
+
+  <!-- NEWS/CURRENT AFFAIRS -->
+  <genre genreId="0x20">News</genre> <!-- 0x20 News/Current Affairs -->
+  <genre genreId="0x20">General News/Current Affairs</genre> <!-- 0x20 News/Current Affairs -->
+  <genre genreId="0x23">Documentary</genre> <!-- 0x23 Documentary -->
+  <genre genreId="0x23">Documentary. News</genre> <!-- 0x23 Documentary -->
+  <genre genreId="0x24">Discussion. News</genre> <!-- 0x24 Discussion/Interview/Debate -->
+
+  <!-- SHOW -->
+  <genre genreId="0x30">Series</genre> <!-- 0x30 Show/Game Show -->
+  <genre genreId="0x30">Show</genre> <!-- 0x30 Show/Game Show -->
+  <genre genreId="0x30">Vets/Pets</genre> <!-- 0x30 Show/Game Show -->
+  <genre genreId="0x30">Wildlife</genre> <!-- 0x30 Show/Game Show -->
+  <genre genreId="0x30">Property</genre> <!-- 0x30 Show/Game Show -->
+  <genre genreId="0x31">General Show/Game Show</genre> <!-- 0x31 Game Show/Quiz/Contest -->
+  <genre genreId="0x31">Game Show</genre> <!-- 0x31 Game Show/Quiz/Contest -->
+  <genre genreId="0x31">Challenge/Reality Show</genre> <!-- 0x31 Game Show/Quiz/Contest -->
+  <genre genreId="0x32">Show. Variety Show</genre> <!-- 0x32 Game Variety Show -->
+  <genre genreId="0x32">Variety Show</genre> <!-- 0x32 Variety Show -->
+  <genre genreId="0x32">Entertainment</genre> <!-- 0x32 Variety Show -->
+  <genre genreId="0x32">Miscellaneous</genre> <!-- 0x32 Variety Show -->
+  <genre genreId="0x33">Talk Show</genre> <!-- 0x33 Talk Show -->
+  <genre genreId="0x34">Show. Talk Show</genre> <!-- 0x33 Talk Show -->
+
+  <!-- SPORTS -->
+  <genre genreId="0x40">Sport</genre> <!-- 0x40 Sports -->
+  <genre genreId="0x40">Live/Sport</genre> <!-- 0x40 Sports -->
+  <genre genreId="0x40">General Sports</genre> <!-- 0x40 Sports -->
+  <genre genreId="0x43">Football. Sports</genre> <!-- 0x43 Football -->
+  <genre genreId="0x4B">Martial Sports</genre> <!-- 0x4B Martial Sports -->
+  <genre genreId="0x4B">Martial Sports. Sports</genre> <!-- 0x4B Martial Sports -->
+  <genre genreId="0x4B">Wrestling</genre> <!-- 0x4B Martial Sports -->
+
+  <!-- CHILDREN/YOUTH -->
+  <genre genreId="0x50">Children</genre> <!-- 0x50 Children's/Youth Programmes -->
+  <genre genreId="0x50">Educational/Schools Programmes</genre> <!-- 0x50 Children's/Youth Programmes -->
+  <genre genreId="0x55">Animation</genre> <!-- 0x55 Cartoons/Puppets -->
+  <genre genreId="0x55">Cartoons/Puppets</genre> <!-- 0x55 Cartoons/Puppets -->
+
+  <!-- //MUSIC/BALLET/DANCE -->
+  <genre genreId="0x60">Music</genre> <!-- 0x60 Music/Ballet/Dance -->
+  <genre genreId="0x60">General Music/Ballet/Dance</genre> <!-- 0x60 Music/Ballet/Dance -->
+  <genre genreId="0x63">Music. Folk</genre> <!-- 0x63 Folk/Traditional Music -->
+  <genre genreId="0x65">Musical</genre> <!-- 0x65 Musical/Opera -->
+
+  <!-- //ARTS/CULTURE -->
+  <genre genreId="0x70">General Arts/Culture</genre> <!-- 0x70 Arts/Culture -->
+  <genre genreId="0x70">Arts/Culture</genre> <!-- 0x70 Arts/Culture -->
+  <genre genreId="0x72">Arts/Culture. Fine Arts</genre> <!-- 0x72 Fine Arts -->
+  <genre genreId="0x73">Religion</genre> <!-- 0x73 Religion -->
+
+  <!-- SOCIAL/POLITICAL/ECONOMICS -->
+  <genre genreId="0x80">Social/Political</genre> <!-- 0x80 Social/Political/Economics -->
+  <genre genreId="0x83">Social/Political. Famous People</genre> <!-- 0x83 Remarkable People -->
+
+  <!-- EDUCATIONAL/SCIENCE -->
+  <genre genreId="0x90">Education</genre> <!-- 0x90 Education/Science/Factual -->
+  <genre genreId="0x90">Educational</genre> <!-- 0x90 Education/Science/Factual -->
+  <genre genreId="0x90">History"</genre> <!-- 0x90 Education/Science/Factual -->
+  <genre genreId="0x90">Factual"</genre> <!-- 0x90 Education/Science/Factual -->
+  <genre genreId="0x90">General Education/Science/Factual Topics</genre> <!-- 0x90 Education/Science/Factual -->
+  <genre genreId="0x90">Science</genre> <!-- 0x90 Education/Science/Factual -->
+  <genre genreId="0x91">Educational. Nature</genre> <!-- 0x91 Nature/Animals/Environment -->
+  <genre genreId="0x91">Environment</genre> <!-- 0x91 Nature/Animals/Environment -->
+  <genre genreId="0x92">Technology</genre> <!-- 0x92 Technology/Natural Sciences -->
+  <genre genreId="0x92">Computers/Internet/Gaming</genre> <!-- 0x92 Technology/Natural Sciences -->
+
+  <!-- LEISURE/HOBBIES -->
+  <genre genreId="0xA0">Leisure</genre> <!-- 0xA0 Leisure/Hobbies -->
+  <genre genreId="0xA0">Leisure. Lifestyle</genre> <!-- 0xA0 Leisure/Hobbies -->
+  <genre genreId="0xA1">Travel</genre> <!-- 0xA1 Tourism/Travel -->
+  <genre genreId="0xA4">Health</genre> <!-- 0xA4 Fitness & Health -->
+  <genre genreId="0xA4">Leisure. Health</genre> <!-- 0xA4 Fitness & Health -->
+  <genre genreId="0xA4">Medicine/Health</genre> <!-- 0xA4 Fitness & Health -->
+  <genre genreId="0xA5">Cookery</genre> <!-- 0xA5 Cooking -->
+  <genre genreId="0xA5">Leisure. Cooking</genre> <!-- 0xA5 Cooking -->
+  <genre genreId="0xA6">Leisure. Shopping</genre> <!-- 0xA6 Advertisement/Shopping -->
+  <genre genreId="0xA6">Advertisement/Shopping</genre> <!-- 0xA6 Advertisement/Shopping -->
+  <genre genreId="0xA6">Consumer</genre> <!-- 0xA6 Advertisement/Shopping -->
+  <!-- SPECIAL -->
+
+  <!-- USERDEFINED -->
+  <genre genreId="0xF1">Factual Crime</genre> <!-- 0xF1 Detective/Thriller -->
+</genres>

--- a/pvr.iptvsimple/resources/data/genres/kodiDvbGenres.xml
+++ b/pvr.iptvsimple/resources/data/genres/kodiDvbGenres.xml
@@ -1,0 +1,138 @@
+<!--
+The following are the DVB Genre Id's used for reference
+
+Source: https://www.etsi.org/deliver/etsi_en/300400_300499/300468/01.11.01_60/en_300468v011101p.pdf
+Page 40
+
+Note: the first 4 bits is genre and last is sub genre
+
+Mapping DVB Genres:
+ - The content below is a reference for Genre Text Mappings
+
+There shoud be no reason to modify this file unless the DVB standard changes.
+
+NOTE: IF YOU MODIFY THIS FILE IT WILL BE OVERWRITTEN NEXT TIME THE ADDON IS STARTED
+
+If you have changes either create a PR containing the changes or an issue with details at:
+  https://github.com/kodi-pvr/pvr.iptvsimple
+-->
+
+<genres>
+  <name>Kodi DVB Genres using Hexadecimal for genreId</name>
+  <!-- UNDEFINED -->
+  <genre genreId="0x00">Undefined</genre>
+
+  <!-- MOVIE / DRAMA -->
+  <genre genreId="0x10">General Movie / Drama</genre>
+  <genre genreId="0x11">Detective / Thriller</genre>
+  <genre genreId="0x12">Adventure / Western / War</genre>
+  <genre genreId="0x13">Science Fiction / Fantasy / Horror</genre>
+  <genre genreId="0x14">Comedy</genre>
+  <genre genreId="0x15">Soap / Melodrama / Folkloric</genre>
+  <genre genreId="0x16">Romance</genre>
+  <genre genreId="0x17">Serious / Classical / Religious / Historical Movie / Drama</genre>
+  <genre genreId="0x18">Adult Movie / Drama</genre>
+
+  <!-- NEWS / CURRENT AFFAIRS -->
+  <genre genreId="0x20">News / Current Affairs</genre>
+  <genre genreId="0x21">News / Weather Report</genre>
+  <genre genreId="0x22">News Magazine</genre>
+  <genre genreId="0x23">Documentary</genre>
+  <genre genreId="0x24">Discussion / Interview / Debate</genre>
+
+  <!-- SHOW -->
+  <genre genreId="0x30">Show / Game Show</genre>
+  <genre genreId="0x31">Game Show / Quiz / Contest</genre>
+  <genre genreId="0x32">Variety Show</genre>
+  <genre genreId="0x33">Talk Show</genre>
+
+  <!-- SPORTS -->
+  <genre genreId="0x40">Sports</genre>
+  <genre genreId="0x41">Special Event</genre>
+  <genre genreId="0x42">Sport Magazine</genre>
+  <genre genreId="0x43">Football</genre>
+  <genre genreId="0x44">Tennis / Squash</genre>
+  <genre genreId="0x45">Team Sports</genre>
+  <genre genreId="0x46">Athletics</genre>
+  <genre genreId="0x47">Motor Sport</genre>
+  <genre genreId="0x48">Water Sport</genre>
+  <genre genreId="0x49">Winter Sports</genre>
+  <genre genreId="0x4A">Equestrian</genre>
+  <genre genreId="0x4B">Martial Sports</genre>
+
+  <!-- CHILDREN / YOUTH -->
+  <genre genreId="0x50">Children's / Youth Programmes</genre>
+  <genre genreId="0x51">Pre-school Children's Programmes</genre>
+  <genre genreId="0x52">Entertainment Programmes for 6 to 14</genre>
+  <genre genreId="0x53">Entertainment Programmes for 10 to 16</genre>
+  <genre genreId="0x54">Informational / Educational / School Programme</genre>
+  <genre genreId="0x55">Cartoons / Puppets</genre>
+
+  <!-- MUSIC / BALLET / DANCE -->
+  <genre genreId="0x60">Music / Ballet / Dance</genre>
+  <genre genreId="0x61">Rock / Pop</genre>
+  <genre genreId="0x62">Serious / Classical Music</genre>
+  <genre genreId="0x63">Folk / Traditional Music</genre>
+  <genre genreId="0x64">Jazz</genre>
+  <genre genreId="0x65">Musical / Opera</genre>
+  <genre genreId="0x66">Ballet</genre>
+
+  <!-- ARTS / CULTURE -->
+  <genre genreId="0x70">Arts / Culture</genre>
+  <genre genreId="0x71">Performing Arts</genre>
+  <genre genreId="0x72">Fine Arts</genre>
+  <genre genreId="0x73">Religion</genre>
+  <genre genreId="0x74">Popular Culture / Traditional Arts</genre>
+  <genre genreId="0x75">Literature</genre>
+  <genre genreId="0x76">Film / Cinema</genre>
+  <genre genreId="0x77">Experimental Film / Video</genre>
+  <genre genreId="0x78">Broadcasting / Press</genre>
+  <genre genreId="0x79">New Media</genre>
+  <genre genreId="0x7A">Arts / Culture Magazines</genre>
+  <genre genreId="0x7B">Fashion</genre>
+
+  <!-- SOCIAL / POLITICAL / ECONOMICS -->
+  <genre genreId="0x80">Social / Political / Economics</genre>
+  <genre genreId="0x81">Magazines / Reports / Documentary</genre>
+  <genre genreId="0x82">Economics / Social Advisory</genre>
+  <genre genreId="0x83">Remarkable People</genre>
+
+  <!-- EDUCATIONAL / SCIENCE -->
+  <genre genreId="0x90">Education / Science / Factual</genre>
+  <genre genreId="0x91">Nature / Animals / Environment</genre>
+  <genre genreId="0x92">Technology / Natural Sciences</genre>
+  <genre genreId="0x93">Medicine / Physiology / Psychology</genre>
+  <genre genreId="0x94">Foreign Countries / Expeditions</genre>
+  <genre genreId="0x95">Social / Spiritual Sciences</genre>
+  <genre genreId="0x96">Further Education</genre>
+  <genre genreId="0x97">Languages</genre>
+
+  <!-- LEISURE / HOBBIES -->
+  <genre genreId="0xA0">Leisure / Hobbies</genre>
+  <genre genreId="0xA1">Tourism / Travel</genre>
+  <genre genreId="0xA2">Handicraft</genre>
+  <genre genreId="0xA3">Motoring</genre>
+  <genre genreId="0xA4">Fitness and Health</genre>
+  <genre genreId="0xA5">Cooking</genre>
+  <genre genreId="0xA6">Advertisement / Shopping</genre>
+  <genre genreId="0xA7">Gardening</genre>
+
+  <!-- SPECIAL -->
+  <genre genreId="0xB0">Special Characteristics</genre>
+  <genre genreId="0xB1">Original Language</genre>
+  <genre genreId="0xB2">Black and White</genre>
+  <genre genreId="0xB3">Unpublished</genre>
+  <genre genreId="0xB4">Live Broadcast</genre>
+
+  <!-- USERDEFINED -->
+  <genre genreId="0xF0">Drama</genre>
+  <genre genreId="0xF1">Detective / Thriller</genre>
+  <genre genreId="0xF2">Adventure / Western / War</genre>
+  <genre genreId="0xF3">Science Fiction / Fantasy / Horror</genre>
+  <!-- below currently ignored by XBMC see http://trac.xbmc.org/ticket/13627 -->
+  <genre genreId="0xF4">Comedy</genre>
+  <genre genreId="0xF5">Soap / Melodrama / Folkloric</genre>
+  <genre genreId="0xF6">Romance</genre>
+  <genre genreId="0xF7">Serious / ClassicalReligion / Historical</genre>
+  <genre genreId="0xF8">Adult</genre>
+</genres>

--- a/pvr.iptvsimple/resources/data/genres/kodiDvbGenresTypeSubtype.xml
+++ b/pvr.iptvsimple/resources/data/genres/kodiDvbGenresTypeSubtype.xml
@@ -1,0 +1,138 @@
+<!--
+The following are the DVB Genre Types and Subtypes used for reference
+
+Source: https://www.etsi.org/deliver/etsi_en/300400_300499/300468/01.11.01_60/en_300468v011101p.pdf
+Page 40
+
+Note: Type represents the first 4 bits of an 8-bit genre ID and Subtyperepresents the last 4 bits
+
+Mapping DVB Genres:
+ - The content below is a reference for Genre Text Mappings
+
+There shoud be no reason to modify this file unless the DVB standard changes.
+
+NOTE: IF YOU MODIFY THIS FILE IT WILL BE OVERWRITTEN NEXT TIME THE ADDON IS STARTED
+
+If you have changes either create a PR containing the changes or an issue with details at:
+  https://github.com/kodi-pvr/pvr.iptvsimple
+-->
+
+<genres>
+  <name>Kodi DVB Genres using Integers for type and subtype</name>
+  <!-- UNDEFINED -->
+  <genre type="0" subtype="0">Undefined</genre>
+
+  <!-- MOVIE/DRAMA -->
+  <genre type="16" subtype="0">Movie / Drama</genre>
+  <genre type="16" subtype="1">Detective / Thriller</genre>
+  <genre type="16" subtype="2">Adventure / Western / War</genre>
+  <genre type="16" subtype="3">Science fiction / Fantasy / Horror</genre>
+  <genre type="16" subtype="4">Comedy</genre>
+  <genre type="16" subtype="5">Soap / Melodrama / Folkloric</genre>
+  <genre type="16" subtype="6">Romance</genre>
+  <genre type="16" subtype="7">Serious / Classical / Religious / Historical Movie / Drama</genre>
+  <genre type="16" subtype="8">Adult Movie / Drama</genre>
+
+  <!-- NEWS/CURRENT AFFAIRS -->
+  <genre type="32" subtype="0">News / Current Affairs</genre>
+  <genre type="32" subtype="1">News / Weather Report</genre>
+  <genre type="32" subtype="2">News Magazine</genre>
+  <genre type="32" subtype="3">Documentary</genre>
+  <genre type="32" subtype="4">Discussion / Interview / Debate</genre>
+
+  <!-- SHOW -->
+  <genre type="48" subtype="0">Show / Game Show</genre>
+  <genre type="48" subtype="1">Game Show / Quiz / Contest</genre>
+  <genre type="48" subtype="2">Variety show</genre>
+  <genre type="48" subtype="3">Talk Show</genre>
+
+  <!-- SPORTS -->
+  <genre type="64" subtype="0">Sports</genre>
+  <genre type="64" subtype="1">Special Event</genre>
+  <genre type="64" subtype="2">Sports Magazines</genre>
+  <genre type="64" subtype="3">Football / Soccer</genre>
+  <genre type="64" subtype="4">Tennis / Squash</genre>
+  <genre type="64" subtype="5">Team Sports</genre>
+  <genre type="64" subtype="6">Athletics</genre>
+  <genre type="64" subtype="7">Motor Sport</genre>
+  <genre type="64" subtype="8">Water Sport</genre>
+  <genre type="64" subtype="9">Winter Sports</genre>
+  <genre type="64" subtype="10">Equestrian</genre>
+  <genre type="64" subtype="11">Martial Sports</genre>
+
+  <!-- CHILDREN/YOUTH -->
+  <genre type="80" subtype="0">Children's / Youth Programs</genre>
+  <genre type="80" subtype="1">Pre-school Children's Programs</genre>
+  <genre type="80" subtype="2">Entertainment programs for 6 to 14</genre>
+  <genre type="80" subtype="3">Entertainment programs for 10 to 16</genre>
+  <genre type="80" subtype="4">Informational / Educational / School programs</genre>
+  <genre type="80" subtype="5">Cartoons / Puppets</genre>
+
+  <!-- MUSIC/BALLET/DANCE -->
+  <genre type="96" subtype="0">Music / Ballet / Dance</genre>
+  <genre type="96" subtype="1">Rock / Pop</genre>
+  <genre type="96" subtype="2">Serious music / Classical Music</genre>
+  <genre type="96" subtype="3">Folk / Traditional Music</genre>
+  <genre type="96" subtype="4">Jazz</genre>
+  <genre type="96" subtype="5">Musical / Opera</genre>
+  <genre type="96" subtype="6">Ballet</genre>
+
+  <!-- ARTS/CULTURE -->
+  <genre type="112" subtype="0">Arts / Culture</genre>
+  <genre type="112" subtype="1">Performing Arts</genre>
+  <genre type="112" subtype="2">Fine Arts</genre>
+  <genre type="112" subtype="3">Religion</genre>
+  <genre type="112" subtype="4">Popular Culture / Traditional Arts</genre>
+  <genre type="112" subtype="5">Literature</genre>
+  <genre type="112" subtype="6">Film / Cinema</genre>
+  <genre type="112" subtype="7">Experimental Film / Video</genre>
+  <genre type="112" subtype="8">Broadcasting / Press</genre>
+  <genre type="112" subtype="9">New Media</genre>
+  <genre type="112" subtype="10">Arts magazines / Culture Magazines</genre>
+  <genre type="112" subtype="11">Fashion</genre>
+
+  <!-- SOCIAL/POLITICAL/ECONOMICS -->
+  <genre type="128" subtype="0">Social / Political issues / Economics</genre>
+  <genre type="128" subtype="1">Magazines / Reports / Documentary</genre>
+  <genre type="128" subtype="2">Economics / Social Advisory</genre>
+  <genre type="128" subtype="3">Remarkable People</genre>
+
+  <!-- EDUCATIONAL/SCIENCE -->
+  <genre type="144" subtype="0">Education / Science / Factual topics</genre>
+  <genre type="144" subtype="1">Nature / Animals / Environment</genre>
+  <genre type="144" subtype="2">Technology / Natural sciences</genre>
+  <genre type="144" subtype="3">Medicine / Physiology / Psychology</genre>
+  <genre type="144" subtype="4">Foreign countries / Expeditions</genre>
+  <genre type="144" subtype="5">Social / Spiritual Sciences</genre>
+  <genre type="144" subtype="6">Further Education</genre>
+  <genre type="144" subtype="7">Languages</genre>
+
+  <!-- LEISURE/HOBBIES -->
+  <genre type="160" subtype="0">Leisure Hobbies</genre>
+  <genre type="160" subtype="1">Tourism / Travel</genre>
+  <genre type="160" subtype="2">Handicraft</genre>
+  <genre type="160" subtype="3">Motoring</genre>
+  <genre type="160" subtype="4">Fitness and Health</genre>
+  <genre type="160" subtype="5">Cooking</genre>
+  <genre type="160" subtype="6">Advertisement / Shopping</genre>
+  <genre type="160" subtype="7">Gardening</genre>
+
+   <!-- SPECIAL -->
+  <genre type="176" subtype="0">Special Characteristics</genre>
+  <genre type="176" subtype="1">Original Language</genre>
+  <genre type="176" subtype="2">Black &amp; White</genre>
+  <genre type="176" subtype="3">Unpublished</genre>
+  <genre type="176" subtype="4">Live Broadcast</genre>
+
+  <!-- USERDEFINED -->
+  <genre type="240" subtype="0">Drama</genre>
+  <genre type="240" subtype="1">Detective/Thriller</genre>
+  <genre type="240" subtype="2">Adventure/Western/War</genre>
+  <genre type="240" subtype="3">Science Fiction/Fantasy/Horror</genre>
+  <!-- below currently ignored by XBMC see http://trac.xbmc.org/ticket/13627 -->
+  <genre type="240" subtype="4">Comedy</genre>
+  <genre type="240" subtype="5">Soap/Melodrama/Folkloric</genre>
+  <genre type="240" subtype="6">Romance</genre>
+  <genre type="240" subtype="7">Serious/ClassicalReligion/Historical</genre>
+  <genre type="240" subtype="8">Adult</genre> 
+</genres>

--- a/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
@@ -214,7 +214,7 @@ msgstr ""
 
 #help: EPG Settings - epgTimeShift
 msgctxt "#30625"
-msgid "Adjust the EPG times by this value in minutes, range is from -720 mins to +720 mins (+/- 12 hours)."
+msgid "Adjust the EPG times by this value in minutes, range is from -720 mins to +840 mins (- 12 hours to +14 hours)."
 msgstr ""
 
 #help: EPG Settings - epgTSOverside

--- a/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
@@ -59,11 +59,17 @@ msgctxt "#30012"
 msgid "M3U playlist URL"
 msgstr ""
 
+#label: General - startNum
 msgctxt "#30013"
 msgid "Start channel number"
 msgstr ""
 
-#empty strings from id 30014 to 30018
+#label: General - numberByOrder
+msgctxt "#30014"
+msgid "Only number by channel order in M3U"
+msgstr ""
+
+#empty strings from id 30015 to 30018
 
 #label-category: epgsettings
 msgctxt "#30019"
@@ -211,8 +217,12 @@ msgctxt "#30605"
 msgid "The number to start numbering channels from."
 msgstr ""
 
-#empty strings from id 30606 to 30619
+#help: General - numberByOrder
+msgctxt "#30606"
+msgid "Ignore any 'tvg-chno' tags and only number channels by the order in the M3U starting at 'Start channel number'."
+msgstr ""
 
+#empty strings from id 30607 to 30619
 
 #help info - EPG Settings
 

--- a/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
@@ -28,6 +28,7 @@ msgstr ""
 #label-option: General - m3uPathType
 #label-option: General - epgPathType
 #label-option: General - logoPathType
+#label-option: General - genresPathType
 msgctxt "#30001"
 msgid "Local path (include local network)"
 msgstr ""
@@ -35,6 +36,7 @@ msgstr ""
 #label-option: General - m3uPathType
 #label-option: General - epgPathType
 #label-option: General - logoPathType
+#label-option: General - genresPathType
 msgctxt "#30002"
 msgid "Remote path (Internet address)"
 msgstr ""
@@ -61,12 +63,16 @@ msgctxt "#30013"
 msgid "Start channel number"
 msgstr ""
 
-#empty strings from id 30014 to 30019
+#empty strings from id 30014 to 30018
 
 #label-category: epgsettings
+msgctxt "#30019"
+msgid "EPG Settings"
+msgstr ""
+
 #label-group: EPG Settings - EPG Settings
 msgctxt "#30020"
-msgid "EPG Settings"
+msgid "EPG"
 msgstr ""
 
 #label: EPG Settings - epgPath
@@ -144,7 +150,30 @@ msgctxt "#30044"
 msgid "Prefer XMLTV"
 msgstr ""
 
-#empty strings from id 30045 to 30599
+#empty strings from id 30045 to 30549
+
+#label-category: genres
+#label-group: Genres - Genres
+msgctxt "#30050"
+msgid "Genres"
+msgstr ""
+
+#label: Genres - useEpgGenreText
+msgctxt "#30051"
+msgid "Use genre text from XMLTV when mapping genres"
+msgstr ""
+
+#label: Genres - genresPath
+msgctxt "#30052"
+msgid "Genres path"
+msgstr ""
+
+#label: Genres - genresUrl
+msgctxt "#30053"
+msgid "Genres URL"
+msgstr ""
+
+#empty strings from id 30054 to 30599
 
 #############
 # help info #
@@ -182,7 +211,7 @@ msgctxt "#30605"
 msgid "The number to start numbering channels from."
 msgstr ""
 
-#empty strings from id 30006 to 30619
+#empty strings from id 30606 to 30619
 
 
 #help info - EPG Settings
@@ -222,13 +251,13 @@ msgctxt "#30626"
 msgid "Whether or not to override the time shift for all channels with `EPG time shift`. If not enabled `EPG time shift` plus the individual time shift per channel (if available) will be used."
 msgstr ""
 
-#empty strings from id 30027 to 30639
+#empty strings from id 30627 to 30639
 
 #help info - Channel Logos
 
 #help-category: Channel Logos
 msgctxt "#30640"
-msgid "Settings realted to Channel Logos."
+msgid "Settings related to Channel Logos."
 msgstr ""
 
 #help: Channel Logos - logoPathType
@@ -249,4 +278,33 @@ msgstr ""
 #help: Channel Logos - logoFromEpg
 msgctxt "#30644"
 msgid "Preference on how to handle channel logos. The options are: [Ignore] - Don't use channel logos from an XMLTV file; [Prefer M3U] - Use the channel logo from the M3U if available otherwise use the XMLTV logo; [Prefer XMLTV] - Use the channel logo from the XMLTV file if available otherwise use the M3U logo."
+msgstr ""
+
+#empty strings from id 30645 to 30659
+
+#help info - Genres
+
+#help-category: Genres
+msgctxt "#30660"
+msgid "Settings related to genres."
+msgstr ""
+
+#help: Genres - useEpgGenreText
+msgctxt "#30661"
+msgid "If enabled, and a genre mapping file is used to get a genre type and sub type use the EPG's genre text (i.e. 'category' text) for the genre instead of the kodi default text."
+msgstr ""
+
+#help: Genres - genresPathType
+msgctxt "#30662"
+msgid "Select where to find the genres XML resource. The options are: [Local path] - A path to a genres XML file whether it be on the device or the local network; [Remote path] - A URL specifying the location of the genres XML file."
+msgstr ""
+
+#help: Genres - genresPath
+msgctxt "#30663"
+msgid "If location is [Local Path] this setting should contain a valid path."
+msgstr ""
+
+#help: Genres - genresUrl
+msgctxt "#30664"
+msgid "If location is [Remote Path] this setting should contain a valid URL."
 msgstr ""

--- a/pvr.iptvsimple/resources/settings.xml
+++ b/pvr.iptvsimple/resources/settings.xml
@@ -110,7 +110,7 @@
           <constraints>
             <minimum>-720</minimum>
             <step>30</step>
-            <maximum>720</maximum>
+            <maximum>840</maximum>
           </constraints>
           <control type="slider" format="integer">
             <formatlabel>14044</formatlabel>

--- a/pvr.iptvsimple/resources/settings.xml
+++ b/pvr.iptvsimple/resources/settings.xml
@@ -59,7 +59,7 @@
 
     <!-- EPG -->
     <category id="epgsettings" label="30020" help="30620">
-      <group id="1" label="30020">
+      <group id="1" label="30019">
        <setting id="epgPathType" type="integer" label="30000" help="30621">
           <level>0</level>
           <default>1</default>
@@ -120,6 +120,53 @@
           <level>0</level>
           <default>false</default>
           <control type="toggle" />
+        </setting>
+      </group>
+    </category>
+
+    <!-- Genres -->
+    <category id="genressettings" label="30050" help="30660">
+      <group id="1" label="30050">
+        <setting id="useEpgGenreText" type="boolean" label="30051" help="30661">
+          <level>0</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="genresPathType" type="integer" label="30000" help="30662">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="30001">0</option> <!-- LOCAL_PATH -->
+              <option label="30002">1</option> <!-- REMOTE_PATH -->
+            </options>
+          </constraints>
+          <control type="spinner" format="integer" />
+        </setting>
+        <setting id="genresPath" type="path" parent="genresPathType" label="30052" help="30663">
+          <level>0</level>
+          <default>special://userdata/addon_data/pvr.iptvsimple/genres/genreTextMappings/genres.xml</default>
+          <constraints>
+            <allowempty>true</allowempty>
+            <writable>false</writable>
+          </constraints>
+          <dependencies>
+            <dependency type="visible" setting="genresPathType" operator="is">0</dependency>
+          </dependencies>
+          <control type="button" format="file">
+            <heading>1033</heading>
+          </control>
+        </setting>
+        <setting id="genresUrl" type="string" parent="genresPathType" label="30053" help="30664">
+          <level>0</level>
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <dependencies>
+            <dependency type="visible" setting="genresPathType" operator="is">1</dependency>
+          </dependencies>
+          <control type="edit" format="string" />
         </setting>
       </group>
     </category>

--- a/pvr.iptvsimple/resources/settings.xml
+++ b/pvr.iptvsimple/resources/settings.xml
@@ -54,6 +54,11 @@
           <default>1</default>
           <control type="edit" format="integer" />
         </setting>
+        <setting id="numberByOrder" type="boolean" label="30014" help="30606">
+          <level>0</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
       </group>
     </category>
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -112,7 +112,7 @@ ADDON_STATUS ADDON_Create(void* hdl, void* props)
 
   Logger::GetInstance().SetPrefix("pvr.iptvsimple");
 
-  Logger::Log(LogLevel::LEVEL_INFO, "%s Creating the PVR IPTV Simple add-on", __FUNCTION__);
+  Logger::Log(LogLevel::LEVEL_INFO, "%s - Creating the PVR IPTV Simple add-on", __FUNCTION__);
 
   m_currentStatus = ADDON_STATUS_UNKNOWN;
   const std::string userPath = pvrprops->strUserPath;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -36,16 +36,6 @@ using namespace iptvsimple;
 using namespace iptvsimple::data;
 using namespace iptvsimple::utilities;
 
-#ifdef TARGET_WINDOWS
-#define snprintf _snprintf
-#ifdef CreateDirectory
-#undef CreateDirectory
-#endif
-#ifdef DeleteFile
-#undef DeleteFile
-#endif
-#endif
-
 bool m_created = false;
 ADDON_STATUS m_currentStatus = ADDON_STATUS_UNKNOWN;
 PVRIptvData* m_data = nullptr;
@@ -117,9 +107,6 @@ ADDON_STATUS ADDON_Create(void* hdl, void* props)
   m_currentStatus = ADDON_STATUS_UNKNOWN;
   const std::string userPath = pvrprops->strUserPath;
   const std::string clientPath = pvrprops->strClientPath;
-
-  if (!XBMC->DirectoryExists(settings.GetUserPath().c_str()))
-    XBMC->CreateDirectory(settings.GetUserPath().c_str());
 
   settings.ReadFromAddon(userPath, clientPath);
 

--- a/src/iptvsimple/ChannelGroups.cpp
+++ b/src/iptvsimple/ChannelGroups.cpp
@@ -67,6 +67,8 @@ PVR_ERROR ChannelGroups::GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_C
   const ChannelGroup* myGroup = FindChannelGroup(group.strGroupName);
   if (myGroup)
   {
+    int channelNumberInGroup = 1;
+
     for (int memberId : myGroup->GetMemberChannelIndexes())
     {
       if (memberId < 0 || memberId >= static_cast<int>(m_channels.GetChannelsAmount()))
@@ -77,12 +79,14 @@ PVR_ERROR ChannelGroups::GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_C
 
       strncpy(xbmcGroupMember.strGroupName, group.strGroupName, sizeof(xbmcGroupMember.strGroupName) - 1);
       xbmcGroupMember.iChannelUniqueId = channel.GetUniqueId();
-      xbmcGroupMember.iChannelNumber = channel.GetChannelNumber();
+      xbmcGroupMember.iChannelNumber = channelNumberInGroup; //Keep the channels in list order as per the M3U
 
       Logger::Log(LEVEL_DEBUG, "%s - Transfer channel group '%s' member '%s', ChannelId '%d', ChannelNumberInGroup: '%d'", __FUNCTION__,
                   myGroup->GetGroupName().c_str(), channel.GetChannelName().c_str(), channel.GetUniqueId(), channelNumberInGroup);
 
       PVR->TransferChannelGroupMember(handle, &xbmcGroupMember);
+
+      channelNumberInGroup++;
     }
   }
 

--- a/src/iptvsimple/ChannelGroups.cpp
+++ b/src/iptvsimple/ChannelGroups.cpp
@@ -67,7 +67,13 @@ PVR_ERROR ChannelGroups::GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_C
   const ChannelGroup* myGroup = FindChannelGroup(group.strGroupName);
   if (myGroup)
   {
-    int channelNumberInGroup = 1;
+    // We set a channel order here that applies to this group in kodi-pvr
+    // This allows the users to use the 'Backend Order' sort option in the left to
+    // have the same order as the backend (regardles of the channel numbering used)
+    //
+    // We don't set a channel number within this group as different channel numbers
+    // per group are not supported in M3U files
+    int channelOrder = 1;
 
     for (int memberId : myGroup->GetMemberChannelIndexes())
     {
@@ -79,14 +85,12 @@ PVR_ERROR ChannelGroups::GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_C
 
       strncpy(xbmcGroupMember.strGroupName, group.strGroupName, sizeof(xbmcGroupMember.strGroupName) - 1);
       xbmcGroupMember.iChannelUniqueId = channel.GetUniqueId();
-      xbmcGroupMember.iChannelNumber = channelNumberInGroup; //Keep the channels in list order as per the M3U
+      xbmcGroupMember.iOrder = channelOrder++; // Keep the channels in list order as per the M3U
 
-      Logger::Log(LEVEL_DEBUG, "%s - Transfer channel group '%s' member '%s', ChannelId '%d', ChannelNumberInGroup: '%d'", __FUNCTION__,
-                  myGroup->GetGroupName().c_str(), channel.GetChannelName().c_str(), channel.GetUniqueId(), channelNumberInGroup);
+      Logger::Log(LEVEL_DEBUG, "%s - Transfer channel group '%s' member '%s', ChannelId '%d', ChannelOrder: '%d'", __FUNCTION__,
+                  myGroup->GetGroupName().c_str(), channel.GetChannelName().c_str(), channel.GetUniqueId(), channelOrder);
 
       PVR->TransferChannelGroupMember(handle, &xbmcGroupMember);
-
-      channelNumberInGroup++;
     }
   }
 

--- a/src/iptvsimple/ChannelGroups.cpp
+++ b/src/iptvsimple/ChannelGroups.cpp
@@ -47,10 +47,10 @@ void ChannelGroups::GetChannelGroups(std::vector<PVR_CHANNEL_GROUP>& kodiChannel
 
   for (const auto& channelGroup : m_channelGroups)
   {
-    Logger::Log(LEVEL_DEBUG, "%s - Transfer channelGroup '%s', ChannelGroupIndex '%d'", __FUNCTION__, channelGroup.GetGroupName().c_str(), channelGroup.GetUniqueId());
-
     if (channelGroup.IsRadio() == radio)
     {
+      Logger::Log(LEVEL_DEBUG, "%s - Transfer channelGroup '%s', ChannelGroupId '%d'", __FUNCTION__, channelGroup.GetGroupName().c_str(), channelGroup.GetUniqueId());
+
       PVR_CHANNEL_GROUP kodiChannelGroup = {0};
 
       channelGroup.UpdateTo(kodiChannelGroup);
@@ -78,6 +78,9 @@ PVR_ERROR ChannelGroups::GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_C
       strncpy(xbmcGroupMember.strGroupName, group.strGroupName, sizeof(xbmcGroupMember.strGroupName) - 1);
       xbmcGroupMember.iChannelUniqueId = channel.GetUniqueId();
       xbmcGroupMember.iChannelNumber = channel.GetChannelNumber();
+
+      Logger::Log(LEVEL_DEBUG, "%s - Transfer channel group '%s' member '%s', ChannelId '%d', ChannelNumberInGroup: '%d'", __FUNCTION__,
+                  myGroup->GetGroupName().c_str(), channel.GetChannelName().c_str(), channel.GetUniqueId(), channelNumberInGroup);
 
       PVR->TransferChannelGroupMember(handle, &xbmcGroupMember);
     }

--- a/src/iptvsimple/Channels.cpp
+++ b/src/iptvsimple/Channels.cpp
@@ -54,6 +54,10 @@ int Channels::GetChannelsAmount() const
 
 void Channels::GetChannels(std::vector<PVR_CHANNEL>& kodiChannels, bool radio) const
 {
+  // We set a channel order here that applies to the 'Any channels' group in kodi-pvr
+  // This allows the users to use the 'Backend Order' sort option in the left to
+  // have the same order as the backend (regardles of the channel numbering used)
+  int channelOrder = 1;
   for (const auto& channel : m_channels)
   {
     if (channel.IsRadio() == radio)
@@ -63,6 +67,7 @@ void Channels::GetChannels(std::vector<PVR_CHANNEL>& kodiChannels, bool radio) c
       PVR_CHANNEL kodiChannel = {0};
 
       channel.UpdateTo(kodiChannel);
+      kodiChannel.iOrder = channelOrder++; // Keep the channels in list order as per the M3U
 
       kodiChannels.emplace_back(kodiChannel);
     }

--- a/src/iptvsimple/Channels.cpp
+++ b/src/iptvsimple/Channels.cpp
@@ -28,6 +28,8 @@
 #include "utilities/FileUtils.h"
 #include "utilities/Logger.h"
 
+#include "p8-platform/util/StringUtils.h"
+
 #include <regex>
 
 using namespace iptvsimple;
@@ -109,22 +111,28 @@ Channel* Channels::GetChannel(int uniqueId)
   return nullptr;
 }
 
-const Channel* Channels::FindChannel(const std::string& id, const std::string& name) const
+const Channel* Channels::FindChannel(const std::string& id, const std::string& displayName) const
 {
-  const std::string tvgName = std::regex_replace(name, std::regex(" "), "_");
+  for (const auto& myChannel : m_channels)
+  {
+    if (StringUtils::EqualsNoCase(myChannel.GetTvgId(), id))
+      return &myChannel;
+  }
+
+  if (displayName.empty())
+    return nullptr;
+
+  const std::string convertedDisplayName = std::regex_replace(displayName, std::regex(" "), "_");
+  for (const auto& myChannel : m_channels)
+  {
+    if (StringUtils::EqualsNoCase(myChannel.GetTvgName(), convertedDisplayName) ||
+        StringUtils::EqualsNoCase(myChannel.GetTvgName(), displayName))
+      return &myChannel;
+  }
 
   for (const auto& myChannel : m_channels)
   {
-    if (myChannel.GetTvgId() == id)
-      return &myChannel;
-
-    if (tvgName.empty())
-      continue;
-
-    if (myChannel.GetTvgName() == tvgName)
-      return &myChannel;
-
-    if (myChannel.GetChannelName() == name)
+    if (StringUtils::EqualsNoCase(myChannel.GetChannelName(), displayName))
       return &myChannel;
   }
 

--- a/src/iptvsimple/Channels.cpp
+++ b/src/iptvsimple/Channels.cpp
@@ -36,8 +36,8 @@ using namespace iptvsimple;
 using namespace iptvsimple::data;
 using namespace iptvsimple::utilities;
 
-Channels::Channels() 
-  : m_logoLocation(Settings::GetInstance().GetLogoLocation()), 
+Channels::Channels()
+  : m_logoLocation(Settings::GetInstance().GetLogoLocation()),
     m_currentChannelNumber(Settings::GetInstance().GetStartChannelNumber()) {}
 
 void Channels::Clear()
@@ -58,8 +58,8 @@ void Channels::GetChannels(std::vector<PVR_CHANNEL>& kodiChannels, bool radio) c
   {
     if (channel.IsRadio() == radio)
     {
-      Logger::Log(LEVEL_DEBUG, "%s - Transfer channel '%s', ChannelIndex '%d'", __FUNCTION__, channel.GetChannelName().c_str(),
-                  channel.GetUniqueId());
+      Logger::Log(LEVEL_DEBUG, "%s - Transfer channel '%s', ChannelId '%d', ChannelNumber: '%d'", __FUNCTION__, channel.GetChannelName().c_str(),
+                  channel.GetUniqueId(), channel.GetChannelNumber());
       PVR_CHANNEL kodiChannel = {0};
 
       channel.UpdateTo(kodiChannel);

--- a/src/iptvsimple/Channels.h
+++ b/src/iptvsimple/Channels.h
@@ -48,7 +48,7 @@ namespace iptvsimple
 
     void AddChannel(iptvsimple::data::Channel& channel, std::vector<int>& groupIdList, iptvsimple::ChannelGroups& channelGroups);
     iptvsimple::data::Channel* GetChannel(int uniqueId);
-    const iptvsimple::data::Channel* FindChannel(const std::string& id, const std::string& name) const;
+    const iptvsimple::data::Channel* FindChannel(const std::string& id, const std::string& displayName) const;
     const std::vector<data::Channel>& GetChannelsList() const { return m_channels; }
     void Clear();
     void ApplyChannelLogos();

--- a/src/iptvsimple/Epg.cpp
+++ b/src/iptvsimple/Epg.cpp
@@ -134,7 +134,7 @@ bool Epg::GetXMLTVFileWithRetries(std::string& data)
 
   while (count < 3) // max 3 tries
   {
-    if ((bytesRead = FileUtils::GetCachedFileContents(TVG_FILE_NAME, m_xmltvLocation, data, Settings::GetInstance().UseEPGCache())) != 0)
+    if ((bytesRead = FileUtils::GetCachedFileContents(XMLTV_CACHE_FILENAME, m_xmltvLocation, data, Settings::GetInstance().UseEPGCache())) != 0)
       break;
 
     Logger::Log(LEVEL_ERROR, "Unable to load EPG file '%s':  file is missing or empty. :%dth try.", m_xmltvLocation.c_str(), ++count);

--- a/src/iptvsimple/Epg.cpp
+++ b/src/iptvsimple/Epg.cpp
@@ -241,7 +241,7 @@ void Epg::LoadEpgEntries(xml_node<>* rootElement, int start, int end)
     if (!GetAttributeValue(channelNode, "channel", id))
       continue;
 
-    if (!channelEpg || StringUtils::CompareNoCase(channelEpg->GetId(), id) != 0)
+    if (!channelEpg || !StringUtils::EqualsNoCase(channelEpg->GetId(), id))
     {
       if (!(channelEpg = FindEpgForChannel(id)))
         continue;
@@ -324,7 +324,7 @@ ChannelEpg* Epg::FindEpgForChannel(const std::string& id)
 {
   for (auto& myChannelEpg : m_channelEpgs)
   {
-    if (StringUtils::CompareNoCase(myChannelEpg.GetId(), id) == 0)
+    if (StringUtils::EqualsNoCase(myChannelEpg.GetId(), id))
       return &myChannelEpg;
   }
 

--- a/src/iptvsimple/Epg.cpp
+++ b/src/iptvsimple/Epg.cpp
@@ -40,12 +40,6 @@ using namespace iptvsimple::data;
 using namespace iptvsimple::utilities;
 using namespace rapidxml;
 
-#ifdef TARGET_WINDOWS
-#ifdef DeleteFile
-#undef DeleteFile
-#endif
-#endif
-
 Epg::Epg(Channels& channels)
   : m_channels(channels), m_xmltvLocation(Settings::GetInstance().GetEpgLocation()), m_epgTimeShift(Settings::GetInstance().GetEpgTimeshiftSecs()),
     m_tsOverride(Settings::GetInstance().GetTsOverride()), m_lastStart(0), m_lastEnd(0)
@@ -216,8 +210,7 @@ bool Epg::LoadChannelEpgs(xml_node<>* rootElement)
 
   m_channelEpgs.clear();
 
-  xml_node<>* channelNode = nullptr;
-  for (channelNode = rootElement->first_node("channel"); channelNode; channelNode = channelNode->next_sibling("channel"))
+  for (xml_node<>* channelNode = rootElement->first_node("channel"); channelNode; channelNode = channelNode->next_sibling("channel"))
   {
     ChannelEpg channelEpg;
 
@@ -473,6 +466,6 @@ void Epg::MoveOldGenresXMLFileToNewLocation()
   else
     FileUtils::CopyFile(FileUtils::GetResourceDataPath() + "/" + GENRES_MAP_FILENAME, DEFAULT_GENRE_TEXT_MAP_FILE);
 
-  XBMC->DeleteFile((ADDON_DATA_BASE_DIR + "/" + GENRES_MAP_FILENAME).c_str());
-  XBMC->DeleteFile((FileUtils::GetSystemAddonPath() + "/" + GENRES_MAP_FILENAME).c_str());
+  FileUtils::DeleteFile(ADDON_DATA_BASE_DIR + "/" + GENRES_MAP_FILENAME.c_str());
+  FileUtils::DeleteFile(FileUtils::GetSystemAddonPath() + "/" + GENRES_MAP_FILENAME.c_str());
 }

--- a/src/iptvsimple/Epg.cpp
+++ b/src/iptvsimple/Epg.cpp
@@ -52,6 +52,9 @@ void Epg::Clear()
 
 bool Epg::LoadEPG(time_t start, time_t end)
 {
+  auto started = std::chrono::high_resolution_clock::now();
+  Logger::Log(LEVEL_DEBUG, "%s EPG Load Start", __FUNCTION__);
+
   if (m_xmltvLocation.empty())
   {
     Logger::Log(LEVEL_NOTICE, "EPG file path is not configured. EPG not loaded.");
@@ -99,10 +102,13 @@ bool Epg::LoadEPG(time_t start, time_t end)
 
   LoadGenres();
 
-  Logger::Log(LEVEL_NOTICE, "EPG Loaded.");
-
   if (Settings::GetInstance().GetEpgLogosMode() != EpgLogosMode::IGNORE_XMLTV)
     ApplyChannelsLogosFromEPG();
+
+  int milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(
+                      std::chrono::high_resolution_clock::now() - started).count();
+
+  Logger::Log(LEVEL_NOTICE, "%s EPG Loaded - %d (ms)", __FUNCTION__, milliseconds);
 
   return true;
 }
@@ -389,7 +395,7 @@ void Epg::ApplyChannelsLogosFromEPG()
 }
 
 bool Epg::LoadGenres()
-{
+{  
   // try to load genres from userdata folder
   std::string filePath = FileUtils::GetUserFilePath(GENRES_MAP_FILENAME);
   if (!XBMC->FileExists(filePath.c_str(), false))

--- a/src/iptvsimple/Epg.cpp
+++ b/src/iptvsimple/Epg.cpp
@@ -335,15 +335,28 @@ ChannelEpg* Epg::FindEpgForChannel(const Channel& channel)
 {
   for (auto& myChannelEpg : m_channelEpgs)
   {
-    if (myChannelEpg.GetId() == channel.GetTvgId())
+    if (StringUtils::EqualsNoCase(myChannelEpg.GetId(), channel.GetTvgId()))
       return &myChannelEpg;
+  }
 
-    const std::string name = std::regex_replace(myChannelEpg.GetName(), std::regex(" "), "_");
-    if (name == channel.GetTvgName() || myChannelEpg.GetName() == channel.GetTvgName())
-      return &myChannelEpg;
+  for (auto& myChannelEpg : m_channelEpgs)
+  {
+    for (const std::string& displayName : myChannelEpg.GetNames())
+    {
+      const std::string convertedDisplayName = std::regex_replace(displayName, std::regex(" "), "_");
+      if (StringUtils::EqualsNoCase(convertedDisplayName, channel.GetTvgName()) || 
+          StringUtils::EqualsNoCase(displayName, channel.GetTvgName()))
+        return &myChannelEpg; 
+    }
+  }
 
-    if (myChannelEpg.GetName() == channel.GetChannelName())
-      return &myChannelEpg;
+  for (auto& myChannelEpg : m_channelEpgs)
+  {
+    for (const std::string& displayName : myChannelEpg.GetNames())
+    {
+      if (StringUtils::EqualsNoCase(displayName, channel.GetChannelName()))
+        return &myChannelEpg;
+    }
   }
 
   return nullptr;

--- a/src/iptvsimple/Epg.cpp
+++ b/src/iptvsimple/Epg.cpp
@@ -79,7 +79,8 @@ bool Epg::LoadEPG(time_t start, time_t end)
 
   if (GetXMLTVFileWithRetries(data))
   {
-    char* buffer = FillBufferFromXMLTVData(data);
+    std::string decompressedData;
+    char* buffer = FillBufferFromXMLTVData(data, decompressedData);
 
     if (!buffer)
       return false;
@@ -152,24 +153,23 @@ bool Epg::GetXMLTVFileWithRetries(std::string& data)
   return true;
 }
 
-char* Epg::FillBufferFromXMLTVData(std::string& data)
+char* Epg::FillBufferFromXMLTVData(std::string& data, std::string& decompressedData)
 {
-  std::string decompressed;
   char* buffer = nullptr;
 
   // gzip packed
   if (data[0] == '\x1F' && data[1] == '\x8B' && data[2] == '\x08')
   {
-    if (!FileUtils::GzipInflate(data, decompressed))
+    if (!FileUtils::GzipInflate(data, decompressedData))
     {
       Logger::Log(LEVEL_ERROR, "%s - Invalid EPG file '%s': unable to decompress file.", __FUNCTION__, m_xmltvLocation.c_str());
       return nullptr;
     }
-    buffer = &(decompressed[0]);
+    buffer = &(decompressedData[0]);
   }
   else
   {
-   buffer = &(data[0]);
+    buffer = &(data[0]);
   }
 
   XmltvFileFormat fileFormat = GetXMLTVFileFormat(buffer);

--- a/src/iptvsimple/Epg.h
+++ b/src/iptvsimple/Epg.h
@@ -60,7 +60,7 @@ namespace iptvsimple
 
     bool LoadEPG(time_t iStart, time_t iEnd);
     bool GetXMLTVFileWithRetries(std::string& data);
-    char* FillBufferFromXMLTVData(std::string& data);
+    char* FillBufferFromXMLTVData(std::string& data, std::string& decompressedData);
     bool LoadChannelEpgs(rapidxml::xml_node<>* rootElement);
     void LoadEpgEntries(rapidxml::xml_node<>* rootElement, int start, int end);
     bool LoadGenres();

--- a/src/iptvsimple/Epg.h
+++ b/src/iptvsimple/Epg.h
@@ -24,6 +24,7 @@
 #include "kodi/libXBMC_pvr.h"
 
 #include "Channels.h"
+#include "Settings.h"
 #include "data/ChannelEpg.h"
 #include "data/EpgGenre.h"
 
@@ -34,6 +35,8 @@ namespace iptvsimple
 {
   static const int SECONDS_IN_DAY = 86400;
   static const std::string GENRES_MAP_FILENAME = "genres.xml";
+  static const std::string GENRE_DIR = "/genres";
+  static const std::string GENRE_ADDON_DATA_BASE_DIR = ADDON_DATA_BASE_DIR + GENRE_DIR;
 
   enum class XmltvFileFormat
   {
@@ -53,6 +56,7 @@ namespace iptvsimple
 
   private:
     static const XmltvFileFormat GetXMLTVFileFormat(const char* buffer);
+    static void MoveOldGenresXMLFileToNewLocation();
 
     bool LoadEPG(time_t iStart, time_t iEnd);
     bool GetXMLTVFileWithRetries(std::string& data);
@@ -73,6 +77,6 @@ namespace iptvsimple
 
     iptvsimple::Channels& m_channels;
     std::vector<data::ChannelEpg> m_channelEpgs;
-    std::vector<iptvsimple::data::EpgGenre> m_genres;
+    std::vector<iptvsimple::data::EpgGenre> m_genreMappings;
   };
 } //namespace iptvsimple

--- a/src/iptvsimple/PlaylistLoader.cpp
+++ b/src/iptvsimple/PlaylistLoader.cpp
@@ -30,6 +30,7 @@
 
 #include "p8-platform/util/StringUtils.h"
 
+#include <chrono>
 #include <cstdlib>
 #include <map>
 #include <regex>
@@ -45,6 +46,9 @@ PlaylistLoader::PlaylistLoader(Channels& channels, ChannelGroups& channelGroups)
 
 bool PlaylistLoader::LoadPlayList()
 {
+  auto started = std::chrono::high_resolution_clock::now();
+  Logger::Log(LEVEL_DEBUG, "%s Playlist Load Start", __FUNCTION__);
+
   if (m_m3uLocation.empty())
   {
     Logger::Log(LEVEL_NOTICE, "Playlist file path is not configured. Channels not loaded.");
@@ -147,9 +151,14 @@ bool PlaylistLoader::LoadPlayList()
 
   stream.clear();
 
+  int milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(
+                      std::chrono::high_resolution_clock::now() - started).count();
+
+  Logger::Log(LEVEL_NOTICE, "%s Playlist Loaded - %d (ms)", __FUNCTION__, milliseconds);
+
   if (m_channels.GetChannelsAmount() == 0)
   {
-    Logger::Log(LEVEL_ERROR, "Unable to load channels from file '%s':  file is corrupted.", m_m3uLocation.c_str());
+    Logger::Log(LEVEL_ERROR, "Unable to load channels from file '%s'", m_m3uLocation.c_str());
     return false;
   }
 

--- a/src/iptvsimple/PlaylistLoader.cpp
+++ b/src/iptvsimple/PlaylistLoader.cpp
@@ -207,7 +207,7 @@ std::string PlaylistLoader::ParseIntoChannel(const std::string& line, Channel& c
       logoSetFromChannelName = true;
     }
 
-    if (!strChnlNo.empty())
+    if (!strChnlNo.empty() && !Settings::GetInstance().NumberChannelsByM3uOrderOnly())
       channel.SetChannelNumber(std::atoi(strChnlNo.c_str()));
 
     double tvgShiftDecimal = std::atof(strTvgShift.c_str());

--- a/src/iptvsimple/PlaylistLoader.cpp
+++ b/src/iptvsimple/PlaylistLoader.cpp
@@ -195,7 +195,7 @@ std::string PlaylistLoader::ParseIntoChannel(const std::string& line, Channel& c
 
     double tvgShiftDecimal = std::atof(strTvgShift.c_str());
 
-    bool isRadio = !StringUtils::CompareNoCase(strRadio, "true");
+    bool isRadio = StringUtils::EqualsNoCase(strRadio, "true");
     channel.SetTvgId(strTvgId);
     channel.SetTvgName(XBMC->UnknownToUTF8(strTvgName.c_str()));
     channel.SetTvgLogo(XBMC->UnknownToUTF8(strTvgLogo.c_str()));

--- a/src/iptvsimple/PlaylistLoader.cpp
+++ b/src/iptvsimple/PlaylistLoader.cpp
@@ -47,18 +47,18 @@ PlaylistLoader::PlaylistLoader(Channels& channels, ChannelGroups& channelGroups)
 bool PlaylistLoader::LoadPlayList()
 {
   auto started = std::chrono::high_resolution_clock::now();
-  Logger::Log(LEVEL_DEBUG, "%s Playlist Load Start", __FUNCTION__);
+  Logger::Log(LEVEL_DEBUG, "%s - Playlist Load Start", __FUNCTION__);
 
   if (m_m3uLocation.empty())
   {
-    Logger::Log(LEVEL_NOTICE, "Playlist file path is not configured. Channels not loaded.");
+    Logger::Log(LEVEL_ERROR, "%s - Playlist file path is not configured. Channels not loaded.", __FUNCTION__);
     return false;
   }
 
   std::string playlistContent;
   if (!FileUtils::GetCachedFileContents(M3U_CACHE_FILENAME, m_m3uLocation, playlistContent, Settings::GetInstance().UseM3UCache()))
   {
-    Logger::Log(LEVEL_ERROR, "Unable to load playlist file '%s':  file is missing or empty.", m_m3uLocation.c_str());
+    Logger::Log(LEVEL_ERROR, "%s - Unable to load playlist cache file '%s':  file is missing or empty.", __FUNCTION__, m_m3uLocation.c_str());
     return false;
   }
 
@@ -78,7 +78,7 @@ bool PlaylistLoader::LoadPlayList()
     line = StringUtils::TrimRight(line, " \t\r\n");
     line = StringUtils::TrimLeft(line, " \t");
 
-    Logger::Log(LEVEL_DEBUG, "Read line: '%s'", line.c_str());
+    Logger::Log(LEVEL_DEBUG, "%s - M3U line read: '%s'", __FUNCTION__, line.c_str());
 
     if (line.empty())
       continue;
@@ -98,8 +98,8 @@ bool PlaylistLoader::LoadPlayList()
       }
       else
       {
-        Logger::Log(LEVEL_ERROR, "URL '%s' missing %s descriptor on line 1, attempting to parse it anyway.",
-                    m_m3uLocation.c_str(), M3U_START_MARKER.c_str());
+        Logger::Log(LEVEL_ERROR, "%s - URL '%s' missing %s descriptor on line 1, attempting to parse it anyway.",
+                    __FUNCTION__, m_m3uLocation.c_str(), M3U_START_MARKER.c_str());
       }
     }
 
@@ -134,7 +134,7 @@ bool PlaylistLoader::LoadPlayList()
     }
     else if (line[0] != '#')
     {
-      Logger::Log(LEVEL_DEBUG, "Found URL: '%s' (current channel name: '%s')", line.c_str(), tmpChannel.GetChannelName().c_str());
+      Logger::Log(LEVEL_DEBUG, "%s - Adding channel '%s' with URL: '%s'", __FUNCTION__, tmpChannel.GetChannelName().c_str(), line.c_str());
 
       if (isRealTime)
         tmpChannel.AddProperty(PVR_STREAM_PROPERTY_ISREALTIMESTREAM, "true");
@@ -158,13 +158,13 @@ bool PlaylistLoader::LoadPlayList()
 
   if (m_channels.GetChannelsAmount() == 0)
   {
-    Logger::Log(LEVEL_ERROR, "Unable to load channels from file '%s'", m_m3uLocation.c_str());
+    Logger::Log(LEVEL_ERROR, "%s - Unable to load channels from file '%s'", __FUNCTION__, m_m3uLocation.c_str());
     return false;
   }
 
   m_channels.ApplyChannelLogos();
 
-  Logger::Log(LEVEL_NOTICE, "Loaded %d channels.", m_channels.GetChannelsAmount());
+  Logger::Log(LEVEL_NOTICE, "%s - Loaded %d channels.", __FUNCTION__, m_channels.GetChannelsAmount());
   return true;
 }
 

--- a/src/iptvsimple/PlaylistLoader.cpp
+++ b/src/iptvsimple/PlaylistLoader.cpp
@@ -181,6 +181,9 @@ std::string PlaylistLoader::ParseIntoChannel(const std::string& line, Channel& c
     std::string strTvgShift   = ReadMarkerValue(infoLine, TVG_INFO_SHIFT_MARKER);
 
     if (strTvgId.empty())
+      strTvgId = ReadMarkerValue(infoLine, TVG_INFO_ID_MARKER_UC);
+      
+    if (strTvgId.empty())
     {
       char buff[255];
       sprintf(buff, "%d", std::atoi(infoLine.c_str()));

--- a/src/iptvsimple/PlaylistLoader.cpp
+++ b/src/iptvsimple/PlaylistLoader.cpp
@@ -56,7 +56,7 @@ bool PlaylistLoader::LoadPlayList()
   }
 
   std::string playlistContent;
-  if (!FileUtils::GetCachedFileContents(M3U_FILE_NAME, m_m3uLocation, playlistContent, Settings::GetInstance().UseM3UCache()))
+  if (!FileUtils::GetCachedFileContents(M3U_CACHE_FILENAME, m_m3uLocation, playlistContent, Settings::GetInstance().UseM3UCache()))
   {
     Logger::Log(LEVEL_ERROR, "Unable to load playlist file '%s':  file is missing or empty.", m_m3uLocation.c_str());
     return false;
@@ -192,7 +192,7 @@ std::string PlaylistLoader::ParseIntoChannel(const std::string& line, Channel& c
 
     if (strTvgId.empty())
       strTvgId = ReadMarkerValue(infoLine, TVG_INFO_ID_MARKER_UC);
-      
+
     if (strTvgId.empty())
     {
       char buff[255];

--- a/src/iptvsimple/PlaylistLoader.cpp
+++ b/src/iptvsimple/PlaylistLoader.cpp
@@ -26,6 +26,7 @@
 #include "../client.h"
 #include "utilities/FileUtils.h"
 #include "utilities/Logger.h"
+#include "utilities/WebUtils.h"
 
 #include "p8-platform/util/StringUtils.h"
 
@@ -190,8 +191,12 @@ std::string PlaylistLoader::ParseIntoChannel(const std::string& line, Channel& c
       strTvgId.append(buff);
     }
 
+    bool logoSetFromChannelName = false;
     if (strTvgLogo.empty())
+    {
       strTvgLogo = channelName;
+      logoSetFromChannelName = true;
+    }
 
     if (!strChnlNo.empty())
       channel.SetChannelNumber(std::atoi(strChnlNo.c_str()));
@@ -204,6 +209,11 @@ std::string PlaylistLoader::ParseIntoChannel(const std::string& line, Channel& c
     channel.SetTvgLogo(XBMC->UnknownToUTF8(strTvgLogo.c_str()));
     channel.SetTvgShift(static_cast<int>(tvgShiftDecimal * 3600.0));
     channel.SetRadio(isRadio);
+
+    // urlencode channel logo when set from channel name and source is Remote Path
+    // append extension as channel name wouldn't have it
+    if (Settings::GetInstance().GetLogoPathType() == PathType::REMOTE_PATH && logoSetFromChannelName)
+      channel.SetTvgLogo(WebUtils::UrlEncode(channel.GetTvgLogo()) + CHANNEL_LOGO_EXTENSION);
 
     if (strTvgShift.empty())
       channel.SetTvgShift(epgTimeShift);

--- a/src/iptvsimple/PlaylistLoader.h
+++ b/src/iptvsimple/PlaylistLoader.h
@@ -34,6 +34,7 @@ namespace iptvsimple
   static const std::string M3U_INFO_MARKER         = "#EXTINF";
   static const std::string M3U_GROUP_MARKER        = "#EXTGRP:";
   static const std::string TVG_INFO_ID_MARKER      = "tvg-id=";
+  static const std::string TVG_INFO_ID_MARKER_UC   = "tvg-ID="; //some provider incorrectly use an uppercase ID
   static const std::string TVG_INFO_NAME_MARKER    = "tvg-name=";
   static const std::string TVG_INFO_LOGO_MARKER    = "tvg-logo=";
   static const std::string TVG_INFO_SHIFT_MARKER   = "tvg-shift=";

--- a/src/iptvsimple/Settings.cpp
+++ b/src/iptvsimple/Settings.cpp
@@ -96,11 +96,11 @@ ADDON_STATUS Settings::SetValue(const std::string& settingName, const void* sett
 {
   // reset cache and restart addon
 
-  std::string strFile = FileUtils::GetUserFilePath(M3U_FILE_NAME);
+  std::string strFile = FileUtils::GetUserDataAddonFilePath(M3U_CACHE_FILENAME);
   if (XBMC->FileExists(strFile.c_str(), false))
     XBMC->DeleteFile(strFile.c_str());
 
-  strFile = FileUtils::GetUserFilePath(TVG_FILE_NAME);
+  strFile = FileUtils::GetUserDataAddonFilePath(XMLTV_CACHE_FILENAME);
   if (XBMC->FileExists(strFile.c_str(), false))
     XBMC->DeleteFile(strFile.c_str());
 

--- a/src/iptvsimple/Settings.cpp
+++ b/src/iptvsimple/Settings.cpp
@@ -29,12 +29,6 @@ using namespace ADDON;
 using namespace iptvsimple;
 using namespace iptvsimple::utilities;
 
-#ifdef TARGET_WINDOWS
-#ifdef DeleteFile
-#undef DeleteFile
-#endif
-#endif
-
 /***************************************************************************
  * PVR settings
  **************************************************************************/
@@ -99,12 +93,12 @@ ADDON_STATUS Settings::SetValue(const std::string& settingName, const void* sett
   // reset cache and restart addon
 
   std::string strFile = FileUtils::GetUserDataAddonFilePath(M3U_CACHE_FILENAME);
-  if (XBMC->FileExists(strFile.c_str(), false))
-    XBMC->DeleteFile(strFile.c_str());
+  if (FileUtils::FileExists(strFile.c_str()))
+    FileUtils::DeleteFile(strFile);
 
   strFile = FileUtils::GetUserDataAddonFilePath(XMLTV_CACHE_FILENAME);
-  if (XBMC->FileExists(strFile.c_str(), false))
-    XBMC->DeleteFile(strFile.c_str());
+  if (FileUtils::FileExists(strFile.c_str()))
+    FileUtils::DeleteFile(strFile);
 
   // M3U
   if (settingName == "m3uPathType")

--- a/src/iptvsimple/Settings.cpp
+++ b/src/iptvsimple/Settings.cpp
@@ -71,6 +71,16 @@ void Settings::ReadFromAddon(const std::string& userPath, const std::string clie
   if (!XBMC->GetSetting("epgTSOverride", &m_tsOverride))
     m_tsOverride = true;
 
+  //Genres
+  if (!XBMC->GetSetting("useEpgGenreText", &m_useEpgGenreTextWhenMapping))
+    m_useEpgGenreTextWhenMapping = false;
+  if (!XBMC->GetSetting("genresPathType", &m_genresPathType))
+    m_genresPathType = PathType::LOCAL_PATH;
+  if (XBMC->GetSetting("genresPath", &buffer))
+    m_genresPath = buffer;
+  if (XBMC->GetSetting("genresUrl", &buffer))
+    m_genresUrl = buffer;
+
   // Channel Logos
   if (!XBMC->GetSetting("logoPathType", &m_logoPathType))
     m_logoPathType = PathType::REMOTE_PATH;
@@ -119,6 +129,16 @@ ADDON_STATUS Settings::SetValue(const std::string& settingName, const void* sett
     return SetSetting<int, ADDON_STATUS>(settingName, settingValue, m_epgTimeShiftMins, ADDON_STATUS_OK, ADDON_STATUS_OK);
   if (settingName == "epgTSOverride")
     return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_tsOverride, ADDON_STATUS_OK, ADDON_STATUS_OK);
+
+  // Genres
+  if (settingName == "useEpgGenreText")
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_useEpgGenreTextWhenMapping, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  if (settingName == "genresPathType")
+    return SetSetting<PathType, ADDON_STATUS>(settingName, settingValue, m_genresPathType, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  if (settingName == "genresPath")
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_genresPath, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  if (settingName == "genresUrl")
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_genresUrl, ADDON_STATUS_OK, ADDON_STATUS_OK);
 
   // Channel Logos
   if (settingName == "logoPathType")

--- a/src/iptvsimple/Settings.cpp
+++ b/src/iptvsimple/Settings.cpp
@@ -56,6 +56,8 @@ void Settings::ReadFromAddon(const std::string& userPath, const std::string clie
       m_cacheM3U = true;
   if (!XBMC->GetSetting("startNum", &m_startChannelNumber))
     m_startChannelNumber = 1;
+  if (!XBMC->GetSetting("numberByOrder", &m_numberChannelsByM3uOrderOnly))
+    m_numberChannelsByM3uOrderOnly = false;
 
   // EPG
   if (!XBMC->GetSetting("epgPathType", &m_epgPathType))
@@ -115,6 +117,8 @@ ADDON_STATUS Settings::SetValue(const std::string& settingName, const void* sett
     return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_cacheM3U, ADDON_STATUS_OK, ADDON_STATUS_OK);
   if (settingName == "startNum")
     return SetSetting<int, ADDON_STATUS>(settingName, settingValue, m_startChannelNumber, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  if (settingName == "numberByOrder")
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_numberChannelsByM3uOrderOnly, ADDON_STATUS_OK, ADDON_STATUS_OK);
 
   // EPG
   if (settingName == "epgPathType")

--- a/src/iptvsimple/Settings.h
+++ b/src/iptvsimple/Settings.h
@@ -73,6 +73,7 @@ namespace iptvsimple
     const std::string& GetM3UUrl() const { return m_m3uUrl; }
     bool UseM3UCache() const { return m_m3uPathType == PathType::REMOTE_PATH ? m_cacheM3U : false; }
     int GetStartChannelNumber() const { return m_startChannelNumber; }
+    bool NumberChannelsByM3uOrderOnly() const { return m_numberChannelsByM3uOrderOnly; }
 
     const std::string& GetEpgLocation() const { return m_epgPathType == PathType::REMOTE_PATH ? m_epgUrl : m_epgPath; }
     const PathType& GetEpgPathType() const { return m_epgPathType; }
@@ -138,6 +139,7 @@ namespace iptvsimple
     std::string m_m3uUrl = "";
     bool m_cacheM3U = false;
     int m_startChannelNumber = 1;
+    bool m_numberChannelsByM3uOrderOnly = false;
 
     PathType m_epgPathType = PathType::REMOTE_PATH;
     std::string m_epgPath = "";

--- a/src/iptvsimple/Settings.h
+++ b/src/iptvsimple/Settings.h
@@ -29,8 +29,8 @@
 
 namespace iptvsimple
 {
-  static const std::string M3U_FILE_NAME = "iptv.m3u.cache";
-  static const std::string TVG_FILE_NAME = "xmltv.xml.cache";
+  static const std::string M3U_CACHE_FILENAME = "iptv.m3u.cache";
+  static const std::string XMLTV_CACHE_FILENAME = "xmltv.xml.cache";
   static const std::string ADDON_DATA_BASE_DIR = "special://userdata/addon_data/pvr.iptvsimple";
   static const std::string DEFAULT_GENRE_TEXT_MAP_FILE = ADDON_DATA_BASE_DIR + "/genres/genreTextMappings/genres.xml";
 

--- a/src/iptvsimple/Settings.h
+++ b/src/iptvsimple/Settings.h
@@ -131,31 +131,31 @@ namespace iptvsimple
       return defaultReturnValue;
     }
 
-    std::string m_userPath = "";
-    std::string m_clientPath = "";
+    std::string m_userPath;
+    std::string m_clientPath;
 
     PathType m_m3uPathType = PathType::REMOTE_PATH;
-    std::string m_m3uPath = "";
-    std::string m_m3uUrl = "";
+    std::string m_m3uPath;
+    std::string m_m3uUrl;
     bool m_cacheM3U = false;
     int m_startChannelNumber = 1;
     bool m_numberChannelsByM3uOrderOnly = false;
 
     PathType m_epgPathType = PathType::REMOTE_PATH;
-    std::string m_epgPath = "";
-    std::string m_epgUrl = "";
+    std::string m_epgPath;
+    std::string m_epgUrl;
     bool m_cacheEPG = false;
     int m_epgTimeShiftMins = 0;
     bool m_tsOverride = true;
 
     bool m_useEpgGenreTextWhenMapping = false;
     PathType m_genresPathType = PathType::LOCAL_PATH;
-    std::string m_genresPath = "";
-    std::string m_genresUrl = "";
+    std::string m_genresPath;
+    std::string m_genresUrl;
 
     PathType m_logoPathType = PathType::REMOTE_PATH;
-    std::string m_logoPath = "";
-    std::string m_logoBaseUrl = "";
+    std::string m_logoPath;
+    std::string m_logoBaseUrl;
     EpgLogosMode m_epgLogosMode = EpgLogosMode::IGNORE_XMLTV;
   };
 } //namespace iptvsimple

--- a/src/iptvsimple/Settings.h
+++ b/src/iptvsimple/Settings.h
@@ -31,6 +31,8 @@ namespace iptvsimple
 {
   static const std::string M3U_FILE_NAME = "iptv.m3u.cache";
   static const std::string TVG_FILE_NAME = "xmltv.xml.cache";
+  static const std::string ADDON_DATA_BASE_DIR = "special://userdata/addon_data/pvr.iptvsimple";
+  static const std::string DEFAULT_GENRE_TEXT_MAP_FILE = ADDON_DATA_BASE_DIR + "/genres/genreTextMappings/genres.xml";
 
   enum class PathType
     : int // same type as addon settings
@@ -80,6 +82,12 @@ namespace iptvsimple
     int GetEpgTimeshiftMins() const { return m_epgTimeShiftMins; }
     int GetEpgTimeshiftSecs() const { return m_epgTimeShiftMins * 60; }
     bool GetTsOverride() const { return m_tsOverride; }
+
+    const std::string& GetGenresLocation() const { return m_genresPathType == PathType::REMOTE_PATH ? m_genresUrl : m_genresPath; }
+    bool UseEpgGenreTextWhenMapping() const { return m_useEpgGenreTextWhenMapping; }
+    const PathType& GetGenresPathType() const { return m_genresPathType; }
+    const std::string& GetGenresPath() const { return m_genresPath; }
+    const std::string& GetGenresUrl() const { return m_genresUrl; }
 
     const std::string& GetLogoLocation() const { return m_logoPathType == PathType::REMOTE_PATH ? m_logoBaseUrl : m_logoPath; }
     const PathType& GetLogoPathType() const { return m_logoPathType; }
@@ -137,6 +145,11 @@ namespace iptvsimple
     bool m_cacheEPG = false;
     int m_epgTimeShiftMins = 0;
     bool m_tsOverride = true;
+
+    bool m_useEpgGenreTextWhenMapping = false;
+    PathType m_genresPathType = PathType::LOCAL_PATH;
+    std::string m_genresPath = "";
+    std::string m_genresUrl = "";
 
     PathType m_logoPathType = PathType::REMOTE_PATH;
     std::string m_logoPath = "";

--- a/src/iptvsimple/data/ChannelEpg.cpp
+++ b/src/iptvsimple/data/ChannelEpg.cpp
@@ -45,7 +45,7 @@ bool ChannelEpg::UpdateFrom(xml_node<>* channelNode, Channels& channels)
   }
 
   if (!foundChannel)
-    return false;    
+    return false;
 
   // get icon if available
   xml_node<>* iconNode = channelNode->first_node("icon");

--- a/src/iptvsimple/data/ChannelEpg.cpp
+++ b/src/iptvsimple/data/ChannelEpg.cpp
@@ -30,16 +30,22 @@ using namespace rapidxml;
 
 bool ChannelEpg::UpdateFrom(xml_node<>* channelNode, Channels& channels)
 {
-  std::string id;
-  if (!GetAttributeValue(channelNode, "id", id))
+  if (!GetAttributeValue(channelNode, "id", m_id))
     return false;
 
-  const std::string name = GetNodeValue(channelNode, "display-name");
-  if (!channels.FindChannel(id, name))
-    return false;
+  bool foundChannel = false;
+  for (xml_node<>* displayNameNode = channelNode->first_node("display-name"); displayNameNode; displayNameNode = displayNameNode->next_sibling("display-name"))
+  {
+    const std::string name = displayNameNode->value();
+    if (channels.FindChannel(m_id, name))
+    {
+      foundChannel = true;
+      m_names.emplace_back(name);
+    }
+  }
 
-  m_id = id;
-  m_name = name;
+  if (!foundChannel)
+    return false;    
 
   // get icon if available
   xml_node<>* iconNode = channelNode->first_node("icon");

--- a/src/iptvsimple/data/ChannelEpg.h
+++ b/src/iptvsimple/data/ChannelEpg.h
@@ -40,8 +40,8 @@ namespace iptvsimple
       const std::string& GetId() const { return m_id; }
       void SetId(const std::string& value) { m_id = value; }
 
-      const std::string& GetName() const { return m_name; }
-      void SetName(const std::string& value) { m_name = value; }
+      const std::vector<std::string>& GetNames() const { return m_names; }
+      void AddName(const std::string& value) { m_names.emplace_back(value); }
 
       const std::string& GetIcon() const { return m_icon; }
       void SetIcon(const std::string& value) { m_icon = value; }
@@ -53,7 +53,7 @@ namespace iptvsimple
 
     private:
       std::string m_id;
-      std::string m_name;
+      std::vector<std::string> m_names;
       std::string m_icon;
       std::vector<EpgEntry> m_epgEntries;
     };

--- a/src/iptvsimple/data/EpgEntry.cpp
+++ b/src/iptvsimple/data/EpgEntry.cpp
@@ -165,11 +165,11 @@ bool EpgEntry::UpdateFrom(rapidxml::xml_node<>* channelNode, const std::string& 
   m_episodeName = GetNodeValue(channelNode, "sub-title");
 
   xml_node<> *creditsNode = channelNode->first_node("credits");
-  if (creditsNode != NULL)
+  if (creditsNode)
   {
-    m_cast = GetNodeValue(creditsNode, "actor");
-    m_director = GetNodeValue(creditsNode, "director");
-    m_writer = GetNodeValue(creditsNode, "writer");
+    m_cast = GetJoinedNodeValues(creditsNode, "actor");
+    m_director = GetJoinedNodeValues(creditsNode, "director");
+    m_writer = GetJoinedNodeValues(creditsNode, "writer");
   }
 
   xml_node<>* iconNode = channelNode->first_node("icon");

--- a/src/iptvsimple/data/EpgEntry.cpp
+++ b/src/iptvsimple/data/EpgEntry.cpp
@@ -234,7 +234,7 @@ bool EpgEntry::UpdateFrom(rapidxml::xml_node<>* channelNode, const std::string& 
   if (!episodeNumbersList.empty())
     ParseEpisodeNumberInfo(episodeNumbersList);
 
-  xml_node<> *creditsNode = channelNode->first_node("credits");
+  xml_node<>* creditsNode = channelNode->first_node("credits");
   if (creditsNode)
   {
     m_cast = GetJoinedNodeValues(creditsNode, "actor");

--- a/src/iptvsimple/data/EpgEntry.cpp
+++ b/src/iptvsimple/data/EpgEntry.cpp
@@ -80,7 +80,7 @@ bool EpgEntry::SetEpgGenre(std::vector<EpgGenre> genres, const std::string& genr
 
   for (const auto& myGenre : genres)
   {
-    if (StringUtils::CompareNoCase(myGenre.GetGenreString(), genreToFind) == 0)
+    if (StringUtils::EqualsNoCase(myGenre.GetGenreString(), genreToFind))
     {
       m_genreType = myGenre.GetGenreType();
       m_genreSubType = myGenre.GetGenreSubType();

--- a/src/iptvsimple/data/EpgEntry.h
+++ b/src/iptvsimple/data/EpgEntry.h
@@ -64,7 +64,7 @@ namespace iptvsimple
       void SetEpisodePartNumber(int value) { m_episodePartNumber = value; }
 
       int GetSeasonNumber() const { return m_seasonNumber; }
-      void SetSeasonNumber(int value) { m_seasonNumber = value; }      
+      void SetSeasonNumber(int value) { m_seasonNumber = value; }
 
       time_t GetStartTime() const { return m_startTime; }
       void SetStartTime(time_t value) { m_startTime = value; }
@@ -107,7 +107,7 @@ namespace iptvsimple
                       int start, int end, int minShiftTime, int maxShiftTime);
 
     private:
-      bool SetEpgGenre(std::vector<EpgGenre> genres, const std::string& genreToFind);
+      bool SetEpgGenre(std::vector<EpgGenre> genreMappings);
       bool ParseEpisodeNumberInfo(std::vector<std::pair<std::string, std::string>>& episodeNumbersList);
       bool ParseXmltvNsEpisodeNumberInfo(const std::string& episodeNumberString);
       bool ParseOnScreenEpisodeNumberInfo(const std::string& episodeNumberString);
@@ -120,7 +120,7 @@ namespace iptvsimple
       int m_starRating;
       int m_episodeNumber = 0;
       int m_episodePartNumber = 0;
-      int m_seasonNumber = 0;      
+      int m_seasonNumber = 0;
       time_t m_startTime;
       time_t m_endTime;
       time_t m_firstAired;

--- a/src/iptvsimple/data/EpgEntry.h
+++ b/src/iptvsimple/data/EpgEntry.h
@@ -34,6 +34,8 @@ namespace iptvsimple
 {
   namespace data
   {
+    static const float STAR_RATING_SCALE = 10.0f;
+
     class EpgEntry
     {
     public:
@@ -51,6 +53,9 @@ namespace iptvsimple
 
       int GetYear() const { return m_year; }
       void SetYear(int value) { m_year = value; }
+
+      int GetStarRating() const { return m_starRating; }
+      void SetStarRating(int value) { m_starRating = value; }
 
       time_t GetStartTime() const { return m_startTime; }
       void SetStartTime(time_t value) { m_startTime = value; }
@@ -100,6 +105,7 @@ namespace iptvsimple
       int m_genreType;
       int m_genreSubType;
       int m_year;
+      int m_starRating;
       time_t m_startTime;
       time_t m_endTime;
       time_t m_firstAired;

--- a/src/iptvsimple/data/EpgEntry.h
+++ b/src/iptvsimple/data/EpgEntry.h
@@ -57,6 +57,15 @@ namespace iptvsimple
       int GetStarRating() const { return m_starRating; }
       void SetStarRating(int value) { m_starRating = value; }
 
+      int GetEpisodeNumber() const { return m_episodeNumber; }
+      void SetEpisodeNumber(int value) { m_episodeNumber = value; }
+
+      int GetEpisodePartNumber() const { return m_episodePartNumber; }
+      void SetEpisodePartNumber(int value) { m_episodePartNumber = value; }
+
+      int GetSeasonNumber() const { return m_seasonNumber; }
+      void SetSeasonNumber(int value) { m_seasonNumber = value; }      
+
       time_t GetStartTime() const { return m_startTime; }
       void SetStartTime(time_t value) { m_startTime = value; }
 
@@ -99,6 +108,9 @@ namespace iptvsimple
 
     private:
       bool SetEpgGenre(std::vector<EpgGenre> genres, const std::string& genreToFind);
+      bool ParseEpisodeNumberInfo(std::vector<std::pair<std::string, std::string>>& episodeNumbersList);
+      bool ParseXmltvNsEpisodeNumberInfo(const std::string& episodeNumberString);
+      bool ParseOnScreenEpisodeNumberInfo(const std::string& episodeNumberString);
 
       int m_broadcastId;
       int m_channelId;
@@ -106,6 +118,9 @@ namespace iptvsimple
       int m_genreSubType;
       int m_year;
       int m_starRating;
+      int m_episodeNumber = 0;
+      int m_episodePartNumber = 0;
+      int m_seasonNumber = 0;      
       time_t m_startTime;
       time_t m_endTime;
       time_t m_firstAired;

--- a/src/iptvsimple/data/EpgEntry.h
+++ b/src/iptvsimple/data/EpgEntry.h
@@ -49,11 +49,17 @@ namespace iptvsimple
       int GetGenreSubType() const { return m_genreSubType; }
       void SetGenreSubType(int value) { m_genreSubType = value; }
 
+      int GetYear() const { return m_year; }
+      void SetYear(int value) { m_year = value; }
+
       time_t GetStartTime() const { return m_startTime; }
       void SetStartTime(time_t value) { m_startTime = value; }
 
       time_t GetEndTime() const { return m_endTime; }
       void SetEndTime(time_t value) { m_endTime = value; }
+
+      time_t GetFirstAired() const { return m_firstAired; }
+      void SetFirstAired(time_t value) { m_firstAired = value; }
 
       const std::string& GetTitle() const { return m_title; }
       void SetTitle(const std::string& value) { m_title = value; }
@@ -93,8 +99,10 @@ namespace iptvsimple
       int m_channelId;
       int m_genreType;
       int m_genreSubType;
+      int m_year;
       time_t m_startTime;
       time_t m_endTime;
+      time_t m_firstAired;
       std::string m_title;
       std::string m_episodeName;
       std::string m_plotOutline;

--- a/src/iptvsimple/data/EpgGenre.cpp
+++ b/src/iptvsimple/data/EpgGenre.cpp
@@ -34,18 +34,31 @@ using namespace rapidxml;
 bool EpgGenre::UpdateFrom(rapidxml::xml_node<>* genreNode)
 {
   std::string buffer;
-  if (!GetAttributeValue(genreNode, "type", buffer))
-    return false;
 
-  if (!StringUtils::IsNaturalNumber(buffer))
-    return false;
+  if (GetAttributeValue(genreNode, "genreId", buffer))
+  {
+    //Combined genre id read as a single hex value.
+    int genreId = std::strtol(buffer.c_str(), nullptr, 16);
 
-  m_genreString = genreNode->value();
-  m_genreType = std::atoi(buffer.c_str());
-  m_genreSubType = 0;
+    m_genreString = genreNode->value();
+    m_genreType = genreId & 0xF0;
+    m_genreSubType = genreId & 0x0F;    
+  }
+  else
+  {
+    if (!GetAttributeValue(genreNode, "type", buffer))
+      return false;
 
-  if (GetAttributeValue(genreNode, "subtype", buffer) && StringUtils::IsNaturalNumber(buffer))
-    m_genreSubType = std::atoi(buffer.c_str());
+    if (!StringUtils::IsNaturalNumber(buffer))
+      return false;
+
+    m_genreString = genreNode->value();
+    m_genreType = std::atoi(buffer.c_str());
+    m_genreSubType = 0;
+
+    if (GetAttributeValue(genreNode, "subtype", buffer) && StringUtils::IsNaturalNumber(buffer))
+      m_genreSubType = std::atoi(buffer.c_str());
+  }
 
   return true;
 }

--- a/src/iptvsimple/utilities/FileUtils.cpp
+++ b/src/iptvsimple/utilities/FileUtils.cpp
@@ -195,6 +195,11 @@ bool FileUtils::FileExists(const std::string& file)
   return XBMC->FileExists(file.c_str(), false);
 }
 
+bool FileUtils::DeleteFile(const std::string& file)
+{
+  return XBMC->DeleteFile(file.c_str());
+}
+
 bool FileUtils::CopyFile(const std::string& sourceFile, const std::string& targetFile)
 {
   bool copySuccessful = true;

--- a/src/iptvsimple/utilities/FileUtils.cpp
+++ b/src/iptvsimple/utilities/FileUtils.cpp
@@ -199,7 +199,7 @@ bool FileUtils::CopyFile(const std::string& sourceFile, const std::string& targe
 {
   bool copySuccessful = true;
 
-  Logger::Log(LEVEL_DEBUG, "%s Copying file: %s, to %s", __FUNCTION__, sourceFile.c_str(), targetFile.c_str());
+  Logger::Log(LEVEL_DEBUG, "%s - Copying file: %s, to %s", __FUNCTION__, sourceFile.c_str(), targetFile.c_str());
 
   void* sourceFileHandle = XBMC->OpenFile(sourceFile.c_str(), 0x08); //READ_NO_CACHE
 
@@ -218,13 +218,13 @@ bool FileUtils::CopyFile(const std::string& sourceFile, const std::string& targe
     }
     else
     {
-      Logger::Log(LEVEL_ERROR, "%s Could not open target file to copy to: %s", __FUNCTION__, targetFile.c_str());
+      Logger::Log(LEVEL_ERROR, "%s - Could not open target file to copy to: %s", __FUNCTION__, targetFile.c_str());
       copySuccessful = false;
     }
   }
   else
   {
-    Logger::Log(LEVEL_ERROR, "%s Could not open source file to copy: %s", __FUNCTION__, sourceFile.c_str());
+    Logger::Log(LEVEL_ERROR, "%s - Could not open source file to copy: %s", __FUNCTION__, sourceFile.c_str());
     copySuccessful = false;
   }
 
@@ -258,7 +258,7 @@ bool FileUtils::CopyDirectory(const std::string& sourceDir, const std::string& t
   }
   else
   {
-    Logger::Log(LEVEL_ERROR, "%s Could not copy directory: %s, to directory: %s", __FUNCTION__, sourceDir.c_str(), targetDir.c_str());
+    Logger::Log(LEVEL_ERROR, "%s - Could not copy directory: %s, to directory: %s", __FUNCTION__, sourceDir.c_str(), targetDir.c_str());
     copySuccessful = false;
   }
   return copySuccessful;

--- a/src/iptvsimple/utilities/FileUtils.cpp
+++ b/src/iptvsimple/utilities/FileUtils.cpp
@@ -33,7 +33,7 @@ using namespace iptvsimple::utilities;
 std::string FileUtils::PathCombine(const std::string& path, const std::string& fileName)
 {
   std::string result = path;
-  
+
   if (!result.empty())
   {
     if (result.at(result.size() - 1) == '\\' ||
@@ -55,12 +55,7 @@ std::string FileUtils::PathCombine(const std::string& path, const std::string& f
   return result;
 }
 
-std::string FileUtils::GetClientFilePath(const std::string& fileName)
-{
-  return PathCombine(Settings::GetInstance().GetClientPath(), fileName);
-}
-
-std::string FileUtils::GetUserFilePath(const std::string& fileName)
+std::string FileUtils::GetUserDataAddonFilePath(const std::string& fileName)
 {
   return PathCombine(Settings::GetInstance().GetUserPath(), fileName);
 }
@@ -157,7 +152,7 @@ int FileUtils::GetCachedFileContents(const std::string& cachedName, const std::s
                                        std::string& contents, const bool useCache /* false */)
 {
   bool needReload = false;
-  const std::string cachedPath = FileUtils::GetUserFilePath(cachedName);
+  const std::string cachedPath = FileUtils::GetUserDataAddonFilePath(cachedName);
 
   // check cached file is exists
   if (useCache && XBMC->FileExists(cachedPath.c_str(), false))

--- a/src/iptvsimple/utilities/FileUtils.h
+++ b/src/iptvsimple/utilities/FileUtils.h
@@ -39,6 +39,14 @@ namespace iptvsimple
       static bool GzipInflate(const std::string& compressedBytes, std::string& uncompressedBytes);
       static int GetCachedFileContents(const std::string& cachedName, const std::string& filePath,
                                        std::string& content, const bool useCache = false);
+      static bool FileExists(const std::string& file);
+      static bool CopyFile(const std::string& sourceFile, const std::string& targetFile);
+      static bool CopyDirectory(const std::string& sourceDir, const std::string& targetDir, bool recursiveCopy);
+      static std::string GetSystemAddonPath();
+      static std::string GetResourceDataPath();
+
+    private:
+      static std::string ReadFileContents(void* fileHandle);
     };
   } // namespace utilities
 } // namespace iptvsimple

--- a/src/iptvsimple/utilities/FileUtils.h
+++ b/src/iptvsimple/utilities/FileUtils.h
@@ -39,6 +39,7 @@ namespace iptvsimple
       static int GetCachedFileContents(const std::string& cachedName, const std::string& filePath,
                                        std::string& content, const bool useCache = false);
       static bool FileExists(const std::string& file);
+      static bool DeleteFile(const std::string& file);
       static bool CopyFile(const std::string& sourceFile, const std::string& targetFile);
       static bool CopyDirectory(const std::string& sourceDir, const std::string& targetDir, bool recursiveCopy);
       static std::string GetSystemAddonPath();

--- a/src/iptvsimple/utilities/FileUtils.h
+++ b/src/iptvsimple/utilities/FileUtils.h
@@ -33,8 +33,7 @@ namespace iptvsimple
     {
     public:
       static std::string PathCombine(const std::string& path, const std::string& fileName);
-      static std::string GetClientFilePath(const std::string& fileName);
-      static std::string GetUserFilePath(const std::string& fileName);
+      static std::string GetUserDataAddonFilePath(const std::string& fileName);
       static int GetFileContents(const std::string& url, std::string& content);
       static bool GzipInflate(const std::string& compressedBytes, std::string& uncompressedBytes);
       static int GetCachedFileContents(const std::string& cachedName, const std::string& filePath,

--- a/src/iptvsimple/utilities/WebUtils.cpp
+++ b/src/iptvsimple/utilities/WebUtils.cpp
@@ -1,0 +1,52 @@
+/*
+ *      Copyright (C) 2005-2019 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "WebUtils.h"
+
+#include <cctype>
+#include <iomanip>
+#include <sstream>
+
+using namespace iptvsimple;
+using namespace iptvsimple::utilities;
+
+// http://stackoverflow.com/a/17708801
+const std::string WebUtils::UrlEncode(const std::string& value)
+{
+  std::ostringstream escaped;
+  escaped.fill('0');
+  escaped << std::hex;
+
+  for (auto c : value)
+  {
+    // Keep alphanumeric and other accepted characters intact
+    if (std::isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~')
+    {
+      escaped << c;
+      continue;
+    }
+
+    // Any other characters are percent-encoded
+    escaped << '%' << std::setw(2) << int(static_cast<unsigned char>(c));
+  }
+
+  return escaped.str();
+}

--- a/src/iptvsimple/utilities/WebUtils.h
+++ b/src/iptvsimple/utilities/WebUtils.h
@@ -1,0 +1,36 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2005-2019 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include <string>
+
+namespace iptvsimple
+{
+  namespace utilities
+  {
+    class WebUtils
+    {
+    public:
+      static const std::string UrlEncode(const std::string& value);
+    };
+  } // namespace utilities
+} // namespace iptvsimple

--- a/src/iptvsimple/utilities/XMLUtils.h
+++ b/src/iptvsimple/utilities/XMLUtils.h
@@ -23,6 +23,7 @@
 
 #include "rapidxml/rapidxml.hpp"
 #include <string>
+#include <vector>
 
 template<class Ch>
 inline std::string GetNodeValue(const rapidxml::xml_node<Ch>* rootNode, const char* tag)
@@ -51,6 +52,21 @@ inline std::string GetJoinedNodeValues(const rapidxml::xml_node<Ch>* rootNode, c
   }
 
   return stringValue;
+}
+
+template<class Ch>
+inline std::vector<std::string> GetNodeValuesList(const rapidxml::xml_node<Ch>* rootNode, const char* tag)
+{
+  std::vector<std::string> stringValues;
+
+  rapidxml::xml_node<Ch>* childNode = nullptr;
+  for(childNode = rootNode->first_node(tag); childNode; childNode = childNode->next_sibling(tag))
+  {
+    if (childNode)
+      stringValues.emplace_back(childNode->value());
+  }
+
+  return stringValues;
 }
 
 template<class Ch>

--- a/src/iptvsimple/utilities/XMLUtils.h
+++ b/src/iptvsimple/utilities/XMLUtils.h
@@ -40,8 +40,7 @@ inline std::string GetJoinedNodeValues(const rapidxml::xml_node<Ch>* rootNode, c
 {
   std::string stringValue;
 
-  rapidxml::xml_node<Ch>* childNode = nullptr;
-  for (childNode = rootNode->first_node(tag); childNode; childNode = childNode->next_sibling(tag))
+  for (rapidxml::xml_node<Ch>* childNode = rootNode->first_node(tag); childNode; childNode = childNode->next_sibling(tag))
   {
     if (childNode)
     {
@@ -59,8 +58,7 @@ inline std::vector<std::string> GetNodeValuesList(const rapidxml::xml_node<Ch>* 
 {
   std::vector<std::string> stringValues;
 
-  rapidxml::xml_node<Ch>* childNode = nullptr;
-  for(childNode = rootNode->first_node(tag); childNode; childNode = childNode->next_sibling(tag))
+  for(rapidxml::xml_node<Ch>* childNode = rootNode->first_node(tag); childNode; childNode = childNode->next_sibling(tag))
   {
     if (childNode)
       stringValues.emplace_back(childNode->value());

--- a/src/iptvsimple/utilities/XMLUtils.h
+++ b/src/iptvsimple/utilities/XMLUtils.h
@@ -35,6 +35,25 @@ inline std::string GetNodeValue(const rapidxml::xml_node<Ch>* rootNode, const ch
 }
 
 template<class Ch>
+inline std::string GetJoinedNodeValues(const rapidxml::xml_node<Ch>* rootNode, const char* tag)
+{
+  std::string stringValue;
+
+  rapidxml::xml_node<Ch>* childNode = nullptr;
+  for (childNode = rootNode->first_node(tag); childNode; childNode = childNode->next_sibling(tag))
+  {
+    if (childNode)
+    {
+      if (!stringValue.empty())
+        stringValue += ",";
+      stringValue += childNode->value();
+    }
+  }
+
+  return stringValue;
+}
+
+template<class Ch>
 inline bool GetAttributeValue(const rapidxml::xml_node<Ch>* node, const char* attributeName, std::string& stringValue)
 {
   rapidxml::xml_attribute<Ch>* attribute = node->first_attribute(attributeName);

--- a/src/iptvsimple/utilities/XMLUtils.h
+++ b/src/iptvsimple/utilities/XMLUtils.h
@@ -58,9 +58,8 @@ inline bool GetAttributeValue(const rapidxml::xml_node<Ch>* node, const char* at
 {
   rapidxml::xml_attribute<Ch>* attribute = node->first_attribute(attributeName);
   if (!attribute)
-  {
     return false;
-  }
+
   stringValue = attribute->value();
   return true;
 }


### PR DESCRIPTION
v4.4.0
- Fixed: Support full timeshift range of -12 to +14 hours
- Fixed: Some providers incorrectly use tvg-ID instead of tvg-id
- Fixed: Support multiple display-names and case insensitive tvg-id is always first, next tvg-name and then channel name find order
- Added: support episode-num for both xmltv_ns and onscreen systems in epg entry
- Added: Update readme for supported M3U and XMLTV formats and genres
- Added: support star rating in epg entry
- Added: support firstAired and year in epg entry
- Added: Update OSX build script
- Added: support multiple actor/director/writers elements in epg entry
- Added: URLEncode and append .png ext for remote logos built from channel name
- Added: Support for mapping by genre hex ID and added example files and settings
- Added: Timing for Playlist and EPG Load
- Added: Option to number channels by M3U order only
- Update: Debug logging
- Added: Channel group member order set to M3U order
- Fixed: Fix segfault for compressed EPG files
- Added: Add ordering for groups as per PVR API 6.1.0
