### PR TITLE
Fix warnings "catching polymorphic type by value" during build

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="4.5.0"
+  version="4.5.1"
   name="PVR IPTV Simple Client"
   provider-name="nightik">
   <requires>@ADDON_DEPENDS@</requires>
@@ -159,6 +159,9 @@
     <disclaimer lang="zh_TW">這是測試中的軟體！原創作者無法針對以下情況負責：包括播放失敗，不正確的電子節目表，多餘的時數，或任何不可預期的不良影響。</disclaimer>
     <platform>@PLATFORM@</platform>
     <news>
+v4.5.1
+- Fix compiler warnings
+
 v4.5.0
 - Fixed: Support full timeshift range of -12 to +14 hours
 - Fixed: Some providers incorrectly use tvg-ID instead of tvg-id

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v4.5.1
+- Fix compiler warnings
+
 v4.5.0
 - Fixed: Support full timeshift range of -12 to +14 hours
 - Fixed: Some providers incorrectly use tvg-ID instead of tvg-id

--- a/src/iptvsimple/Epg.cpp
+++ b/src/iptvsimple/Epg.cpp
@@ -84,7 +84,7 @@ bool Epg::LoadEPG(time_t start, time_t end)
     {
       xmlDoc.parse<0>(buffer);
     }
-    catch (parse_error p)
+    catch (parse_error& p)
     {
       Logger::Log(LEVEL_ERROR, "%s - Unable parse EPG XML: %s", __FUNCTION__, p.what());
       return false;
@@ -430,7 +430,7 @@ bool Epg::LoadGenres()
   {
     xmlDoc.parse<0>(buffer);
   }
-  catch (parse_error p)
+  catch (parse_error& p)
   {
     return false;
   }


### PR DESCRIPTION
This fixes the `warning: catching polymorphic type 'class rapidxml::parse_error' by value` warnings during build.