### PR TITLE
Speed up EPG loading

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="3.8.2"
+  version="3.8.3"
   name="PVR IPTV Simple Client"
   provider-name="nightik">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v3.8.3
+- Speed up EPG loading
+
 v3.8.2
 - Update github wiki link in addon.xml
 

--- a/src/PVRIptvData.cpp
+++ b/src/PVRIptvData.cpp
@@ -419,7 +419,8 @@ bool PVRIptvData::LoadEPG(time_t iStart, time_t iEnd)
     GetNodeValue(pChannelNode, "date", dateString);
     if (!dateString.empty())
     {
-      if (std::regex_match(dateString, std::regex("^[1-9][0-9][0-9][0-9][0-9][1-9][0-9][1-9]")))
+      static const std::regex dateRegex("^[1-9][0-9][0-9][0-9][0-9][1-9][0-9][1-9]");
+      if (std::regex_match(dateString, dateRegex))
         entry.firstAired = static_cast<time_t>(ParseDateTime(dateString));
 
       std::sscanf(dateString.c_str(), "%04d", &entry.iYear);
@@ -534,10 +535,12 @@ bool PVRIptvData::ParseXmltvNsEpisodeNumberInfo(const std::string& episodeNumber
 
 bool PVRIptvData::ParseOnScreenEpisodeNumberInfo(const std::string& episodeNumberString, PVRIptvEpgEntry& entry)
 {
-  const std::string text = std::regex_replace(episodeNumberString, std::regex("[ \\txX_\\.]"), "");
+  static const std::regex numRegex("[ \\txX_\\.]");
+  const std::string text = std::regex_replace(episodeNumberString, numRegex, "");
 
   std::smatch match;
-  if (std::regex_match(text, match, std::regex("^[sS]([0-9][0-9]*)[eE][pP]?([0-9][0-9]*)$")))
+  static const std::regex epRegex("^[sS]([0-9][0-9]*)[eE][pP]?([0-9][0-9]*)$");
+  if (std::regex_match(text, match, epRegex))
   {
     if (match.size() == 3)
     {


### PR DESCRIPTION
With #269 there are two regex which are evaluated on every function call. In my case loading time was increased from 800msec to 10sec. This PR replaces those regex with static ones.
For Leia branch.