### PR TITLE
Speed up EPG loading

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="4.5.1"
+  version="4.5.2"
   name="PVR IPTV Simple Client"
   provider-name="nightik">
   <requires>@ADDON_DEPENDS@</requires>
@@ -159,6 +159,9 @@
     <disclaimer lang="zh_TW">這是測試中的軟體！原創作者無法針對以下情況負責：包括播放失敗，不正確的電子節目表，多餘的時數，或任何不可預期的不良影響。</disclaimer>
     <platform>@PLATFORM@</platform>
     <news>
+v4.5.2
+- Speed up EPG loading
+
 v4.5.1
 - Fix compiler warnings
 

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v4.5.2
+- Speed up EPG loading
+
 v4.5.1
 - Fix compiler warnings
 

--- a/src/iptvsimple/data/EpgEntry.cpp
+++ b/src/iptvsimple/data/EpgEntry.cpp
@@ -213,7 +213,8 @@ bool EpgEntry::UpdateFrom(rapidxml::xml_node<>* channelNode, const std::string& 
   const std::string dateString = GetNodeValue(channelNode, "date");
   if (!dateString.empty())
   {
-    if (std::regex_match(dateString, std::regex("^[1-9][0-9][0-9][0-9][0-9][1-9][0-9][1-9]")))
+    static const std::regex dateRegex("^[1-9][0-9][0-9][0-9][0-9][1-9][0-9][1-9]");
+    if (std::regex_match(dateString, dateRegex))
       m_firstAired = static_cast<time_t>(ParseDateTime(dateString));
 
     std::sscanf(dateString.c_str(), "%04d", &m_year);
@@ -310,10 +311,12 @@ bool EpgEntry::ParseXmltvNsEpisodeNumberInfo(const std::string& episodeNumberStr
 
 bool EpgEntry::ParseOnScreenEpisodeNumberInfo(const std::string& episodeNumberString)
 {
-  const std::string text = std::regex_replace(episodeNumberString, std::regex("[ \\txX_\\.]"), "");
+  static const std::regex numRegex("[ \\txX_\\.]");
+  const std::string text = std::regex_replace(episodeNumberString, numRegex, "");
 
   std::smatch match;
-  if (std::regex_match(text, match, std::regex("^[sS]([0-9][0-9]*)[eE][pP]?([0-9][0-9]*)$")))
+  static const std::regex epRegex("^[sS]([0-9][0-9]*)[eE][pP]?([0-9][0-9]*)$");
+  if (std::regex_match(text, match, epRegex))
   {
     if (match.size() == 3)
     {


### PR DESCRIPTION
With #269 there are two regex which are evaluated on every function call. In my case loading time was increased from 800msec to 10sec. This PR replaces those regex with static ones.