### PR TITLE
Add channel logo extension for relative paths only

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The addon will read all the `<category>` elements of a `programme` and use this 
 * **Genres URL**: If location is `Remote Path` this setting should contain a valid URL.
 
 ### Channel Logos
-Settings realted to Channel Logos.
+Settings related to Channel Logos.
 
 * **Location**: Select where to find the channel logos. The options are:
     - `Local path` - A path to a folder whether it be on the device or the local network.
@@ -110,6 +110,13 @@ Settings realted to Channel Logos.
     - `Ignore` - Don't use channel logos from an XMLTV file.
     - `Prefer M3U` - Use the channel logo from the M3U if available otherwise use the XMLTV logo.
     - `Prefer XMLTV` - Use the channel logo from the XMLTV file if available otherwise use the M3U logo.
+
+### Advanced
+Advanced settings such as multicast relays.
+
+* **Transform multicast stream URLs**: Multicast (UDP/RTP) streams do not work well on Wifi networks. A multicast relay can convert the stream from UDP/RTP multicast to HTTP. Enabling this option will transform multicast stream URLs from the M3U file to HTTP addresses so they can be accesssed via a 'udpxy' relay on the local network. E.g. a UDP multicast stream URL like `udp://@239.239.3.38:5239` would get transformed to something like `http://192.168.1.1:4000/udp/239.239.3.38:5239`.
+* **Relay hostname or IP address**: The hostname or ip address of the multicast relay (`udpxy`) on the local network.
+* **Relay port**: The port of the multicast relay (`udpxy`) on the local network..
 
 ## Appendix
 

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ http://path-to-stream/live/channel-z.ts
   - `tvg-name`: A name for this channel in the EPG XMLTV data.
   - `group-title`: A semi-colon separted list of channel groups that this channel belongs to.
   - `tvg-chno`: The number to be used for this channel.
-  - `tvg-logo`: A URL pointing to the logo for this channel.
+  - `tvg-logo`: A URL pointing to the logo for this channel. For relative URLs `.png` will be appended if not provided, absolute URLs will not be modified.
   - `radio`: If the value matches "true" (case insensitive) this is a radio channel.
   - `tvg-shift`: Channel specific shift value in hours.
 - `#EXTGRP`: A semi-colon separted list of channel groups that this channel belongs to.

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ http://path-to-stream/live/channel-z.ts
 - `#KODIPROP`: A single property in the format `key=value` that can be passed to Kodi. Multiple can be passed.
 - `#EXTVLCOPT`: A single property in the format `key=value` that can be passed to Kodi. Multiple can be passed.
 - `#EXT-X-PLAYLIST-TYPE`: If this element is present with a value of `VOD` (Video on Demand) the stream is marked as not being live.
-- `URL`: The final line in each channel stanza is the URL used for the stream. Appending `|User-Agent=<agent-name>` will change the user agent.
+- `URL`: The final line in each channel stanza is the URL used for the stream. Appending `|User-Agent=<agent-name>` will change the user agent. Other HTTP header fields can be set in the same fashion: `|name1=val1&name2=val2` etc. The header fields supported in this way by Kodi can be found [here](#http-header-fields-supported-by-kodi).
 
 When processing an XMLTV file the addon will attempt to find a channel loaded from the M3U that matches the EPG channel. It will cycle through the full set of M3U channels checking for one condition on each pass. The first channel found to match is the channel chosen for this EPG channel data.
 
@@ -296,6 +296,18 @@ The `programme` element supports the attributes `start`/`stop` in the format `YY
   - For `episode-num` elements using the `onscreen` system only the `S01E02` format is supported.
 - `credits`: Only director, writer and actor are supported (multiple of each can be supplied).
 - `icon`: If multiple elements are provided only the first will be used.
+
+### HTTP header fields supported by Kodi
+
+HTTP header fields can be sent by appending the following format to the URL: `|name1=val1&name2=val2`. Note that kodi does not support sending not standard header fields.
+
+**Special fields**
+
+`cookie, cookies, seekable, user-agent`
+
+**Standard fields**
+
+`accept, accept-language, accept-datetime, authorization, cache-control, connection, content-md5, date, expect, forwarded, from, if-match, if-modified-since, if-none-match, if-range, if-unmodified-since, max-forwards, origin, pragma, range, referer, te, upgrade, via, warning, x-requested-with, dnt, x-forwarded-for, x-forwarded-host, x-forwarded-proto, front-end-https, x-http-method-override, x-att-deviceid, x-wap-profile, x-uidh, x-csrf-token, x-request-id, x-correlation-id`
 
 ### Manual Steps to rebuild the addon on MacOSX
 

--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="4.6.2"
+  version="4.7.0"
   name="PVR IPTV Simple Client"
   provider-name="nightik">
   <requires>@ADDON_DEPENDS@</requires>
@@ -159,8 +159,11 @@
     <disclaimer lang="zh_TW">這是測試中的軟體！原創作者無法針對以下情況負責：包括播放失敗，不正確的電子節目表，多餘的時數，或任何不可預期的不良影響。</disclaimer>
     <platform>@PLATFORM@</platform>
     <news>
-v4.6.2
+v4.7.0
 - Fixed: Add channel logo extension for relative paths only
+- Fixed: Logger fix ported from pvr.hts
+- Update: Update readme
+- Added: Transform UDP/RTP multicast stream URLs to local udpxy URLs
 
 v4.6.1
 - Fixed: Fix channel logos getting default extension

--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="4.6.1"
+  version="4.6.2"
   name="PVR IPTV Simple Client"
   provider-name="nightik">
   <requires>@ADDON_DEPENDS@</requires>
@@ -159,6 +159,9 @@
     <disclaimer lang="zh_TW">這是測試中的軟體！原創作者無法針對以下情況負責：包括播放失敗，不正確的電子節目表，多餘的時數，或任何不可預期的不良影響。</disclaimer>
     <platform>@PLATFORM@</platform>
     <news>
+v4.6.2
+- Fixed: Add channel logo extension for relative paths only
+
 v4.6.1
 - Fixed: Fix channel logos getting default extension
 

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,5 +1,8 @@
-v4.6.2
+v4.7.0
 - Fixed: Add channel logo extension for relative paths only
+- Fixed: Logger fix ported from pvr.hts
+- Update: update readme
+- Added: Transform UDP/RTP multicast stream URLs to local udpxy URLs
 
 v4.6.1
 - Fixed: Fix channel logos getting default extension

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v4.6.2
+- Fixed: Add channel logo extension for relative paths only
+
 v4.6.1
 - Fixed: Fix channel logos getting default extension
 

--- a/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
@@ -214,7 +214,34 @@ msgctxt "#30053"
 msgid "Genres URL"
 msgstr ""
 
-#empty strings from id 30054 to 30599
+#empty strings from id 30054 to 30559
+
+#label-category: advanced
+msgctxt "#30060"
+msgid "Advanced"
+msgstr ""
+
+#label-group: Advanced - Multicast relay
+msgctxt "#30061"
+msgid "Multicast relay (udpxy)"
+msgstr ""
+
+#label: Advanced - transformMulticastStreamUrls
+msgctxt "#30062"
+msgid "Transform multicast stream URLs"
+msgstr ""
+
+#label: Advanced - udpxyHost
+msgctxt "#30063"
+msgid "Relay hostname or IP address"
+msgstr ""
+
+#label: Advanced - udpxyPort
+msgctxt "#30064"
+msgid "Relay port"
+msgstr ""
+
+#empty strings from id 30065 to 30599
 
 #############
 # help info #
@@ -367,4 +394,28 @@ msgstr ""
 #help: Genres - genresUrl
 msgctxt "#30664"
 msgid "If location is [Remote Path] this setting should contain a valid URL."
+msgstr ""
+
+#empty strings from id 30665 to 30679
+
+#help info - Advanced
+
+#help-category: Advanced
+msgctxt "#30680"
+msgid "Advanced settings including multicast relays etc."
+msgstr ""
+
+#help: Advanced - transformMulticastStreamUrls
+msgctxt "#30681"
+msgid "Multicast (UDP/RTP) streams do not work well on Wifi networks. A multicast relay can convert the stream from UDP/RTP multicast to HTTP. Enabling this option will transform multicast stream URLs from the M3U file to HTTP addresses so they can be accesssed via a 'udpxy' relay on the local network. E.g. a UDP multicast stream URL like 'udp://@239.239.3.38:5239' would get transformed to something like 'http://192.168.1.1:4000/udp/239.239.3.38:5239'."
+msgstr ""
+
+#help: Advanced - udpxyHost
+msgctxt "#30682"
+msgid "The hostname or ip address of the multicast relay (udpxy) on the local network."
+msgstr ""
+
+#help: Advanced - udpxyPort
+msgctxt "#30683"
+msgid "The port of the multicast relay (udpxy) on the local network."
 msgstr ""

--- a/pvr.iptvsimple/resources/settings.xml
+++ b/pvr.iptvsimple/resources/settings.xml
@@ -276,5 +276,37 @@
       </group>
     </category>
 
+    <!-- Advanced -->
+    <category id="advanced" label="30060" help="30680">
+      <group id="1" label="30061">
+        <setting id="transformMulticastStreamUrls" type="boolean" label="30062" help="30681">
+          <level>2</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="udpxyHost" type="string" parent="transformMulticastStreamUrls" label="30063" help="30682">
+          <level>2</level>
+          <default>127.0.0.1</default>
+          <dependencies>
+            <dependency type="visible" setting="transformMulticastStreamUrls" operator="is">true</dependency>
+          </dependencies>
+          <control type="edit" format="string" />
+        </setting>
+        <setting id="udpxyPort" type="integer" parent="transformMulticastStreamUrls" label="30064" help="30683">
+          <level>2</level>
+          <default>4022</default>
+          <constraints>
+            <minimum>1</minimum>
+            <step>1</step>
+            <maximum>65535</maximum>
+          </constraints>
+          <dependencies>
+            <dependency type="visible" setting="transformMulticastStreamUrls" operator="is">true</dependency>
+          </dependencies>
+          <control type="edit" format="integer" />
+        </setting>
+      </group>
+    </category>
+
   </section>
 </settings>

--- a/src/iptvsimple/Settings.cpp
+++ b/src/iptvsimple/Settings.cpp
@@ -92,6 +92,14 @@ void Settings::ReadFromAddon(const std::string& userPath, const std::string clie
     m_logoBaseUrl = buffer;
   if (!XBMC->GetSetting("logoFromEpg", &m_epgLogosMode))
     m_epgLogosMode = EpgLogosMode::IGNORE_XMLTV;
+
+  // Advanced
+  if (!XBMC->GetSetting("transformMulticastStreamUrls", &m_transformMulticastStreamUrls))
+    m_transformMulticastStreamUrls = false;
+  if (XBMC->GetSetting("udpxyHost", &buffer))
+    m_udpxyHost = buffer;
+  if (!XBMC->GetSetting("udpxyPort", &m_udpxyPort))
+    m_udpxyPort = DEFAULT_UDPXY_MULTICAST_RELAY_PORT;
 }
 
 ADDON_STATUS Settings::SetValue(const std::string& settingName, const void* settingValue)
@@ -159,6 +167,14 @@ ADDON_STATUS Settings::SetValue(const std::string& settingName, const void* sett
     return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_logoBaseUrl, ADDON_STATUS_OK, ADDON_STATUS_OK);
   if (settingName == "logoFromEpg")
     return SetSetting<EpgLogosMode, ADDON_STATUS>(settingName, settingValue, m_epgLogosMode, ADDON_STATUS_OK, ADDON_STATUS_OK);
+
+  // Advanced
+  if (settingName == "transformMulticastStreamUrls")
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_transformMulticastStreamUrls, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  if (settingName == "udpxyHost")
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_udpxyHost, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  if (settingName == "udpxyPort")
+    return SetSetting<int, ADDON_STATUS>(settingName, settingValue, m_udpxyPort, ADDON_STATUS_OK, ADDON_STATUS_OK);
 
   return ADDON_STATUS_OK;
 }

--- a/src/iptvsimple/Settings.h
+++ b/src/iptvsimple/Settings.h
@@ -34,6 +34,7 @@ namespace iptvsimple
   static const std::string XMLTV_CACHE_FILENAME = "xmltv.xml.cache";
   static const std::string ADDON_DATA_BASE_DIR = "special://userdata/addon_data/pvr.iptvsimple";
   static const std::string DEFAULT_GENRE_TEXT_MAP_FILE = ADDON_DATA_BASE_DIR + "/genres/genreTextMappings/genres.xml";
+  static const int DEFAULT_UDPXY_MULTICAST_RELAY_PORT = 4022;
 
   enum class PathType
     : int // same type as addon settings
@@ -108,6 +109,10 @@ namespace iptvsimple
     const std::string& GetLogoBaseUrl() const { return m_logoBaseUrl; }
     const EpgLogosMode& GetEpgLogosMode() const { return m_epgLogosMode; }
 
+    bool TransformMulticastStreamUrls() const { return m_transformMulticastStreamUrls; }
+    const std::string& GetUdpxyHost() const { return m_udpxyHost; }
+    int GetUdpxyPort() const { return m_udpxyPort; }
+
   private:
     Settings() = default;
 
@@ -175,5 +180,9 @@ namespace iptvsimple
     std::string m_logoPath;
     std::string m_logoBaseUrl;
     EpgLogosMode m_epgLogosMode = EpgLogosMode::IGNORE_XMLTV;
+
+    bool m_transformMulticastStreamUrls = false;
+    std::string m_udpxyHost;
+    int m_udpxyPort = DEFAULT_UDPXY_MULTICAST_RELAY_PORT;
   };
 } //namespace iptvsimple

--- a/src/iptvsimple/data/Channel.cpp
+++ b/src/iptvsimple/data/Channel.cpp
@@ -96,11 +96,11 @@ void Channel::SetIconPathFromTvgLogo(const std::string& tvgLogo, std::string& ch
     const std::string& logoLocation = Settings::GetInstance().GetLogoLocation();
     if (!logoLocation.empty())
     {
-      // not absolute path
+      // not absolute path, only append .png in this case.
       m_iconPath = utilities::FileUtils::PathCombine(logoLocation, m_iconPath);
+
+      if (!StringUtils::EndsWithNoCase(m_iconPath, ".png"))
+        m_iconPath += CHANNEL_LOGO_EXTENSION;
     }
   }    
-
-  if (!StringUtils::EndsWithNoCase(m_iconPath, ".png"))
-    m_iconPath += CHANNEL_LOGO_EXTENSION;
 }

--- a/src/iptvsimple/data/Channel.h
+++ b/src/iptvsimple/data/Channel.h
@@ -31,6 +31,8 @@ namespace iptvsimple
   namespace data
   {
     static const std::string CHANNEL_LOGO_EXTENSION  = ".png";
+    static const std::string UDP_MULTICAST_PREFIX = "udp://@";
+    static const std::string RTP_MULTICAST_PREFIX = "rtp://@";
 
     class Channel
     {
@@ -65,7 +67,7 @@ namespace iptvsimple
       void SetIconPath(const std::string& value) { m_iconPath = value; }
 
       const std::string& GetStreamURL() const { return m_streamURL; }
-      void SetStreamURL(const std::string& value) { m_streamURL = value; }
+      void SetStreamURL(const std::string& url);
 
       const std::string& GetTvgId() const { return m_tvgId; }
       void SetTvgId(const std::string& value) { m_tvgId = value; }

--- a/src/iptvsimple/utilities/Logger.cpp
+++ b/src/iptvsimple/utilities/Logger.cpp
@@ -23,6 +23,8 @@
 
 #include <cstdarg>
 
+#include <p8-platform/util/StringUtils.h>
+
 using namespace iptvsimple::utilities;
 
 Logger::Logger()
@@ -43,20 +45,21 @@ void Logger::Log(LogLevel level, const char* message, ...)
 {
   auto& logger = GetInstance();
 
-  char buffer[MESSAGE_BUFFER_SIZE];
-  std::string logMessage = message;
-  const std::string prefix = logger.m_prefix;
+  std::string logMessage;
 
   // Prepend the prefix when set
+  const std::string prefix = logger.m_prefix;
   if (!prefix.empty())
-    logMessage = prefix + " - " + message;
+    logMessage = prefix + " - ";
+
+  logMessage += message;
 
   va_list arguments;
   va_start(arguments, message);
-  vsprintf(buffer, logMessage.c_str(), arguments);
+  logMessage = StringUtils::FormatV(logMessage.c_str(), arguments);
   va_end(arguments);
 
-  logger.m_implementation(level, buffer);
+  logger.m_implementation(level, logMessage.c_str());
 }
 
 void Logger::SetImplementation(LoggerImplementation implementation)

--- a/src/iptvsimple/utilities/Logger.h
+++ b/src/iptvsimple/utilities/Logger.h
@@ -80,8 +80,6 @@ namespace iptvsimple
       void SetPrefix(const std::string& prefix);
 
     private:
-      static const unsigned int MESSAGE_BUFFER_SIZE = 16384;
-
       Logger();
 
       /**


### PR DESCRIPTION
v4.7.0
- Fixed: Add channel logo extension for relative paths only
- Fixed: Logger fix ported from pvr.hts
- Update: Update readme
- Added: Transform UDP/RTP multicast stream URLs to local udpxy URLs