### PR TITLE
tvg-id does not match a channel if no display-names in xmltv

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="3.8.5"
+  version="3.8.6"
   name="PVR IPTV Simple Client"
   provider-name="nightik">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,7 @@
+v3.8.6
+- Fixed: tvg-id does not match a channel if no display-names in xmltv
+- Fixed: Combine multiple XMLTV channels sharing same id
+
 v3.8.5
 - Fixed: Add channel logo extension for relative paths only
 - Update: update readme

--- a/src/PVRIptvData.cpp
+++ b/src/PVRIptvData.cpp
@@ -351,6 +351,18 @@ bool PVRIptvData::LoadEPG(time_t iStart, time_t iEnd)
     if (pIconNode == NULL || !GetAttributeValue(pIconNode, "src", epgChannel.strIcon))
       epgChannel.strIcon = "";
 
+    PVRIptvEpgChannel* existingEpgChannel = FindEpgForChannel(epgChannel.strId);
+    if (existingEpgChannel)
+    {
+      for (const std::string& displayName : epgChannel.strNames)
+        existingEpgChannel->strNames.emplace_back(displayName);
+
+      if (existingEpgChannel->strIcon.empty() && !epgChannel.strIcon.empty())
+        existingEpgChannel->strIcon = epgChannel.strIcon;
+
+      continue;
+    }
+
     m_epg.push_back(epgChannel);
   }
 
@@ -1155,6 +1167,17 @@ PVRIptvEpgChannel * PVRIptvData::FindEpg(const std::string &strId)
   }
 
   return NULL;
+}
+
+PVRIptvEpgChannel* PVRIptvData::FindEpgForChannel(const std::string& id)
+{
+  for (auto& epgChannel : m_epg)
+  {
+    if (StringUtils::EqualsNoCase(epgChannel.strId, id))
+      return &epgChannel;
+  }
+
+  return nullptr;
 }
 
 PVRIptvEpgChannel * PVRIptvData::FindEpgForChannel(PVRIptvChannel &channel)

--- a/src/PVRIptvData.cpp
+++ b/src/PVRIptvData.cpp
@@ -326,8 +326,11 @@ bool PVRIptvData::LoadEPG(time_t iStart, time_t iEnd)
       continue;
 
     bool foundChannel = false;
+    bool haveDisplayNames = false;
     for (xml_node<>* pDisplayNameNode = pChannelNode->first_node("display-name"); pDisplayNameNode; pDisplayNameNode = pDisplayNameNode->next_sibling("display-name"))
     {
+      haveDisplayNames = true;
+
       const std::string strName = pDisplayNameNode->value();
       if (FindChannel(epgChannel.strId, strName))
       {
@@ -335,6 +338,10 @@ bool PVRIptvData::LoadEPG(time_t iStart, time_t iEnd)
         epgChannel.strNames.emplace_back(strName);
       }
     }
+
+    // If there are no display names just check if the id matches a channel
+    if (!haveDisplayNames && FindChannel(epgChannel.strId, ""))
+      foundChannel = true;
 
     if (!foundChannel)
       continue;

--- a/src/PVRIptvData.h
+++ b/src/PVRIptvData.h
@@ -118,6 +118,7 @@ protected:
   virtual PVRIptvChannel*      FindChannel(const std::string &strId, const std::string &strName);
   virtual PVRIptvChannelGroup* FindGroup(const std::string &strName);
   virtual PVRIptvEpgChannel*   FindEpg(const std::string &strId);
+  PVRIptvEpgChannel* FindEpgForChannel(const std::string& id);
   virtual PVRIptvEpgChannel*   FindEpgForChannel(PVRIptvChannel &channel);
   virtual bool                 FindEpgGenre(const std::string& strGenre, int& iType, int& iSubType);
   virtual bool                 GzipInflate( const std::string &compressedBytes, std::string &uncompressedBytes);


### PR DESCRIPTION
v3.8.6
- Fixed: tvg-id does not match a channel if no display-names in xmltv
- Fixed: Combine multiple XMLTV channels sharing same id
