### PR TITLE
Inputstream ffmpeg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ set(IPTV_SOURCES src/client.cpp
                  src/iptvsimple/data/EpgGenre.cpp
                  src/iptvsimple/utilities/FileUtils.cpp
                  src/iptvsimple/utilities/Logger.cpp
+                 src/iptvsimple/utilities/StreamUtils.cpp
                  src/iptvsimple/utilities/WebUtils.cpp)
 
 set(IPTV_HEADERS src/client.h
@@ -50,6 +51,7 @@ set(IPTV_HEADERS src/client.h
                  src/iptvsimple/data/EpgGenre.h
                  src/iptvsimple/utilities/FileUtils.h
                  src/iptvsimple/utilities/Logger.h
+                 src/iptvsimple/utilities/StreamUtils.h
                  src/iptvsimple/utilities/WebUtils.h
                  src/iptvsimple/utilities/XMLUtils.h)
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Note: Once mapped to genre IDs the text displayed can either be the DVB standard
 #### M3U format elemnents:
 
 ```
-#EXTM3U tvg-shift="-4.5"
+#EXTM3U tvg-shift="-4.5" x-tvg-url="http://path-to-xmltv/guide.xml"
 #EXTINF:0 tvg-id="channel-x" tvg-name="Channel_X" group-title="Entertainment" tvg-chno="10" tvg-logo="http://path-to-icons/channel-x.png" radio="true" tvg-shift="-3.5",Channel X
 #EXTVLCOPT:program=745
 #KODIPROP:key=val
@@ -230,7 +230,9 @@ http://path-to-stream/live/channel-y.ts
 http://path-to-stream/live/channel-z.ts
 ```
 
-- `#EXTM3U`: Marker for the start of an M3U file. Has an optional `tvg-shift` value that will be used for all channels if a `tvg-shift` value is not supplied per channel.
+- `#EXTM3U`: Marker for the start of an M3U file.
+  - `tvg-shift`: Value that will be used for all channels if a `tvg-shift` value is not supplied per channel.
+  - `x-tvg-url`: URL for the XMLTV data. Only used if the addon settings do not contain an EPG location for XMLTV data.
 - `#EXTINF`: Contains a set of values, ending with a comma followed by the `channel name`.
   - `tvg-id`: A unique identifier for this channel used to map to the EPG XMLTV data.
   - `tvg-name`: A name for this channel in the EPG XMLTV data.

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Advanced settings such as multicast relays.
 * **Transform multicast stream URLs**: Multicast (UDP/RTP) streams do not work well on Wifi networks. A multicast relay can convert the stream from UDP/RTP multicast to HTTP. Enabling this option will transform multicast stream URLs from the M3U file to HTTP addresses so they can be accesssed via a 'udpxy' relay on the local network. E.g. a UDP multicast stream URL like `udp://@239.239.3.38:5239` would get transformed to something like `http://192.168.1.1:4000/udp/239.239.3.38:5239`.
 * **Relay hostname or IP address**: The hostname or ip address of the multicast relay (`udpxy`) on the local network.
 * **Relay port**: The port of the multicast relay (`udpxy`) on the local network.
+* **Use FFMpeg http reconnect options if possible**: Note this can only apply to http/https streams that are processed by libavformat (M3u8/HLS steram will use this by default). Using libavformat can be specified in an M3U file by setting the property `inputstreamclass` to `inputstream.ffmpeg`. I.e. adding the line: `#KODIPROP:inputstreamclass=inputstream.ffmpeg`.
 * **Use inputstream.adaptive for m3u8 (HLS) streams**: Use inputstream.adaptive instead of ffmpeg's libavformat for m3u8 (HLS) streams.
 
 ## Appendix

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ http://path-to-stream/live/channel-z.ts
 - `#KODIPROP`: A single property in the format `key=value` that can be passed to Kodi. Multiple can be passed each on a separate line.
 - `#EXTVLCOPT`: A single property in the format `key=value` that can be passed to Kodi. Multiple can be passed each on a separate line. Note that if either a `http-user-agent` or a `http-referrer` property is found it will added to the URL as a HTTP header as `user-agent` or `referrer` respectively if not already provided in the URL. These two fields specifically will be dropped as properties whether or not they are added as header values. They will be added in the same format as the `URL` below.
 - `#EXT-X-PLAYLIST-TYPE`: If this element is present with a value of `VOD` (Video on Demand) the stream is marked as not being live.
-- `URL`: The final line in each channel stanza is the URL used for the stream. Appending `|user-agent=<agent-name>` will change the user agent. Other HTTP header fields can be set in the same fashion: `|name1=val1&name2=val2` etc. The header fields supported in this way by Kodi can be found [here](#http-header-fields-supported-by-kodi).
+- `URL`: The final line in each channel stanza is the URL used for the stream. Appending `|user-agent=<agent-name>` will change the user agent. Other HTTP header fields can be set in the same fashion: `|name1=val1&name2=val2` etc. The header fields supported in this way by Kodi can be found [here](#http-header-fields-supported-by-kodi). If you want to pass custom headers that are not supported by kodi you need to prefix them with an `!`, for example: : `|!name1=val1&!name2=val2`. 
 
 When processing an XMLTV file the addon will attempt to find a channel loaded from the M3U that matches the EPG channel. It will cycle through the full set of M3U channels checking for one condition on each pass. The first channel found to match is the channel chosen for this EPG channel data.
 
@@ -317,6 +317,10 @@ HTTP header fields can be sent by appending the following format to the URL: `|n
 **Standard fields**
 
 `accept, accept-language, accept-datetime, authorization, cache-control, connection, content-md5, date, expect, forwarded, from, if-match, if-modified-since, if-none-match, if-range, if-unmodified-since, max-forwards, origin, pragma, range, referer, te, upgrade, via, warning, x-requested-with, dnt, x-forwarded-for, x-forwarded-host, x-forwarded-proto, front-end-https, x-http-method-override, x-att-deviceid, x-wap-profile, x-uidh, x-csrf-token, x-request-id, x-correlation-id`
+
+**Other fields supported by ffmpeg**
+
+`reconnect_at_eof, reconnect_streamed, reconnect_delay_max, icy, icy_metadata_headers, icy_metadata_packet`
 
 ### Manual Steps to rebuild the addon on MacOSX
 

--- a/README.md
+++ b/README.md
@@ -240,10 +240,10 @@ http://path-to-stream/live/channel-z.ts
   - `radio`: If the value matches "true" (case insensitive) this is a radio channel.
   - `tvg-shift`: Channel specific shift value in hours.
 - `#EXTGRP`: A semi-colon separted list of channel groups that this channel belongs to.
-- `#KODIPROP`: A single property in the format `key=value` that can be passed to Kodi. Multiple can be passed.
-- `#EXTVLCOPT`: A single property in the format `key=value` that can be passed to Kodi. Multiple can be passed.
+- `#KODIPROP`: A single property in the format `key=value` that can be passed to Kodi. Multiple can be passed each on a separate line.
+- `#EXTVLCOPT`: A single property in the format `key=value` that can be passed to Kodi. Multiple can be passed each on a separate line. Note that if either a `http-user-agent` or a `http-referrer` property is found it will added to the URL as a HTTP header as `user-agent` or `referrer` respectively if not already provided in the URL. These two fields specifically will be dropped as properties whether or not they are added as header values. They will be added in the same format as the `URL` below.
 - `#EXT-X-PLAYLIST-TYPE`: If this element is present with a value of `VOD` (Video on Demand) the stream is marked as not being live.
-- `URL`: The final line in each channel stanza is the URL used for the stream. Appending `|User-Agent=<agent-name>` will change the user agent. Other HTTP header fields can be set in the same fashion: `|name1=val1&name2=val2` etc. The header fields supported in this way by Kodi can be found [here](#http-header-fields-supported-by-kodi).
+- `URL`: The final line in each channel stanza is the URL used for the stream. Appending `|user-agent=<agent-name>` will change the user agent. Other HTTP header fields can be set in the same fashion: `|name1=val1&name2=val2` etc. The header fields supported in this way by Kodi can be found [here](#http-header-fields-supported-by-kodi).
 
 When processing an XMLTV file the addon will attempt to find a channel loaded from the M3U that matches the EPG channel. It will cycle through the full set of M3U channels checking for one condition on each pass. The first channel found to match is the channel chosen for this EPG channel data.
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ Advanced settings such as multicast relays.
 
 * **Transform multicast stream URLs**: Multicast (UDP/RTP) streams do not work well on Wifi networks. A multicast relay can convert the stream from UDP/RTP multicast to HTTP. Enabling this option will transform multicast stream URLs from the M3U file to HTTP addresses so they can be accesssed via a 'udpxy' relay on the local network. E.g. a UDP multicast stream URL like `udp://@239.239.3.38:5239` would get transformed to something like `http://192.168.1.1:4000/udp/239.239.3.38:5239`.
 * **Relay hostname or IP address**: The hostname or ip address of the multicast relay (`udpxy`) on the local network.
-* **Relay port**: The port of the multicast relay (`udpxy`) on the local network..
+* **Relay port**: The port of the multicast relay (`udpxy`) on the local network.
+* **Use inputstream.adaptive for m3u8 (HLS) streams**: Use inputstream.adaptive instead of ffmpeg's libavformat for m3u8 (HLS) streams.
 
 ## Appendix
 
@@ -245,7 +246,7 @@ http://path-to-stream/live/channel-z.ts
 - `#KODIPROP`: A single property in the format `key=value` that can be passed to Kodi. Multiple can be passed each on a separate line.
 - `#EXTVLCOPT`: A single property in the format `key=value` that can be passed to Kodi. Multiple can be passed each on a separate line. Note that if either a `http-user-agent` or a `http-referrer` property is found it will added to the URL as a HTTP header as `user-agent` or `referrer` respectively if not already provided in the URL. These two fields specifically will be dropped as properties whether or not they are added as header values. They will be added in the same format as the `URL` below.
 - `#EXT-X-PLAYLIST-TYPE`: If this element is present with a value of `VOD` (Video on Demand) the stream is marked as not being live.
-- `URL`: The final line in each channel stanza is the URL used for the stream. Appending `|user-agent=<agent-name>` will change the user agent. Other HTTP header fields can be set in the same fashion: `|name1=val1&name2=val2` etc. The header fields supported in this way by Kodi can be found [here](#http-header-fields-supported-by-kodi). If you want to pass custom headers that are not supported by kodi you need to prefix them with an `!`, for example: : `|!name1=val1&!name2=val2`. 
+- `URL`: The final line in each channel stanza is the URL used for the stream. Appending `|user-agent=<agent-name>` will change the user agent. Other HTTP header fields can be set in the same fashion: `|name1=val1&name2=val2` etc. The header fields supported in this way by Kodi can be found [here](#http-header-fields-supported-by-kodi). If you want to pass custom headers that are not supported by kodi you need to prefix them with an `!`, for example: : `|!name1=val1&!name2=val2`.
 
 When processing an XMLTV file the addon will attempt to find a channel loaded from the M3U that matches the EPG channel. It will cycle through the full set of M3U channels checking for one condition on each pass. The first channel found to match is the channel chosen for this EPG channel data.
 

--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="4.7.1"
+  version="4.8.0"
   name="PVR IPTV Simple Client"
   provider-name="nightik">
   <requires>@ADDON_DEPENDS@</requires>
@@ -159,6 +159,19 @@
     <disclaimer lang="zh_TW">這是測試中的軟體！原創作者無法針對以下情況負責：包括播放失敗，不正確的電子節目表，多餘的時數，或任何不可預期的不良影響。</disclaimer>
     <platform>@PLATFORM@</platform>
     <news>
+v4.8.0
+- Added: Allow use of inputstream ffmpeg for m3u8 files missing correct extension
+- Added: Support for x-tvg-url in playlist header for XMLTV data
+- Added: Add EXTVLCOPT properties for headers
+- Fixed: Fix RTP multicast stream prefix
+- Added: Add support for Dash and Smooth streaming via inputstream.adaptive
+- Added: Add option to use inputsream.adaptive for m3u8/hls streams
+- Added: Support FFmpeg reconnect for http streams using inputstream ffmpeg
+- Fixed: Limit allowed EXTVLCOPT properties to known set
+- Fixed: Add extra stream properties as lower case only
+- Fixed: Support inputstreamaddon for overriding inputstream
+- Update: Readme
+
 v4.7.1
 - Update: Switch from rapixml to pugixml
 - Fixed: tvg-id does not match a channel if no display-names in xmltv

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,16 @@
+v4.8.0
+- Added: Allow use of inputstream ffmpeg for m3u8 files missing correct extension
+- Added: Support for x-tvg-url in playlist header for XMLTV data
+- Added: Add EXTVLCOPT properties for headers
+- Fixed: Fix RTP multicast stream prefix
+- Added: Add support for Dash and Smooth streaming via inputstream.adaptive
+- Added: Add option to use inputsream.adaptive for m3u8/hls streams
+- Added: Support FFmpeg reconnect for http streams using inputstream ffmpeg
+- Fixed: Limit allowed EXTVLCOPT properties to known set
+- Fixed: Add extra stream properties as lower case only
+- Fixed: Support inputstreamaddon for overriding inputstream
+- Update: Readme
+
 v4.7.1
 - Update: Switch from rapixml to pugixml
 - Fixed: tvg-id does not match a channel if no display-names in xmltv

--- a/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
@@ -241,7 +241,17 @@ msgctxt "#30064"
 msgid "Relay port"
 msgstr ""
 
-#empty strings from id 30065 to 30599
+#label-group: Advanced - Streaming
+msgctxt "#30065"
+msgid "Streaming"
+msgstr ""
+
+#label: Advanced - useInputstreamAdaptiveforHls
+msgctxt "#30066"
+msgid "Use inputstream.adaptive for m3u8 (HLS) streams"
+msgstr ""
+
+#empty strings from id 30067 to 30599
 
 #############
 # help info #
@@ -418,4 +428,9 @@ msgstr ""
 #help: Advanced - udpxyPort
 msgctxt "#30683"
 msgid "The port of the multicast relay (udpxy) on the local network."
+msgstr ""
+
+#help: Advanced - useInputstreamAdaptiveforHls
+msgctxt "#30684"
+msgid "Use inputstream.adaptive instead of ffmpeg's libavformat for m3u8 (HLS) streams."
 msgstr ""

--- a/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
@@ -251,7 +251,12 @@ msgctxt "#30066"
 msgid "Use inputstream.adaptive for m3u8 (HLS) streams"
 msgstr ""
 
-#empty strings from id 30067 to 30599
+#label: Advanced - useFFmpegReconnect
+msgctxt "#30067"
+msgid "Use FFMpeg http reconnect options if possible"
+msgstr ""
+
+#empty strings from id 30068 to 30599
 
 #############
 # help info #
@@ -412,7 +417,7 @@ msgstr ""
 
 #help-category: Advanced
 msgctxt "#30680"
-msgid "Advanced settings including multicast relays etc."
+msgid "Advanced settings including multicast relays, streaming properties etc."
 msgstr ""
 
 #help: Advanced - transformMulticastStreamUrls
@@ -433,4 +438,9 @@ msgstr ""
 #help: Advanced - useInputstreamAdaptiveforHls
 msgctxt "#30684"
 msgid "Use inputstream.adaptive instead of ffmpeg's libavformat for m3u8 (HLS) streams."
+msgstr ""
+
+#help: Advanced - useFFmpegReconnect
+msgctxt "#30685"
+msgid "Note this can only apply to http/https streams that are processed by libavformat (M3u8/HLS steram will use this by default). Using libavformat can be specified in an M3U file by setting the property `inputstreamclass` to `inputstream.ffmpeg`. I.e. adding the line: `#KODIPROP:inputstreamclass=inputstream.ffmpeg`."
 msgstr ""

--- a/pvr.iptvsimple/resources/settings.xml
+++ b/pvr.iptvsimple/resources/settings.xml
@@ -307,6 +307,11 @@
         </setting>
       </group>
       <group id="2" label="30065">
+        <setting id="useFFmpegReconnect" type="boolean" label="30067" help="30685">
+          <level>2</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
         <setting id="useInputstreamAdaptiveforHls" type="boolean" label="30066" help="30684">
           <level>2</level>
           <default>false</default>

--- a/pvr.iptvsimple/resources/settings.xml
+++ b/pvr.iptvsimple/resources/settings.xml
@@ -288,7 +288,7 @@
           <level>2</level>
           <default>127.0.0.1</default>
           <dependencies>
-            <dependency type="visible" setting="transformMulticastStreamUrls" operator="is">true</dependency>
+            <dependency type="enable" setting="transformMulticastStreamUrls" operator="is">true</dependency>
           </dependencies>
           <control type="edit" format="string" />
         </setting>
@@ -301,9 +301,16 @@
             <maximum>65535</maximum>
           </constraints>
           <dependencies>
-            <dependency type="visible" setting="transformMulticastStreamUrls" operator="is">true</dependency>
+            <dependency type="enable" setting="transformMulticastStreamUrls" operator="is">true</dependency>
           </dependencies>
           <control type="edit" format="integer" />
+        </setting>
+      </group>
+      <group id="2" label="30065">
+        <setting id="useInputstreamAdaptiveforHls" type="boolean" label="30066" help="30684">
+          <level>2</level>
+          <default>false</default>
+          <control type="toggle" />
         </setting>
       </group>
     </category>

--- a/pvr.iptvsimple/resources/settings.xml
+++ b/pvr.iptvsimple/resources/settings.xml
@@ -308,12 +308,12 @@
       </group>
       <group id="2" label="30065">
         <setting id="useFFmpegReconnect" type="boolean" label="30067" help="30685">
-          <level>2</level>
+          <level>3</level>
           <default>true</default>
           <control type="toggle" />
         </setting>
         <setting id="useInputstreamAdaptiveforHls" type="boolean" label="30066" help="30684">
-          <level>2</level>
+          <level>3</level>
           <default>false</default>
           <control type="toggle" />
         </setting>

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -272,8 +272,11 @@ PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL* channel, PVR_NAMED_VALUE
       {
         Logger::Log(LogLevel::LEVEL_DEBUG, "%s - setting inputstream adaptive for stream URL: %s", __FUNCTION__, streamURL.c_str());
         StreamUtils::SetStreamProperty(properties, iPropertiesCount, "inputstreamclass", "inputstream.adaptive");
-        StreamUtils::SetStreamProperty(properties, iPropertiesCount, "inputstream.adaptive.manifest_type", "hls");
-        StreamUtils::SetStreamProperty(properties, iPropertiesCount, PVR_STREAM_PROPERTY_MIMETYPE, "application/x-mpegURL");
+        StreamUtils::SetStreamProperty(properties, iPropertiesCount, "inputstream.adaptive.manifest_type", StreamUtils::GetManifestType(streamType));
+        if (streamType == StreamType::HLS || streamType == StreamType::DASH)
+          StreamUtils::SetStreamProperty(properties, iPropertiesCount, PVR_STREAM_PROPERTY_MIMETYPE, StreamUtils::GetMimeType(streamType));
+        if (streamType == StreamType::DASH)
+          StreamUtils::SetStreamProperty(properties, iPropertiesCount, "inputstream.adaptive.manifest_update_parameter", "full");
       }
     }
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -261,10 +261,20 @@ PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL* channel, PVR_NAMED_VALUE
     if (streamType == StreamType::OTHER_TYPE)
       streamType = StreamUtils::InspectStreamType(streamURL);
 
-    if (streamType == StreamType::HLS)
+    if (streamType != StreamType::OTHER_TYPE)
     {
-      Logger::Log(LogLevel::LEVEL_DEBUG, "%s - setting inputstream ffmpeg for stream URL: %s", __FUNCTION__, streamURL.c_str());
-      StreamUtils::SetStreamProperty(properties, iPropertiesCount, "inputstreamclass", "inputstream.ffmpeg");
+      if (streamType == StreamType::HLS && !settings.UseInputstreamAdaptiveforHls())
+      {
+        Logger::Log(LogLevel::LEVEL_DEBUG, "%s - setting inputstream ffmpeg for stream URL: %s", __FUNCTION__, streamURL.c_str());
+        StreamUtils::SetStreamProperty(properties, iPropertiesCount, "inputstreamclass", "inputstream.ffmpeg");
+      }
+      else
+      {
+        Logger::Log(LogLevel::LEVEL_DEBUG, "%s - setting inputstream adaptive for stream URL: %s", __FUNCTION__, streamURL.c_str());
+        StreamUtils::SetStreamProperty(properties, iPropertiesCount, "inputstreamclass", "inputstream.adaptive");
+        StreamUtils::SetStreamProperty(properties, iPropertiesCount, "inputstream.adaptive.manifest_type", "hls");
+        StreamUtils::SetStreamProperty(properties, iPropertiesCount, PVR_STREAM_PROPERTY_MIMETYPE, "application/x-mpegURL");
+      }
     }
 
     return PVR_ERROR_NO_ERROR;

--- a/src/iptvsimple/PlaylistLoader.cpp
+++ b/src/iptvsimple/PlaylistLoader.cpp
@@ -95,6 +95,7 @@ bool PlaylistLoader::LoadPlayList()
       {
         double tvgShiftDecimal = std::atof(ReadMarkerValue(line, TVG_INFO_SHIFT_MARKER).c_str());
         epgTimeShift = static_cast<int>(tvgShiftDecimal * 3600.0);
+        Settings::GetInstance().SetTvgUrl(ReadMarkerValue(line, TVG_URL_MARKER));
         continue;
       }
       else

--- a/src/iptvsimple/PlaylistLoader.cpp
+++ b/src/iptvsimple/PlaylistLoader.cpp
@@ -250,7 +250,8 @@ void PlaylistLoader::ParseSinglePropertyIntoChannel(const std::string& line, Cha
   auto pos = value.find('=');
   if (pos != std::string::npos)
   {
-    const std::string prop = value.substr(0, pos);
+    std::string prop = value.substr(0, pos);
+    StringUtils::ToLower(prop);
     const std::string propValue = value.substr(pos + 1);
 
     bool addProperty = true;

--- a/src/iptvsimple/PlaylistLoader.cpp
+++ b/src/iptvsimple/PlaylistLoader.cpp
@@ -252,9 +252,21 @@ void PlaylistLoader::ParseSinglePropertyIntoChannel(const std::string& line, Cha
   {
     const std::string prop = value.substr(0, pos);
     const std::string propValue = value.substr(pos + 1);
-    channel.AddProperty(prop, propValue);
 
-    Logger::Log(LEVEL_DEBUG, "%s - Found %s property: '%s' value: '%s'", __FUNCTION__, markerName.c_str(), prop.c_str(), propValue.c_str());
+    bool addProperty = true;
+    if (markerName == EXTVLCOPT_DASH_MARKER)
+    {
+      addProperty &= prop == "http-reconnect";
+    }
+    else if (markerName == EXTVLCOPT_MARKER)
+    {
+      addProperty &= prop == "http-user-agent" || prop == "http-referrer" || prop == "program";
+    }
+
+    if (addProperty)
+      channel.AddProperty(prop, propValue);
+
+    Logger::Log(LEVEL_DEBUG, "%s - Found %s property: '%s' value: '%s' added: %s", __FUNCTION__, markerName.c_str(), prop.c_str(), propValue.c_str(), addProperty ? "true" : "false");
   }
 }
 

--- a/src/iptvsimple/PlaylistLoader.cpp
+++ b/src/iptvsimple/PlaylistLoader.cpp
@@ -123,6 +123,10 @@ bool PlaylistLoader::LoadPlayList()
     {
       ParseSinglePropertyIntoChannel(line, tmpChannel, EXTVLCOPT_MARKER);
     }
+    else if (StringUtils::StartsWith(line, EXTVLCOPT_DASH_MARKER)) //#EXTVLCOPT--
+    {
+      ParseSinglePropertyIntoChannel(line, tmpChannel, EXTVLCOPT_DASH_MARKER);
+    }
     else if (StringUtils::StartsWith(line, M3U_GROUP_MARKER)) //#EXTGRP:
     {
       const std::string groupNamesListString = ReadMarkerValue(line, M3U_GROUP_MARKER);

--- a/src/iptvsimple/PlaylistLoader.h
+++ b/src/iptvsimple/PlaylistLoader.h
@@ -43,6 +43,7 @@ namespace iptvsimple
   static const std::string GROUP_NAME_MARKER       = "group-title=";
   static const std::string KODIPROP_MARKER         = "#KODIPROP:";
   static const std::string EXTVLCOPT_MARKER        = "#EXTVLCOPT:";
+  static const std::string EXTVLCOPT_DASH_MARKER   = "#EXTVLCOPT--";
   static const std::string RADIO_MARKER            = "radio=";
   static const std::string PLAYLIST_TYPE_MARKER    = "#EXT-X-PLAYLIST-TYPE:";
 

--- a/src/iptvsimple/PlaylistLoader.h
+++ b/src/iptvsimple/PlaylistLoader.h
@@ -33,6 +33,7 @@ namespace iptvsimple
   static const std::string M3U_START_MARKER        = "#EXTM3U";
   static const std::string M3U_INFO_MARKER         = "#EXTINF";
   static const std::string M3U_GROUP_MARKER        = "#EXTGRP:";
+  static const std::string TVG_URL_MARKER          = "x-tvg-url=";
   static const std::string TVG_INFO_ID_MARKER      = "tvg-id=";
   static const std::string TVG_INFO_ID_MARKER_UC   = "tvg-ID="; //some provider incorrectly use an uppercase ID
   static const std::string TVG_INFO_NAME_MARKER    = "tvg-name=";

--- a/src/iptvsimple/Settings.cpp
+++ b/src/iptvsimple/Settings.cpp
@@ -100,6 +100,8 @@ void Settings::ReadFromAddon(const std::string& userPath, const std::string clie
     m_udpxyHost = buffer;
   if (!XBMC->GetSetting("udpxyPort", &m_udpxyPort))
     m_udpxyPort = DEFAULT_UDPXY_MULTICAST_RELAY_PORT;
+  if (!XBMC->GetSetting("useInputstreamAdaptiveforHls", &m_useInputstreamAdaptiveforHls))
+    m_useInputstreamAdaptiveforHls = false;
 }
 
 ADDON_STATUS Settings::SetValue(const std::string& settingName, const void* settingValue)
@@ -175,6 +177,8 @@ ADDON_STATUS Settings::SetValue(const std::string& settingName, const void* sett
     return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_udpxyHost, ADDON_STATUS_OK, ADDON_STATUS_OK);
   if (settingName == "udpxyPort")
     return SetSetting<int, ADDON_STATUS>(settingName, settingValue, m_udpxyPort, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  if (settingName == "useInputstreamAdaptiveforHls")
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_useInputstreamAdaptiveforHls, ADDON_STATUS_OK, ADDON_STATUS_OK);
 
   return ADDON_STATUS_OK;
 }

--- a/src/iptvsimple/Settings.cpp
+++ b/src/iptvsimple/Settings.cpp
@@ -100,6 +100,8 @@ void Settings::ReadFromAddon(const std::string& userPath, const std::string clie
     m_udpxyHost = buffer;
   if (!XBMC->GetSetting("udpxyPort", &m_udpxyPort))
     m_udpxyPort = DEFAULT_UDPXY_MULTICAST_RELAY_PORT;
+  if (!XBMC->GetSetting("useFFmpegReconnect", &m_useFFmpegReconnect))
+    m_useFFmpegReconnect = false;
   if (!XBMC->GetSetting("useInputstreamAdaptiveforHls", &m_useInputstreamAdaptiveforHls))
     m_useInputstreamAdaptiveforHls = false;
 }
@@ -177,6 +179,8 @@ ADDON_STATUS Settings::SetValue(const std::string& settingName, const void* sett
     return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_udpxyHost, ADDON_STATUS_OK, ADDON_STATUS_OK);
   if (settingName == "udpxyPort")
     return SetSetting<int, ADDON_STATUS>(settingName, settingValue, m_udpxyPort, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  if (settingName == "useFFmpegReconnect")
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_useFFmpegReconnect, ADDON_STATUS_OK, ADDON_STATUS_OK);
   if (settingName == "useInputstreamAdaptiveforHls")
     return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_useInputstreamAdaptiveforHls, ADDON_STATUS_OK, ADDON_STATUS_OK);
 

--- a/src/iptvsimple/Settings.h
+++ b/src/iptvsimple/Settings.h
@@ -88,7 +88,11 @@ namespace iptvsimple
     int GetM3URefreshIntervalMins() const { return m_m3uRefreshIntervalMins; }
     int GetM3URefreshHour() const { return m_m3uRefreshHour; }
 
-    const std::string& GetEpgLocation() const { return m_epgPathType == PathType::REMOTE_PATH ? m_epgUrl : m_epgPath; }
+    const std::string& GetEpgLocation() const
+    {
+      const std::string& epgLocation = m_epgPathType == PathType::REMOTE_PATH ? m_epgUrl : m_epgPath;
+      return epgLocation.empty() ? m_tvgUrl : epgLocation;
+    }
     const PathType& GetEpgPathType() const { return m_epgPathType; }
     const std::string& GetEpgPath() const { return m_epgPath; }
     const std::string& GetEpgUrl() const { return m_epgUrl; }
@@ -112,6 +116,9 @@ namespace iptvsimple
     bool TransformMulticastStreamUrls() const { return m_transformMulticastStreamUrls; }
     const std::string& GetUdpxyHost() const { return m_udpxyHost; }
     int GetUdpxyPort() const { return m_udpxyPort; }
+
+    std::string& GetTvgUrl() { return m_tvgUrl; }
+    void SetTvgUrl(const std::string& tvgUrl) { m_tvgUrl = tvgUrl; }
 
   private:
     Settings() = default;
@@ -184,5 +191,7 @@ namespace iptvsimple
     bool m_transformMulticastStreamUrls = false;
     std::string m_udpxyHost;
     int m_udpxyPort = DEFAULT_UDPXY_MULTICAST_RELAY_PORT;
+
+    std::string m_tvgUrl;
   };
 } //namespace iptvsimple

--- a/src/iptvsimple/Settings.h
+++ b/src/iptvsimple/Settings.h
@@ -119,7 +119,7 @@ namespace iptvsimple
     bool UseFFmpegReconnect() const { return m_useFFmpegReconnect; }
     bool UseInputstreamAdaptiveforHls() const { return m_useInputstreamAdaptiveforHls; }
 
-    std::string& GetTvgUrl() { return m_tvgUrl; }
+    const std::string& GetTvgUrl() const { return m_tvgUrl; }
     void SetTvgUrl(const std::string& tvgUrl) { m_tvgUrl = tvgUrl; }
 
   private:

--- a/src/iptvsimple/Settings.h
+++ b/src/iptvsimple/Settings.h
@@ -116,6 +116,7 @@ namespace iptvsimple
     bool TransformMulticastStreamUrls() const { return m_transformMulticastStreamUrls; }
     const std::string& GetUdpxyHost() const { return m_udpxyHost; }
     int GetUdpxyPort() const { return m_udpxyPort; }
+    bool UseInputstreamAdaptiveforHls() const { return m_useInputstreamAdaptiveforHls; }
 
     std::string& GetTvgUrl() { return m_tvgUrl; }
     void SetTvgUrl(const std::string& tvgUrl) { m_tvgUrl = tvgUrl; }
@@ -191,6 +192,7 @@ namespace iptvsimple
     bool m_transformMulticastStreamUrls = false;
     std::string m_udpxyHost;
     int m_udpxyPort = DEFAULT_UDPXY_MULTICAST_RELAY_PORT;
+    bool m_useInputstreamAdaptiveforHls = false;
 
     std::string m_tvgUrl;
   };

--- a/src/iptvsimple/Settings.h
+++ b/src/iptvsimple/Settings.h
@@ -116,6 +116,7 @@ namespace iptvsimple
     bool TransformMulticastStreamUrls() const { return m_transformMulticastStreamUrls; }
     const std::string& GetUdpxyHost() const { return m_udpxyHost; }
     int GetUdpxyPort() const { return m_udpxyPort; }
+    bool UseFFmpegReconnect() const { return m_useFFmpegReconnect; }
     bool UseInputstreamAdaptiveforHls() const { return m_useInputstreamAdaptiveforHls; }
 
     std::string& GetTvgUrl() { return m_tvgUrl; }
@@ -192,6 +193,7 @@ namespace iptvsimple
     bool m_transformMulticastStreamUrls = false;
     std::string m_udpxyHost;
     int m_udpxyPort = DEFAULT_UDPXY_MULTICAST_RELAY_PORT;
+    bool m_useFFmpegReconnect = true;
     bool m_useInputstreamAdaptiveforHls = false;
 
     std::string m_tvgUrl;

--- a/src/iptvsimple/data/Channel.cpp
+++ b/src/iptvsimple/data/Channel.cpp
@@ -144,7 +144,7 @@ void Channel::RemoveProperty(const std::string& propName)
 
 void Channel::TryToAddPropertyAsHeader(const std::string& propertyName, const std::string& headerName)
 {
-  std::string value = GetProperty(propertyName);
+  const std::string value = GetProperty(propertyName);
 
   if (!value.empty())
   {

--- a/src/iptvsimple/data/Channel.cpp
+++ b/src/iptvsimple/data/Channel.cpp
@@ -112,7 +112,7 @@ void Channel::SetStreamURL(const std::string& url)
   m_streamURL = url;
 
   if (Settings::GetInstance().TransformMulticastStreamUrls() &&
-      (StringUtils::StartsWith(url, UDP_MULTICAST_PREFIX) || StringUtils::StartsWith(url, UDP_MULTICAST_PREFIX)))
+      (StringUtils::StartsWith(url, UDP_MULTICAST_PREFIX) || StringUtils::StartsWith(url, RTP_MULTICAST_PREFIX)))
   {
     const std::string typePath = StringUtils::StartsWith(url, "rtp") ? "/rtp/" : "/udp/";
 

--- a/src/iptvsimple/data/Channel.cpp
+++ b/src/iptvsimple/data/Channel.cpp
@@ -25,6 +25,7 @@
 #include "../Settings.h"
 #include "../utilities/FileUtils.h"
 #include "../utilities/Logger.h"
+#include "../utilities/StreamUtils.h"
 #include "../utilities/WebUtils.h"
 #include "../../client.h"
 
@@ -127,7 +128,7 @@ void Channel::SetStreamURL(const std::string& url)
   }
 }
 
-std::string Channel::GetProperty(const std::string& propName)
+std::string Channel::GetProperty(const std::string& propName) const
 {
   auto propPair = m_properties.find(propName);
   if (propPair != m_properties.end())
@@ -147,25 +148,7 @@ void Channel::TryToAddPropertyAsHeader(const std::string& propertyName, const st
 
   if (!value.empty())
   {
-    bool hasProtocolOptions = false;
-    bool addHeader = true;
-    size_t found = m_streamURL.find("|");
-
-    if (found != std::string::npos)
-    {
-      hasProtocolOptions = true;
-      addHeader = m_streamURL.find(headerName + "=", found + 1) == std::string::npos;
-    }
-
-    if (addHeader)
-    {
-      if (!hasProtocolOptions)
-        m_streamURL += "|";
-      else
-        m_streamURL += "&";
-
-      m_streamURL += headerName + "=" + value;
-    }
+    m_streamURL = StreamUtils::AddHeaderToStreamUrl(m_streamURL, headerName, value);
 
     RemoveProperty(propertyName);
   }

--- a/src/iptvsimple/data/Channel.h
+++ b/src/iptvsimple/data/Channel.h
@@ -31,6 +31,8 @@ namespace iptvsimple
   namespace data
   {
     static const std::string CHANNEL_LOGO_EXTENSION  = ".png";
+    static const std::string HTTP_PREFIX = "http://";
+    static const std::string HTTPS_PREFIX = "https://";
     static const std::string UDP_MULTICAST_PREFIX = "udp://@";
     static const std::string RTP_MULTICAST_PREFIX = "rtp://@";
 
@@ -78,6 +80,7 @@ namespace iptvsimple
       const std::map<std::string, std::string>& GetProperties() const { return m_properties; }
       void SetProperties(std::map<std::string, std::string>& value) { m_properties = value; }
       void AddProperty(const std::string& prop, const std::string& value) { m_properties.insert({prop, value}); }
+      std::string GetProperty(const std::string& propName);
 
       void UpdateTo(Channel& left) const;
       void UpdateTo(PVR_CHANNEL& left) const;
@@ -85,6 +88,9 @@ namespace iptvsimple
       void SetIconPathFromTvgLogo(const std::string& tvgLogo, std::string& channelName);
 
     private:
+      void RemoveProperty(const std::string& propName);
+      void TryToAddPropertyAsHeader(const std::string& propertyName, const std::string& headerName);
+
       bool m_radio = false;
       int m_uniqueId = 0;
       int m_channelNumber = 0;

--- a/src/iptvsimple/data/Channel.h
+++ b/src/iptvsimple/data/Channel.h
@@ -31,10 +31,6 @@ namespace iptvsimple
   namespace data
   {
     static const std::string CHANNEL_LOGO_EXTENSION  = ".png";
-    static const std::string HTTP_PREFIX = "http://";
-    static const std::string HTTPS_PREFIX = "https://";
-    static const std::string UDP_MULTICAST_PREFIX = "udp://@";
-    static const std::string RTP_MULTICAST_PREFIX = "rtp://@";
 
     class Channel
     {
@@ -80,7 +76,7 @@ namespace iptvsimple
       const std::map<std::string, std::string>& GetProperties() const { return m_properties; }
       void SetProperties(std::map<std::string, std::string>& value) { m_properties = value; }
       void AddProperty(const std::string& prop, const std::string& value) { m_properties.insert({prop, value}); }
-      std::string GetProperty(const std::string& propName);
+      std::string GetProperty(const std::string& propName) const;
 
       void UpdateTo(Channel& left) const;
       void UpdateTo(PVR_CHANNEL& left) const;

--- a/src/iptvsimple/data/Channel.h
+++ b/src/iptvsimple/data/Channel.h
@@ -30,7 +30,7 @@ namespace iptvsimple
 {
   namespace data
   {
-    static const std::string CHANNEL_LOGO_EXTENSION  = ".png";
+    static const std::string CHANNEL_LOGO_EXTENSION = ".png";
 
     class Channel
     {

--- a/src/iptvsimple/utilities/StreamUtils.cpp
+++ b/src/iptvsimple/utilities/StreamUtils.cpp
@@ -31,7 +31,7 @@ using namespace iptvsimple;
 using namespace iptvsimple::data;
 using namespace iptvsimple::utilities;
 
-void StreamUtils::SetStreamProperty(PVR_NAMED_VALUE* properties, unsigned int* propertiesCount, const std::string &name, const std::string &value)
+void StreamUtils::SetStreamProperty(PVR_NAMED_VALUE* properties, unsigned int* propertiesCount, const std::string& name, const std::string& value)
 {
   strncpy(properties[*propertiesCount].strName, name.c_str(), sizeof(properties[*propertiesCount].strName) - 1);
   strncpy(properties[*propertiesCount].strValue, value.c_str(), sizeof(properties[*propertiesCount].strValue) - 1);

--- a/src/iptvsimple/utilities/StreamUtils.cpp
+++ b/src/iptvsimple/utilities/StreamUtils.cpp
@@ -1,0 +1,58 @@
+/*
+ *      Copyright (C) 2005-2019 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "StreamUtils.h"
+
+#include "WebUtils.h"
+
+#include <p8-platform/util/StringUtils.h>
+
+using namespace iptvsimple;
+using namespace iptvsimple::utilities;
+
+void StreamUtils::SetStreamProperty(PVR_NAMED_VALUE* properties, unsigned int* propertiesCount, const std::string &name, const std::string &value)
+{
+  strncpy(properties[*propertiesCount].strName, name.c_str(), sizeof(properties[*propertiesCount].strName) - 1);
+  strncpy(properties[*propertiesCount].strValue, value.c_str(), sizeof(properties[*propertiesCount].strValue) - 1);
+  (*propertiesCount)++;
+}
+
+const StreamType StreamUtils::GetStreamType(const std::string& url)
+{
+  if (url.find(".m3u8") != std::string::npos)
+    return StreamType::HLS;
+
+  return StreamType::OTHER_TYPE;
+}
+
+const StreamType StreamUtils::InspectStreamType(const std::string& url)
+{
+  int httpCode = 0;
+  const std::string source = WebUtils::ReadFileContentsStartOnly(url, &httpCode);
+
+  if (httpCode == 200)
+  {
+    if (StringUtils::StartsWith(source, "#EXTM3U") && source.find("#EXT-X-STREAM-INF") != std::string::npos)
+      return StreamType::HLS;
+  }
+
+  return StreamType::OTHER_TYPE;
+}

--- a/src/iptvsimple/utilities/StreamUtils.cpp
+++ b/src/iptvsimple/utilities/StreamUtils.cpp
@@ -40,6 +40,13 @@ const StreamType StreamUtils::GetStreamType(const std::string& url)
   if (url.find(".m3u8") != std::string::npos)
     return StreamType::HLS;
 
+  if (url.find(".mpd") != std::string::npos)
+    return StreamType::DASH;
+
+  if (url.find(".ism") != std::string::npos &&
+      !(url.find(".ismv") != std::string::npos || url.find(".isma") != std::string::npos))
+    return StreamType::SMOOTH_STREAMING;
+
   return StreamType::OTHER_TYPE;
 }
 
@@ -52,7 +59,41 @@ const StreamType StreamUtils::InspectStreamType(const std::string& url)
   {
     if (StringUtils::StartsWith(source, "#EXTM3U") && source.find("#EXT-X-STREAM-INF") != std::string::npos)
       return StreamType::HLS;
+
+    if (source.find("<MPD") != std::string::npos)
+      return StreamType::DASH;
+
+    if (source.find("<SmoothStreamingMedia") != std::string::npos)
+      return StreamType::SMOOTH_STREAMING;
   }
 
   return StreamType::OTHER_TYPE;
+}
+
+const std::string StreamUtils::GetManifestType(const StreamType& streamType)
+{
+  switch (streamType)
+  {
+    case StreamType::HLS:
+      return "hls";
+    case StreamType::DASH:
+      return "mpd";
+    case StreamType::SMOOTH_STREAMING:
+      return "ism";
+    default:
+      return "";
+  }
+}
+
+const std::string StreamUtils::GetMimeType(const StreamType& streamType)
+{
+  switch (streamType)
+  {
+    case StreamType::HLS:
+      return "application/x-mpegURL";
+    case StreamType::DASH:
+      return "application/xml+dash";
+    default:
+      return "";
+  }
 }

--- a/src/iptvsimple/utilities/StreamUtils.cpp
+++ b/src/iptvsimple/utilities/StreamUtils.cpp
@@ -154,6 +154,11 @@ bool StreamUtils::UseKodiInputstreams(const StreamType& streamType)
   return streamType == StreamType::OTHER_TYPE || (streamType == StreamType::HLS && !Settings::GetInstance().UseInputstreamAdaptiveforHls());
 }
 
+bool StreamUtils::ChannelSpecifiesInputstream(const iptvsimple::data::Channel& channel)
+{
+  return !(channel.GetProperty(PVR_STREAM_PROPERTY_INPUTSTREAMCLASS).empty() && channel.GetProperty(PVR_STREAM_PROPERTY_INPUTSTREAMADDON).empty());
+}
+
 bool StreamUtils::SupportsFFmpegReconnect(const StreamType& streamType, const iptvsimple::data::Channel& channel)
 {
   return streamType == StreamType::HLS ||

--- a/src/iptvsimple/utilities/StreamUtils.h
+++ b/src/iptvsimple/utilities/StreamUtils.h
@@ -44,7 +44,7 @@ namespace iptvsimple
     class StreamUtils
     {
     public:
-      static void SetStreamProperty(PVR_NAMED_VALUE* properties, unsigned int* propertiesCount, const std::string &name, const std::string &value);
+      static void SetStreamProperty(PVR_NAMED_VALUE* properties, unsigned int* propertiesCount, const std::string& name, const std::string& value);
       static const StreamType GetStreamType(const std::string& url);
       static const StreamType InspectStreamType(const std::string& url);
       static const std::string GetManifestType(const StreamType& streamType);

--- a/src/iptvsimple/utilities/StreamUtils.h
+++ b/src/iptvsimple/utilities/StreamUtils.h
@@ -33,6 +33,8 @@ namespace iptvsimple
       : int // same type as addon settings
     {
       HLS = 0,
+      DASH,
+      SMOOTH_STREAMING,
       OTHER_TYPE
     };
 
@@ -42,6 +44,8 @@ namespace iptvsimple
       static void SetStreamProperty(PVR_NAMED_VALUE* properties, unsigned int* propertiesCount, const std::string &name, const std::string &value);
       static const StreamType GetStreamType(const std::string& url);
       static const StreamType InspectStreamType(const std::string& url);
+      static const std::string GetManifestType(const StreamType& streamType);
+      static const std::string GetMimeType(const StreamType& streamType);
     };
   } // namespace utilities
 } // namespace iptvsimple

--- a/src/iptvsimple/utilities/StreamUtils.h
+++ b/src/iptvsimple/utilities/StreamUtils.h
@@ -52,6 +52,7 @@ namespace iptvsimple
       static std::string GetURLWithFFmpegReconnectOptions(const std::string& streamUrl, const StreamType& streamType, const iptvsimple::data::Channel& channel);
       static std::string AddHeaderToStreamUrl(const std::string& streamUrl, const std::string& headerName, const std::string& headerValue);
       static bool UseKodiInputstreams(const StreamType& streamType);
+      static bool ChannelSpecifiesInputstream(const iptvsimple::data::Channel& channe);
 
     private:
       static bool SupportsFFmpegReconnect(const StreamType& streamType, const iptvsimple::data::Channel& channel);

--- a/src/iptvsimple/utilities/StreamUtils.h
+++ b/src/iptvsimple/utilities/StreamUtils.h
@@ -23,15 +23,25 @@
 
 #include <string>
 
+#include <kodi/xbmc_pvr_types.h>
+
 namespace iptvsimple
 {
   namespace utilities
   {
-    class WebUtils
+    enum class StreamType
+      : int // same type as addon settings
+    {
+      HLS = 0,
+      OTHER_TYPE
+    };
+
+    class StreamUtils
     {
     public:
-      static const std::string UrlEncode(const std::string& value);
-      static std::string ReadFileContentsStartOnly(const std::string &url, int *httpCode);
+      static void SetStreamProperty(PVR_NAMED_VALUE* properties, unsigned int* propertiesCount, const std::string &name, const std::string &value);
+      static const StreamType GetStreamType(const std::string& url);
+      static const StreamType InspectStreamType(const std::string& url);
     };
   } // namespace utilities
 } // namespace iptvsimple

--- a/src/iptvsimple/utilities/StreamUtils.h
+++ b/src/iptvsimple/utilities/StreamUtils.h
@@ -21,6 +21,9 @@
  *
  */
 
+#include "../data/Channel.h"
+
+#include <map>
 #include <string>
 
 #include <kodi/xbmc_pvr_types.h>
@@ -46,6 +49,12 @@ namespace iptvsimple
       static const StreamType InspectStreamType(const std::string& url);
       static const std::string GetManifestType(const StreamType& streamType);
       static const std::string GetMimeType(const StreamType& streamType);
+      static std::string GetURLWithFFmpegReconnectOptions(const std::string& streamUrl, const StreamType& streamType, const iptvsimple::data::Channel& channel);
+      static std::string AddHeaderToStreamUrl(const std::string& streamUrl, const std::string& headerName, const std::string& headerValue);
+      static bool UseKodiInputstreams(const StreamType& streamType);
+
+    private:
+      static bool SupportsFFmpegReconnect(const StreamType& streamType, const iptvsimple::data::Channel& channel);
     };
   } // namespace utilities
 } // namespace iptvsimple

--- a/src/iptvsimple/utilities/WebUtils.cpp
+++ b/src/iptvsimple/utilities/WebUtils.cpp
@@ -55,7 +55,7 @@ const std::string WebUtils::UrlEncode(const std::string& value)
   return escaped.str();
 }
 
-std::string WebUtils::ReadFileContentsStartOnly(const std::string &url, int *httpCode)
+std::string WebUtils::ReadFileContentsStartOnly(const std::string& url, int* httpCode)
 {
   std::string strContent;
   void* fileHandle = XBMC->OpenFile(url.c_str(), 0x08); //READ_NO_CACHE

--- a/src/iptvsimple/utilities/WebUtils.cpp
+++ b/src/iptvsimple/utilities/WebUtils.cpp
@@ -21,6 +21,8 @@
 
 #include "WebUtils.h"
 
+#include "../../client.h"
+
 #include <cctype>
 #include <iomanip>
 #include <sstream>
@@ -49,4 +51,24 @@ const std::string WebUtils::UrlEncode(const std::string& value)
   }
 
   return escaped.str();
+}
+
+std::string WebUtils::ReadFileContentsStartOnly(const std::string &url, int *httpCode)
+{
+  std::string strContent;
+  void* fileHandle = XBMC->OpenFile(url.c_str(), 0x08); //READ_NO_CACHE
+  if (fileHandle)
+  {
+    char buffer[1024];
+    if (int bytesRead = XBMC->ReadFile(fileHandle, buffer, 1024))
+      strContent.append(buffer, bytesRead);
+    XBMC->CloseFile(fileHandle);
+  }
+
+  if (strContent.empty())
+    *httpCode = 500;
+  else
+    *httpCode = 200;
+
+  return strContent;
 }

--- a/src/iptvsimple/utilities/WebUtils.cpp
+++ b/src/iptvsimple/utilities/WebUtils.cpp
@@ -27,6 +27,8 @@
 #include <iomanip>
 #include <sstream>
 
+#include <p8-platform/util/StringUtils.h>
+
 using namespace iptvsimple;
 using namespace iptvsimple::utilities;
 
@@ -71,4 +73,9 @@ std::string WebUtils::ReadFileContentsStartOnly(const std::string &url, int *htt
     *httpCode = 200;
 
   return strContent;
+}
+
+bool WebUtils::IsHttpUrl(const std::string& url)
+{
+  return StringUtils::StartsWith(url, HTTP_PREFIX) || StringUtils::StartsWith(url, HTTPS_PREFIX);
 }

--- a/src/iptvsimple/utilities/WebUtils.h
+++ b/src/iptvsimple/utilities/WebUtils.h
@@ -27,11 +27,17 @@ namespace iptvsimple
 {
   namespace utilities
   {
+    static const std::string HTTP_PREFIX = "http://";
+    static const std::string HTTPS_PREFIX = "https://";
+    static const std::string UDP_MULTICAST_PREFIX = "udp://@";
+    static const std::string RTP_MULTICAST_PREFIX = "rtp://@";
+
     class WebUtils
     {
     public:
       static const std::string UrlEncode(const std::string& value);
       static std::string ReadFileContentsStartOnly(const std::string &url, int *httpCode);
+      static bool IsHttpUrl(const std::string& url);
     };
   } // namespace utilities
 } // namespace iptvsimple

--- a/src/iptvsimple/utilities/WebUtils.h
+++ b/src/iptvsimple/utilities/WebUtils.h
@@ -36,7 +36,7 @@ namespace iptvsimple
     {
     public:
       static const std::string UrlEncode(const std::string& value);
-      static std::string ReadFileContentsStartOnly(const std::string &url, int *httpCode);
+      static std::string ReadFileContentsStartOnly(const std::string& url, int* httpCode);
       static bool IsHttpUrl(const std::string& url);
     };
   } // namespace utilities


### PR DESCRIPTION
v4.8.0
- Added: Allow use of inputstream ffmpeg for m3u8 files missing correct extension
- Added: Support for x-tvg-url in playlist header for XMLTV data
- Added: Add EXTVLCOPT properties for headers
- Fixed: Fix RTP multicast stream prefix
- Added: Add support for Dash and Smooth streaming via inputstream.adaptive
- Added: Add option to use inputsream.adaptive for m3u8/hls streams
- Added: Support FFmpeg reconnect for http streams using inputstream ffmpeg
- Fixed: Limit allowed EXTVLCOPT properties to known set
- Fixed: Add extra stream properties as lower case only
- Fixed: Support inputstreamaddon for overriding inputstream
- Update: Readme