### PR TITLE
Fix for local channels logo with .jpg extension not working

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="3.8.6"
+  version="3.8.7"
   name="PVR IPTV Simple Client"
   provider-name="nightik">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v3.8.7
+- Fixed: Local channels logo with .jpg extension not working
+
 v3.8.6
 - Fixed: tvg-id does not match a channel if no display-names in xmltv
 - Fixed: Combine multiple XMLTV channels sharing same id

--- a/src/PVRIptvData.cpp
+++ b/src/PVRIptvData.cpp
@@ -715,7 +715,9 @@ bool PVRIptvData::LoadPlayList(void)
         if (m_logoPathType == REMOTE_PATH_TYPE && logoSetFromChannelName)
           tmpChannel.strTvgLogo = UrlEncode(tmpChannel.strTvgLogo);
 
-        if (tmpChannel.strTvgLogo.find("://") == std::string::npos && !StringUtils::EndsWithNoCase(tmpChannel.strTvgLogo, ".png"))
+        if (tmpChannel.strTvgLogo.find("://") == std::string::npos &&
+            !StringUtils::EndsWithNoCase(tmpChannel.strTvgLogo, ".png") &&
+            !StringUtils::EndsWithNoCase(tmpChannel.strTvgLogo, ".jpg"))
           tmpChannel.strTvgLogo += CHANNEL_LOGO_EXTENSION;
 
         if (strTvgShift.empty())


### PR DESCRIPTION
v3.8.7
- Fixed: Local channels logo with .jpg extension not working