### PR TITLE
Fix for local channels logo with .jpg extension not working - Matrix

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="4.8.0"
+  version="4.8.1"
   name="PVR IPTV Simple Client"
   provider-name="nightik">
   <requires>@ADDON_DEPENDS@</requires>
@@ -159,6 +159,9 @@
     <disclaimer lang="zh_TW">這是測試中的軟體！原創作者無法針對以下情況負責：包括播放失敗，不正確的電子節目表，多餘的時數，或任何不可預期的不良影響。</disclaimer>
     <platform>@PLATFORM@</platform>
     <news>
+v4.8.1
+- Fixed: Local channels logo with .jpg extension not working
+
 v4.8.0
 - Added: Allow use of inputstream ffmpeg for m3u8 files missing correct extension
 - Added: Support for x-tvg-url in playlist header for XMLTV data

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v4.8.1
+- Fixed: Local channels logo with .jpg extension not working
+
 v4.8.0
 - Added: Allow use of inputstream ffmpeg for m3u8 files missing correct extension
 - Added: Support for x-tvg-url in playlist header for XMLTV data

--- a/src/iptvsimple/data/Channel.cpp
+++ b/src/iptvsimple/data/Channel.cpp
@@ -102,7 +102,7 @@ void Channel::SetIconPathFromTvgLogo(const std::string& tvgLogo, std::string& ch
       // not absolute path, only append .png in this case.
       m_iconPath = utilities::FileUtils::PathCombine(logoLocation, m_iconPath);
 
-      if (!StringUtils::EndsWithNoCase(m_iconPath, ".png"))
+      if (!StringUtils::EndsWithNoCase(m_iconPath, ".png") && !StringUtils::EndsWithNoCase(m_iconPath, ".jpg"))
         m_iconPath += CHANNEL_LOGO_EXTENSION;
     }
   }


### PR DESCRIPTION
v4.8.1
- Fixed: Local channels logo with .jpg extension not working