### PR TITLE
Check if file exists before inspecting stream type and initialise stream properties count

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ General settings required for the addon to function.
     - `Disabled` - Don't auto refresh the M3U file.
     - `Repeated refresh` - Refresh the M3U on a minute based interval.
     - `Once per day` - Refresh the M3U once per day.
-* **Refresh interval"**: If M3U auto refresh mode is `Repeated refresh` refresh the M3U every time this number of minutes passes. Max 120 minutes.
-* **ORefresh hour (24h)**: If M3U auto refresh mode is `Once per day` refresh the M3U every time this horu if the day is reached.
+* **Refresh interval**: If M3U auto refresh mode is `Repeated refresh` refresh the M3U every time this number of minutes passes. Max 120 minutes.
+* **Refresh hour (24h)**: If M3U auto refresh mode is `Once per day` refresh the M3U every time this horu if the day is reached.
 
 ### EPG
 Settings related to the EPG.
@@ -117,7 +117,7 @@ Advanced settings such as multicast relays.
 * **Transform multicast stream URLs**: Multicast (UDP/RTP) streams do not work well on Wifi networks. A multicast relay can convert the stream from UDP/RTP multicast to HTTP. Enabling this option will transform multicast stream URLs from the M3U file to HTTP addresses so they can be accesssed via a 'udpxy' relay on the local network. E.g. a UDP multicast stream URL like `udp://@239.239.3.38:5239` would get transformed to something like `http://192.168.1.1:4000/udp/239.239.3.38:5239`.
 * **Relay hostname or IP address**: The hostname or ip address of the multicast relay (`udpxy`) on the local network.
 * **Relay port**: The port of the multicast relay (`udpxy`) on the local network.
-* **Use FFMpeg http reconnect options if possible**: Note this can only apply to http/https streams that are processed by libavformat (M3u8/HLS steram will use this by default). Using libavformat can be specified in an M3U file by setting the property `inputstreamclass` to `inputstream.ffmpeg`. I.e. adding the line: `#KODIPROP:inputstreamclass=inputstream.ffmpeg`.
+* **Use FFMpeg http reconnect options if possible**: Note this can only apply to http/https streams that are processed by libavformat (e.g. M3u8/HLS). Using libavformat can be specified in an M3U file by setting the property `inputstreamclass` as `inputstream.ffmpeg`. I.e. adding the line: `#KODIPROP:inputstreamclass=inputstream.ffmpeg`. If this opton is not enabled it can still be enabled per stream/channel by adding a kodi property, i.e.: `#KODIPROP:http-reconnect=true`.
 * **Use inputstream.adaptive for m3u8 (HLS) streams**: Use inputstream.adaptive instead of ffmpeg's libavformat for m3u8 (HLS) streams.
 
 ## Appendix

--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="4.8.1"
+  version="4.8.2"
   name="PVR IPTV Simple Client"
   provider-name="nightik">
   <requires>@ADDON_DEPENDS@</requires>
@@ -159,6 +159,14 @@
     <disclaimer lang="zh_TW">這是測試中的軟體！原創作者無法針對以下情況負責：包括播放失敗，不正確的電子節目表，多餘的時數，或任何不可預期的不良影響。</disclaimer>
     <platform>@PLATFORM@</platform>
     <news>
+v4.8.2
+- Fixed: Initialise properties size and check max
+- Fixed: Playing a channel will crash if file/URL does not exist
+- Fixed: Support both input stream class and addon properties
+- Fixed: Allow override of ffmpeg reconnect option
+- Fixed: Fix header property spelling
+- Update: Readme
+
 v4.8.1
 - Fixed: Local channels logo with .jpg extension not working
 

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,11 @@
+v4.8.2
+- Fixed: Initialise properties size and check max
+- Fixed: Playing a channel will crash if file/URL does not exist
+- Fixed: Support both input stream class and addon properties
+- Fixed: Allow override of ffmpeg reconnect option
+- Fixed: Fix header property spelling
+- Update: Readme
+
 v4.8.1
 - Fixed: Local channels logo with .jpg extension not working
 

--- a/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
@@ -442,5 +442,5 @@ msgstr ""
 
 #help: Advanced - useFFmpegReconnect
 msgctxt "#30685"
-msgid "Note this can only apply to http/https streams that are processed by libavformat (M3u8/HLS steram will use this by default). Using libavformat can be specified in an M3U file by setting the property `inputstreamclass` to `inputstream.ffmpeg`. I.e. adding the line: `#KODIPROP:inputstreamclass=inputstream.ffmpeg`."
+msgid "Note this can only apply to http/https streams that are processed by libavformat (e.g. M3u8/HLS). Using libavformat can be specified in an M3U file by setting the property `inputstreamclass` as `inputstream.ffmpeg`. I.e. adding the line: `#KODIPROP:inputstreamclass=inputstream.ffmpeg`. If this opton is not enabled it can still be enabled per stream/channel by adding a kodi property, i.e.: `#KODIPROP:http-reconnect=true`."
 msgstr ""

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -250,10 +250,12 @@ PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL* channel, PVR_NAMED_VALUE
   {
     std::string streamURL = m_currentChannel.GetStreamURL();
 
+    unsigned int propertiesMax = *iPropertiesCount;
+    *iPropertiesCount = 0; // Need to initialise here as current value will be size of properties array
     if (StreamUtils::ChannelSpecifiesInputstream(m_currentChannel))
     {
       // Channel has an inputstream class set so we only set the stream URL
-      StreamUtils::SetStreamProperty(properties, iPropertiesCount, PVR_STREAM_PROPERTY_STREAMURL, streamURL);
+      StreamUtils::SetStreamProperty(properties, iPropertiesCount, propertiesMax, PVR_STREAM_PROPERTY_STREAMURL, streamURL);
     }
     else
     {
@@ -265,20 +267,20 @@ PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL* channel, PVR_NAMED_VALUE
       if (StreamUtils::UseKodiInputstreams(streamType))
       {
         std::string ffmpegStreamURL = StreamUtils::GetURLWithFFmpegReconnectOptions(streamURL, streamType, m_currentChannel);
-        StreamUtils::SetStreamProperty(properties, iPropertiesCount, PVR_STREAM_PROPERTY_STREAMURL, ffmpegStreamURL);
+        StreamUtils::SetStreamProperty(properties, iPropertiesCount, propertiesMax, PVR_STREAM_PROPERTY_STREAMURL, ffmpegStreamURL);
 
         if (streamType == StreamType::HLS)
-          StreamUtils::SetStreamProperty(properties, iPropertiesCount, PVR_STREAM_PROPERTY_INPUTSTREAMCLASS, PVR_STREAM_PROPERTY_VALUE_INPUTSTREAMFFMPEG);
+          StreamUtils::SetStreamProperty(properties, iPropertiesCount, propertiesMax, PVR_STREAM_PROPERTY_INPUTSTREAMCLASS, PVR_STREAM_PROPERTY_VALUE_INPUTSTREAMFFMPEG);
       }
       else // inputstream.adpative
       {
-        StreamUtils::SetStreamProperty(properties, iPropertiesCount, PVR_STREAM_PROPERTY_STREAMURL, streamURL);
-        StreamUtils::SetStreamProperty(properties, iPropertiesCount, PVR_STREAM_PROPERTY_INPUTSTREAMCLASS, "inputstream.adaptive");
-        StreamUtils::SetStreamProperty(properties, iPropertiesCount, "inputstream.adaptive.manifest_type", StreamUtils::GetManifestType(streamType));
+        StreamUtils::SetStreamProperty(properties, iPropertiesCount, propertiesMax, PVR_STREAM_PROPERTY_STREAMURL, streamURL);
+        StreamUtils::SetStreamProperty(properties, iPropertiesCount, propertiesMax, PVR_STREAM_PROPERTY_INPUTSTREAMCLASS, "inputstream.adaptive");
+        StreamUtils::SetStreamProperty(properties, iPropertiesCount, propertiesMax, "inputstream.adaptive.manifest_type", StreamUtils::GetManifestType(streamType));
         if (streamType == StreamType::HLS || streamType == StreamType::DASH)
-          StreamUtils::SetStreamProperty(properties, iPropertiesCount, PVR_STREAM_PROPERTY_MIMETYPE, StreamUtils::GetMimeType(streamType));
+          StreamUtils::SetStreamProperty(properties, iPropertiesCount, propertiesMax, PVR_STREAM_PROPERTY_MIMETYPE, StreamUtils::GetMimeType(streamType));
         if (streamType == StreamType::DASH)
-          StreamUtils::SetStreamProperty(properties, iPropertiesCount, "inputstream.adaptive.manifest_update_parameter", "full");
+          StreamUtils::SetStreamProperty(properties, iPropertiesCount, propertiesMax, "inputstream.adaptive.manifest_update_parameter", "full");
       }
     }
 
@@ -287,7 +289,7 @@ PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL* channel, PVR_NAMED_VALUE
     if (!m_currentChannel.GetProperties().empty())
     {
       for (auto& prop : m_currentChannel.GetProperties())
-        StreamUtils::SetStreamProperty(properties, iPropertiesCount, prop.first, prop.second);
+        StreamUtils::SetStreamProperty(properties, iPropertiesCount, propertiesMax, prop.first, prop.second);
     }
 
     return PVR_ERROR_NO_ERROR;

--- a/src/iptvsimple/data/Channel.cpp
+++ b/src/iptvsimple/data/Channel.cpp
@@ -115,7 +115,7 @@ void Channel::SetStreamURL(const std::string& url)
   if (StringUtils::StartsWith(url, HTTP_PREFIX) || StringUtils::StartsWith(url, HTTPS_PREFIX))
   {
     TryToAddPropertyAsHeader("http-user-agent", "user-agent");
-    TryToAddPropertyAsHeader("http-referrer", "referrer");
+    TryToAddPropertyAsHeader("http-referrer", "referer"); // spelling differences are correct
   }
 
   if (Settings::GetInstance().TransformMulticastStreamUrls() &&

--- a/src/iptvsimple/utilities/StreamUtils.cpp
+++ b/src/iptvsimple/utilities/StreamUtils.cpp
@@ -32,11 +32,18 @@ using namespace iptvsimple;
 using namespace iptvsimple::data;
 using namespace iptvsimple::utilities;
 
-void StreamUtils::SetStreamProperty(PVR_NAMED_VALUE* properties, unsigned int* propertiesCount, const std::string& name, const std::string& value)
+void StreamUtils::SetStreamProperty(PVR_NAMED_VALUE* properties, unsigned int* propertiesCount, unsigned int propertiesMax, const std::string& name, const std::string& value)
 {
-  strncpy(properties[*propertiesCount].strName, name.c_str(), sizeof(properties[*propertiesCount].strName) - 1);
-  strncpy(properties[*propertiesCount].strValue, value.c_str(), sizeof(properties[*propertiesCount].strValue) - 1);
-  (*propertiesCount)++;
+  if (*propertiesCount < propertiesMax)
+  {
+    strncpy(properties[*propertiesCount].strName, name.c_str(), sizeof(properties[*propertiesCount].strName) - 1);
+    strncpy(properties[*propertiesCount].strValue, value.c_str(), sizeof(properties[*propertiesCount].strValue) - 1);
+    (*propertiesCount)++;
+  }
+  else
+  {
+    Logger::Log(LogLevel::LEVEL_ERROR, "%s - Could not add property as max number reached: %s=%s - count : %u", __FUNCTION__, name.c_str(), value.c_str(), propertiesMax);
+  }
 }
 
 const StreamType StreamUtils::GetStreamType(const std::string& url)

--- a/src/iptvsimple/utilities/StreamUtils.cpp
+++ b/src/iptvsimple/utilities/StreamUtils.cpp
@@ -22,6 +22,7 @@
 #include "StreamUtils.h"
 
 #include "../Settings.h"
+#include "FileUtils.h"
 #include "Logger.h"
 #include "WebUtils.h"
 
@@ -55,6 +56,9 @@ const StreamType StreamUtils::GetStreamType(const std::string& url)
 
 const StreamType StreamUtils::InspectStreamType(const std::string& url)
 {
+  if (!FileUtils::FileExists(url))
+    return StreamType::OTHER_TYPE;
+
   int httpCode = 0;
   const std::string source = WebUtils::ReadFileContentsStartOnly(url, &httpCode);
 

--- a/src/iptvsimple/utilities/StreamUtils.cpp
+++ b/src/iptvsimple/utilities/StreamUtils.cpp
@@ -105,10 +105,8 @@ std::string StreamUtils::GetURLWithFFmpegReconnectOptions(const std::string& str
 {
   std::string newStreamUrl = streamUrl;
 
-  if (WebUtils::IsHttpUrl(streamUrl) &&
-      channel.GetProperty("http-reconnect") == "true" &&
-      SupportsFFmpegReconnect(streamType, channel) &&
-      Settings::GetInstance().UseFFmpegReconnect())
+  if (WebUtils::IsHttpUrl(streamUrl) && SupportsFFmpegReconnect(streamType, channel) &&
+      (channel.GetProperty("http-reconnect") == "true" || Settings::GetInstance().UseFFmpegReconnect()))
   {
     newStreamUrl = AddHeaderToStreamUrl(newStreamUrl, "reconnect", "1");
     if (streamType != StreamType::HLS)
@@ -116,7 +114,7 @@ std::string StreamUtils::GetURLWithFFmpegReconnectOptions(const std::string& str
     newStreamUrl = AddHeaderToStreamUrl(newStreamUrl, "reconnect_streamed", "1");
     newStreamUrl = AddHeaderToStreamUrl(newStreamUrl, "reconnect_delay_max", "4294");
 
-    Logger::Log(LogLevel::LEVEL_NOTICE, "%s - FFmpeg Reconnect Stream URL: %s", __FUNCTION__, newStreamUrl.c_str());
+    Logger::Log(LogLevel::LEVEL_DEBUG, "%s - FFmpeg Reconnect Stream URL: %s", __FUNCTION__, newStreamUrl.c_str());
   }
 
   return newStreamUrl;

--- a/src/iptvsimple/utilities/StreamUtils.cpp
+++ b/src/iptvsimple/utilities/StreamUtils.cpp
@@ -160,6 +160,6 @@ bool StreamUtils::ChannelSpecifiesInputstream(const iptvsimple::data::Channel& c
 bool StreamUtils::SupportsFFmpegReconnect(const StreamType& streamType, const iptvsimple::data::Channel& channel)
 {
   return streamType == StreamType::HLS ||
-         channel.GetProperty(PVR_STREAM_PROPERTY_INPUTSTREAMCLASS) == PVR_STREAM_PROPERTY_VALUE_INPUTSTREAMFFMPEG;
+         channel.GetProperty(PVR_STREAM_PROPERTY_INPUTSTREAMCLASS) == PVR_STREAM_PROPERTY_VALUE_INPUTSTREAMFFMPEG ||
+         channel.GetProperty(PVR_STREAM_PROPERTY_INPUTSTREAMADDON) == PVR_STREAM_PROPERTY_VALUE_INPUTSTREAMFFMPEG;
 }
-

--- a/src/iptvsimple/utilities/StreamUtils.h
+++ b/src/iptvsimple/utilities/StreamUtils.h
@@ -44,7 +44,7 @@ namespace iptvsimple
     class StreamUtils
     {
     public:
-      static void SetStreamProperty(PVR_NAMED_VALUE* properties, unsigned int* propertiesCount, const std::string& name, const std::string& value);
+      static void SetStreamProperty(PVR_NAMED_VALUE* properties, unsigned int* propertiesCount, unsigned int propertiesMax, const std::string& name, const std::string& value);
       static const StreamType GetStreamType(const std::string& url);
       static const StreamType InspectStreamType(const std::string& url);
       static const std::string GetManifestType(const StreamType& streamType);


### PR DESCRIPTION
v4.8.2
- Fixed: Initialise properties size and check max
- Fixed: Playing a channel will crash if file/URL does not exist
- Fixed: Support both input stream class and addon properties
- Fixed: Allow override of ffmpeg reconnect option
- Fixed: Fix header property spelling
- Update: Readme