### PR TITLE
Caching, stream type and settings levels fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,12 @@ General settings required for the addon to function.
 * **Cache M3U at local storage**: If location is `Remote path` select whether or not the the M3U file should be cached locally.
 * **Start channel number**: The number to start numbering channels from. Only used when `Use backend channel numbers` from PVR settings is enabled and a channel number is not supplied in the M3U file.
 * **Only number by channel order in M3U**: Ignore any 'tvg-chno' tags and only number channels by the order in the M3U starting at 'Start channel number'.
-* **M3U auto refresh mode**: Select the auto refresh mode for the M3U file. The options are:
-    - `Disabled` - Don't auto refresh the M3U file.
-    - `Repeated refresh` - Refresh the M3U on a minute based interval.
-    - `Once per day` - Refresh the M3U once per day.
-* **Refresh interval**: If M3U auto refresh mode is `Repeated refresh` refresh the M3U every time this number of minutes passes. Max 120 minutes.
-* **Refresh hour (24h)**: If M3U auto refresh mode is `Once per day` refresh the M3U every time this horu if the day is reached.
+* **Auto refresh mode**: Select the auto refresh mode for the M3U/XMLTV files. Note that caching is disabled if auto refresh is used. The options are:
+    - `Disabled` - Don't auto refresh the files.
+    - `Repeated refresh` - Refresh the files on a minute based interval.
+    - `Once per day` - Refresh the files once per day.
+* **Refresh interval**: If auto refresh mode is `Repeated refresh` refresh the files every time this number of minutes passes. Max 120 minutes.
+* **Refresh hour (24h)**: If auto refresh mode is `Once per day` refresh the files every time this hour of the day is reached.
 
 ### EPG
 Settings related to the EPG.

--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="4.8.3"
+  version="4.8.4"
   name="PVR IPTV Simple Client"
   provider-name="nightik">
   <requires>@ADDON_DEPENDS@</requires>
@@ -159,6 +159,11 @@
     <disclaimer lang="zh_TW">這是測試中的軟體！原創作者無法針對以下情況負責：包括播放失敗，不正確的電子節目表，多餘的時數，或任何不可預期的不良影響。</disclaimer>
     <platform>@PLATFORM@</platform>
     <news>
+v4.8.4
+- Fixed: Disable caching when using refresh M3U/XMLTV modes
+- Fixed: Also check channel mime type property when determinig stream type
+- Fixed: Correct settings levels
+
 v4.8.3
 - Fixed: Channel and epg refresh infinite loop
 

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,8 @@
+v4.8.4
+- Fixed: Disable caching when using refresh M3U/XMLTV modes
+- Fixed: Also check channel mime type property when determinig stream type
+- Fixed: Correct settings levels
+
 v4.8.3
 - Fixed: Channel and epg refresh infinite loop
 

--- a/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
@@ -86,7 +86,7 @@ msgstr ""
 
 #label: General - m3uRefreshMode
 msgctxt "#30015"
-msgid "M3U auto refresh mode"
+msgid "Auto refresh mode"
 msgstr ""
 
 #label: General - m3uRefreshIntervalMins
@@ -304,17 +304,17 @@ msgstr ""
 
 #help: General - m3uRefreshMode
 msgctxt "#30607"
-msgid "Select the auto refresh mode for the M3U file. The options are: [Disabled] - Don't auto refresh the M3U file; [Repeated refresh] - Refresh the M3U on a minute based interval; [Once per day] - Refresh the M3U once per day."
+msgid "Select the auto refresh mode for the M3U/XMLTV files. Note that caching is disabled if auto refresh is used. The options are: [Disabled] - Don't auto refresh the files; [Repeated refresh] - Refresh the files on a minute based interval; [Once per day] - Refresh the files once per day."
 msgstr ""
 
 #help: General - m3uRefreshIntervalMins
 msgctxt "#30608"
-msgid "If M3U auto refresh mode is [Repeated refresh] refresh the M3U every time this number of minutes passes. Max 120 minutes."
+msgid "If M3U auto refresh mode is [Repeated refresh] refresh the files every time this number of minutes passes. Max 120 minutes."
 msgstr ""
 
 #help: General - m3uRefreshHour
 msgctxt "#30609"
-msgid "If M3U auto refresh mode is [Once per day] refresh the M3U every time this horu if the day is reached."
+msgid "If auto refresh mode is [Once per day] refresh the files every time this hour of the day is reached"
 msgstr ""
 
 #empty strings from id 30610 to 30619

--- a/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
@@ -99,7 +99,10 @@ msgctxt "#30017"
 msgid "Refresh hour (24h)"
 msgstr ""
 
-#empty string 30018
+#label-group: General - Refresh
+msgctxt "#30018"
+msgid "Refresh"
+msgstr ""
 
 #label-category: epgsettings
 msgctxt "#30019"

--- a/pvr.iptvsimple/resources/settings.xml
+++ b/pvr.iptvsimple/resources/settings.xml
@@ -55,12 +55,14 @@
           <control type="edit" format="integer" />
         </setting>
         <setting id="numberByOrder" type="boolean" label="30014" help="30606">
-          <level>0</level>
+          <level>2</level>
           <default>false</default>
           <control type="toggle" />
         </setting>
+      </group>
+      <group id="2" label="30018">
         <setting id="m3uRefreshMode" type="integer" label="30015" help="30607">
-          <level>0</level>
+          <level>1</level>
           <default>0</default>
           <constraints>
             <options>
@@ -72,7 +74,7 @@
           <control type="list" format="integer" />
         </setting>
         <setting id="m3uRefreshIntervalMins" type="integer" parent="m3uRefreshMode" label="30016" help="30608">
-          <level>0</level>
+          <level>1</level>
           <default>60</default>
           <constraints>
             <minimum>0</minimum>
@@ -87,7 +89,7 @@
           </control>
         </setting>
         <setting id="m3uRefreshHour" type="integer" parent="m3uRefreshMode" label="30017" help="30609">
-          <level>2</level>
+          <level>1</level>
           <default>4</default>
           <constraints>
             <minimum>0</minimum>

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -259,7 +259,7 @@ PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL* channel, PVR_NAMED_VALUE
     }
     else
     {
-      StreamType streamType = StreamUtils::GetStreamType(streamURL);
+      StreamType streamType = StreamUtils::GetStreamType(streamURL, m_currentChannel);
       if (streamType == StreamType::OTHER_TYPE)
         streamType = StreamUtils::InspectStreamType(streamURL);
 

--- a/src/iptvsimple/Epg.cpp
+++ b/src/iptvsimple/Epg.cpp
@@ -127,9 +127,12 @@ bool Epg::GetXMLTVFileWithRetries(std::string& data)
   int bytesRead = 0;
   int count = 0;
 
+  // Cache is only allowed if refresh mode is disabled
+  bool useEPGCache = Settings::GetInstance().GetM3URefreshMode() != RefreshMode::DISABLED ? false : Settings::GetInstance().UseEPGCache();
+
   while (count < 3) // max 3 tries
   {
-    if ((bytesRead = FileUtils::GetCachedFileContents(XMLTV_CACHE_FILENAME, m_xmltvLocation, data, Settings::GetInstance().UseEPGCache())) != 0)
+    if ((bytesRead = FileUtils::GetCachedFileContents(XMLTV_CACHE_FILENAME, m_xmltvLocation, data, useEPGCache)) != 0)
       break;
 
     Logger::Log(LEVEL_ERROR, "%s - Unable to load EPG file '%s':  file is missing or empty. :%dth try.", __FUNCTION__, m_xmltvLocation.c_str(), ++count);

--- a/src/iptvsimple/PlaylistLoader.cpp
+++ b/src/iptvsimple/PlaylistLoader.cpp
@@ -56,8 +56,11 @@ bool PlaylistLoader::LoadPlayList()
     return false;
   }
 
+  // Cache is only allowed if refresh mode is disabled
+  bool useM3UCache = Settings::GetInstance().GetM3URefreshMode() != RefreshMode::DISABLED ? false : Settings::GetInstance().UseM3UCache();
+
   std::string playlistContent;
-  if (!FileUtils::GetCachedFileContents(M3U_CACHE_FILENAME, m_m3uLocation, playlistContent, Settings::GetInstance().UseM3UCache()))
+  if (!FileUtils::GetCachedFileContents(M3U_CACHE_FILENAME, m_m3uLocation, playlistContent, useM3UCache))
   {
     Logger::Log(LEVEL_ERROR, "%s - Unable to load playlist cache file '%s':  file is missing or empty.", __FUNCTION__, m_m3uLocation.c_str());
     return false;

--- a/src/iptvsimple/utilities/StreamUtils.cpp
+++ b/src/iptvsimple/utilities/StreamUtils.cpp
@@ -46,12 +46,15 @@ void StreamUtils::SetStreamProperty(PVR_NAMED_VALUE* properties, unsigned int* p
   }
 }
 
-const StreamType StreamUtils::GetStreamType(const std::string& url)
+const StreamType StreamUtils::GetStreamType(const std::string& url, const Channel& channel)
 {
-  if (url.find(".m3u8") != std::string::npos)
+  if (url.find(".m3u8") != std::string::npos ||
+      channel.GetProperty(PVR_STREAM_PROPERTY_MIMETYPE) == "application/x-mpegURL" ||
+      channel.GetProperty(PVR_STREAM_PROPERTY_MIMETYPE) == "application/vnd.apple.mpegurl")
     return StreamType::HLS;
 
-  if (url.find(".mpd") != std::string::npos)
+  if (url.find(".mpd") != std::string::npos ||
+      channel.GetProperty(PVR_STREAM_PROPERTY_MIMETYPE) == "application/xml+dash")
     return StreamType::DASH;
 
   if (url.find(".ism") != std::string::npos &&

--- a/src/iptvsimple/utilities/StreamUtils.h
+++ b/src/iptvsimple/utilities/StreamUtils.h
@@ -45,7 +45,7 @@ namespace iptvsimple
     {
     public:
       static void SetStreamProperty(PVR_NAMED_VALUE* properties, unsigned int* propertiesCount, unsigned int propertiesMax, const std::string& name, const std::string& value);
-      static const StreamType GetStreamType(const std::string& url);
+      static const StreamType GetStreamType(const std::string& url, const iptvsimple::data::Channel& channel);
       static const StreamType InspectStreamType(const std::string& url);
       static const std::string GetManifestType(const StreamType& streamType);
       static const std::string GetMimeType(const StreamType& streamType);


### PR DESCRIPTION
v4.8.4
- Fixed: Disable caching when using refresh M3U/XMLTV modes
- Fixed: Also check channel mime type property when determining stream type
- Fixed: Correct settings levels