### PR TITLE
fix tvg-ID not accepted as an M3U tag

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="3.8.7"
+  version="3.8.8"
   name="PVR IPTV Simple Client"
   provider-name="nightik">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v3.8.8
+- Fixed: tvg-ID not accepted as an M3U tag
+
 v3.8.7
 - Fixed: Local channels logo with .jpg extension not working
 

--- a/src/PVRIptvData.cpp
+++ b/src/PVRIptvData.cpp
@@ -684,7 +684,7 @@ bool PVRIptvData::LoadPlayList(void)
         strTvgShift   = ReadMarkerValue(strInfoLine, TVG_INFO_SHIFT_MARKER);
 
         if (strTvgId.empty())
-          ReadMarkerValue(strInfoLine, TVG_INFO_ID_MARKER_UC);
+          strTvgId = ReadMarkerValue(strInfoLine, TVG_INFO_ID_MARKER_UC);
 
         if (strTvgId.empty())
         {


### PR DESCRIPTION
v3.8.8
- Fixed: tvg-ID not accepted as an M3U tag