### PR TITLE
Catchup/Archive Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,11 +22,12 @@ message(STATUS "ZLIB_LIBRARIES: ${ZLIB_LIBRARIES}")
 
 set(IPTV_SOURCES src/client.cpp
                  src/PVRIptvData.cpp
-                 src/iptvsimple/Settings.cpp
+                 src/iptvsimple/CatchupController.cpp
                  src/iptvsimple/Channels.cpp
                  src/iptvsimple/ChannelGroups.cpp
                  src/iptvsimple/Epg.cpp
                  src/iptvsimple/PlaylistLoader.cpp
+                 src/iptvsimple/Settings.cpp
                  src/iptvsimple/data/Channel.cpp
                  src/iptvsimple/data/ChannelEpg.cpp
                  src/iptvsimple/data/ChannelGroup.cpp
@@ -39,11 +40,12 @@ set(IPTV_SOURCES src/client.cpp
 
 set(IPTV_HEADERS src/client.h
                  src/PVRIptvData.h
-                 src/iptvsimple/Settings.h
+                 src/iptvsimple/CatchupController.h
                  src/iptvsimple/Channels.h
                  src/iptvsimple/ChannelGroups.h
                  src/iptvsimple/Epg.h
                  src/iptvsimple/PlaylistLoader.h
+                 src/iptvsimple/Settings.h
                  src/iptvsimple/data/Channel.h
                  src/iptvsimple/data/ChannelEpg.h
                  src/iptvsimple/data/ChannelGroup.h

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ For settings related to genres please see the next section.
 * **XMLTV path**: If location is `Local Path` this setting should contain a valid path.
 * **XMLTV URL**: If location is `Remote Path` this setting should contain a valid URL.
 * **Cache XMLTV at local storage**: If location is `Remote path` select whether or not the the XMLTV file should be cached locally.
-* **EPG time shift**: Adjust the EPG times by this value in minutes, range is from -720 mins to +840 mins (- 12 hours to +14 hours).
+* **EPG time shift**: Adjust the EPG times by this value, from -12 hours to +14 hours.
 * **Apply time shift to all channels**: Whether or not to override the time shift for all channels with `EPG time shift`. If not enabled `EPG time shift` plus the individual time shift per channel (if available) will be used.
 
 ### Genres

--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="4.8.5"
+  version="4.9.0"
   name="PVR IPTV Simple Client"
   provider-name="nightik">
   <requires>@ADDON_DEPENDS@</requires>
@@ -159,6 +159,15 @@
     <disclaimer lang="zh_TW">這是測試中的軟體！原創作者無法針對以下情況負責：包括播放失敗，不正確的電子節目表，多餘的時數，或任何不可預期的不良影響。</disclaimer>
     <platform>@PLATFORM@</platform>
     <news>
+v4.9.0
+- Added: Catchup support (a.k.a Archive)
+- Added: Missing check for HLS stream type
+- Update: Readme
+- Fixed: strings.po comments
+
+v4.8.5
+- Update: Transifix language files
+
 v4.8.4
 - Fixed: Disable caching when using refresh M3U/XMLTV modes
 - Fixed: Also check channel mime type property when determinig stream type

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,12 @@
+v4.9.0
+- Added: Catchup support (a.k.a Archive)
+- Added: Missing check for HLS stream type
+- Update: Readme
+- Fixed: strings.po comments
+
+v4.8.5
+- Update: Transifix language files
+
 v4.8.4
 - Fixed: Disable caching when using refresh M3U/XMLTV modes
 - Fixed: Also check channel mime type property when determinig stream type

--- a/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
@@ -259,7 +259,60 @@ msgctxt "#30067"
 msgid "Use FFMpeg http reconnect options if possible"
 msgstr ""
 
-#empty strings from id 30068 to 30599
+#empty strings from id 30068 to 30099
+
+#label-category: catchup
+#label-group: Catchup - Catchup
+msgctxt "#30100"
+msgid "Catchup"
+msgstr ""
+
+#label: Catchup - enableCatchup
+msgctxt "#30101"
+msgid "Enable catchup"
+msgstr ""
+
+#label: Catchup - catchupQueryFormat
+msgctxt "#30102"
+msgid "Query format string"
+msgstr ""
+
+#label: Catchup - catchupDays
+msgctxt "#30103"
+msgid "Catchup window"
+msgstr ""
+
+#label: Catchup - allChannelsSupportCatchup
+msgctxt "#30104"
+msgid "All channels support catchup"
+msgstr ""
+
+#label-group: Catchup - Watch From EPG
+msgctxt "#30105"
+msgid "Watch From EPG"
+msgstr ""
+
+#label: Catchup - catchupPlayEpgAsLive
+msgctxt "#30106"
+msgid "Play from EPG in Live TV mode (using timeshift)"
+msgstr ""
+
+#label: Catchup - catchupWatchEpgBeginBuffer
+msgctxt "#30107"
+msgid "Buffer before program start"
+msgstr ""
+
+#label: Catchup - catchupWatchEpgEndBuffer
+msgctxt "#30108"
+msgid "Buffer after program end"
+msgstr ""
+
+#label: Catchup - catchupOnlyOnFinishedProgrammes
+msgctxt "#30109"
+msgid "Catchup only available on finished programmes"
+msgstr ""
+
+#empty strings from id 30110 to 30599
 
 #############
 # help info #
@@ -445,5 +498,54 @@ msgstr ""
 
 #help: Advanced - useFFmpegReconnect
 msgctxt "#30685"
-msgid "Note this can only apply to http/https streams that are processed by libavformat (e.g. M3u8/HLS). Using libavformat can be specified in an M3U file by setting the property `inputstreamclass` as `inputstream.ffmpeg`. I.e. adding the line: `#KODIPROP:inputstreamclass=inputstream.ffmpeg`. If this opton is not enabled it can still be enabled per stream/channel by adding a kodi property, i.e.: `#KODIPROP:http-reconnect=true`."
+msgid "Note this can only apply to http/https streams that are processed by libavformat (e.g. M3u8/HLS). Using libavformat can be specified in an M3U file by setting the property `inputstreamclass` as `inputstream.ffmpeg` for kodi's internal implementation or `inputstream.ffmpegdirect` for addon version. I.e. adding the line: `#KODIPROP:inputstreamclass=inputstream.ffmpeg`. If this option is not enabled it can still be enabled per stream/channel by adding a kodi property, i.e.: `#KODIPROP:http-reconnect=true`."
+msgstr ""
+
+#empty strings from id 30686 to 30699
+
+#help info - Catchup
+
+#help-category: Catchup
+msgctxt "#30700"
+msgid "Catchup settings for viewing archived live programmes. Allows the option of 'Play programme' when viewing EPG entry info."
+msgstr ""
+
+#help: Catchup - enableCatchup
+msgctxt "#30701"
+msgid "Should be enabled if there are channels supporting catchup in your M3U list."
+msgstr ""
+
+#help: Catchup - catchupQueryFormat
+msgctxt "#30702"
+msgid "A query format string (provider dependent) allowing timestamp information to be appended to a URL to denote when to catchup from. E.g. `&cutv={Y}-{m}-{d}T{H}:{M}:{S}`, which allows year, month, day, hour minute and second to be inserted to give: `&cutv=2019-11-26T22:00:32`. If the M3U entry using has a catchup mode of 'default' or 'append' and a 'catchup-source' tag is provided in the M3U entry this setting will be ignored."
+msgstr ""
+
+#help: Catchup - catchupDays
+msgctxt "#30703"
+msgid "A number of days into the past in which it is possible to catchup on a programme. Can be overidden in an M3U entry using a 'catchup-days' tag."
+msgstr ""
+
+#help: Catchup - allChannelsSupportCatchup
+msgctxt "#30704"
+msgid "If enabled it is assumed that all channels support catchup. If there are no catchup specific tags in the M3U entries then the stream URL will be used as the source, and the 'Query format string' and 'Catchup window' number of days will come from the addon settings. If this option is disabled then a M3U entry must have at least a 'catchup=\"default\"' or 'catchup=\"append\"' tag to enable catchup."
+msgstr ""
+
+#help: Catchup - catchupPlayEpgAsLive
+msgctxt "#30705"
+msgid "When disabled any catchup programme from the past will be played like a video (bounded by start and end times). If enabled, it will instead act like a live stream with timeshift, also allowing the ability to skip back and forward programmes."
+msgstr ""
+
+#help: Catchup - catchupWatchEpgBeginBuffer
+msgctxt "#30706"
+msgid "The amount of buffer to give before the playback start point of an EPG entry that will be watched as a video."
+msgstr ""
+
+#help: Catchup - catchupWatchEpgEndBuffer
+msgctxt "#30707"
+msgid "The amount of buffer to give after the playback end point of an EPG entry that will be watched as a video."
+msgstr ""
+
+#help: Catchup - catchupOnlyOnFinishedProgrammes
+msgctxt "#30708"
+msgid "When selected from the EPG the current live programme cannot be watched as catchup until finished."
 msgstr ""

--- a/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
@@ -18,335 +18,432 @@ msgstr ""
 
 #settings labels
 
+#label: General - m3uPathType
+#label: EPG Settings - epgPathType
+#label: Channel Logos - logoPathType
 msgctxt "#30000"
 msgid "Location"
 msgstr ""
 
+#label-option: General - m3uPathType
+#label-option: General - epgPathType
+#label-option: General - logoPathType
+#label-option: General - genresPathType
 msgctxt "#30001"
 msgid "Local path (include local network)"
 msgstr ""
 
+#label-option: General - m3uPathType
+#label-option: General - epgPathType
+#label-option: General - logoPathType
+#label-option: General - genresPathType
 msgctxt "#30002"
 msgid "Remote path (Internet address)"
 msgstr ""
 
+#label-option: General - m3uRefreshMode
 msgctxt "#30003"
 msgid "Disabled"
 msgstr ""
 
+#label-option: General - m3uRefreshMode
 msgctxt "#30004"
 msgid "Repeated refresh"
 msgstr ""
 
+#label-option: General - m3uRefreshMode
 msgctxt "#30005"
 msgid "Once per day"
 msgstr ""
 
 #empty strings from id 30006 to 30009
 
+#label-category: general
+#label-group: General - General
 msgctxt "#30010"
 msgid "General"
 msgstr ""
 
+#label: General - m3uPath
 msgctxt "#30011"
 msgid "M3U playlist path"
 msgstr ""
 
+#label: General - m3uUrl
 msgctxt "#30012"
 msgid "M3U playlist URL"
 msgstr ""
 
+#label: General - startNum
 msgctxt "#30013"
 msgid "Start channel number"
 msgstr ""
 
+#label: General - numberByOrder
 msgctxt "#30014"
 msgid "Only number by channel order in M3U"
 msgstr ""
 
+#label: General - m3uRefreshMode
 msgctxt "#30015"
 msgid "Auto refresh mode"
 msgstr ""
 
+#label: General - m3uRefreshIntervalMins
 msgctxt "#30016"
 msgid "Refresh interval"
 msgstr ""
 
+#label: General - m3uRefreshHour
 msgctxt "#30017"
 msgid "Refresh hour (24h)"
 msgstr ""
 
+#label-group: General - Refresh
 msgctxt "#30018"
 msgid "Refresh"
 msgstr ""
 
+#label-category: epgsettings
 msgctxt "#30019"
 msgid "EPG Settings"
 msgstr ""
 
+#label-group: EPG Settings - EPG Settings
 msgctxt "#30020"
 msgid "EPG"
 msgstr ""
 
+#label: EPG Settings - epgPath
 msgctxt "#30021"
 msgid "XMLTV path"
 msgstr ""
 
+#label: EPG Settings - epgUrl
 msgctxt "#30022"
 msgid "XMLTV URL"
 msgstr ""
 
+#label: EPG Settings - epgTSOverride
 msgctxt "#30023"
 msgid "Apply time shift to all channels"
 msgstr ""
 
+#label: EPG Settings - epgTimeShift
 msgctxt "#30024"
 msgid "EPG time shift"
 msgstr ""
 
+#label: General - m3uCache
 msgctxt "#30025"
 msgid "Cache m3u at local storage"
 msgstr ""
 
+#label: EPG Settings - epgCache
 msgctxt "#30026"
 msgid "Cache XMLTV at local storage"
 msgstr ""
 
+#format-label: EPG Settings - epgTimeShift
 msgctxt "#30027"
 msgid "{0:.1f} hours"
 msgstr ""
 
 #empty strings from id 30028 to 30029
 
+#label-category: channellogos
+#label-group: Channel Logos - Channel Logos
 msgctxt "#30030"
 msgid "Channel Logos"
 msgstr ""
 
+#label: Channel Logos - logoPath
 msgctxt "#30031"
 msgid "Channel logos folder"
 msgstr ""
 
+#label: Channel Logos - logoBaseUrl
 msgctxt "#30032"
 msgid "Channel logos base URL"
 msgstr ""
 
 #empty strings from id 30033 to 30039
 
+#label-group: Channel Logos - XMLTV Logos Options
 msgctxt "#30040"
 msgid "XMLTV Logos Options"
 msgstr ""
 
+#label: Channel Logos - logoFromEpg
 msgctxt "#30041"
 msgid "Channels logos from XMLTV"
 msgstr ""
 
+#label-option: Channel Logos - logoFromEpg
 msgctxt "#30042"
 msgid "Ignore"
 msgstr ""
 
+#label-option: Channel Logos - logoFromEpg
 msgctxt "#30043"
 msgid "Prefer M3U"
 msgstr ""
 
+#label-option: Channel Logos - logoFromEpg
 msgctxt "#30044"
 msgid "Prefer XMLTV"
 msgstr ""
 
 #empty strings from id 30045 to 30049
 
+#label-category: genres
+#label-group: Genres - Genres
 msgctxt "#30050"
 msgid "Genres"
 msgstr ""
 
+#label: Genres - useEpgGenreText
 msgctxt "#30051"
 msgid "Use genre text from XMLTV when mapping genres"
 msgstr ""
 
+#label: Genres - genresPath
 msgctxt "#30052"
 msgid "Genres path"
 msgstr ""
 
+#label: Genres - genresUrl
 msgctxt "#30053"
 msgid "Genres URL"
 msgstr ""
 
 #empty strings from id 30054 to 30059
 
+#label-category: advanced
 msgctxt "#30060"
 msgid "Advanced"
 msgstr ""
 
+#label-group: Advanced - Multicast relay
 msgctxt "#30061"
 msgid "Multicast relay (udpxy)"
 msgstr ""
 
+#label: Advanced - transformMulticastStreamUrls
 msgctxt "#30062"
 msgid "Transform multicast stream URLs"
 msgstr ""
 
+#label: Advanced - udpxyHost
 msgctxt "#30063"
 msgid "Relay hostname or IP address"
 msgstr ""
 
+#label: Advanced - udpxyPort
 msgctxt "#30064"
 msgid "Relay port"
 msgstr ""
 
+#label-group: Advanced - Streaming
 msgctxt "#30065"
 msgid "Streaming"
 msgstr ""
 
+#label: Advanced - useInputstreamAdaptiveforHls
 msgctxt "#30066"
 msgid "Use inputstream.adaptive for m3u8 (HLS) streams"
 msgstr ""
 
+#label: Advanced - useFFmpegReconnect
 msgctxt "#30067"
 msgid "Use FFMpeg http reconnect options if possible"
 msgstr ""
 
 #empty strings from id 30068 to 30599
+
+#############
+# help info #
+#############
+
 #help info - General
 
+#help-category: General
 msgctxt "#30600"
 msgid "General settings required for the addon to function."
 msgstr ""
 
+#help: General - m3uPathType
 msgctxt "#30601"
 msgid "Select where to find the M3U resource. The options are: [Local path] - A path to an M3U file whether it be on the device or the local network; [Remote path] - A URL specifying the location of the M3U file."
 msgstr ""
 
+#help: General - m3uPath
 msgctxt "#30602"
 msgid "If location is [Local path] this setting must contain a valid path for the addon to function."
 msgstr ""
 
+#help: General - m3uUrl
 msgctxt "#30603"
 msgid "If location is [Remote path] this setting must contain a valid URL for the addon to function."
 msgstr ""
 
+#help: General - m3uCache
 msgctxt "#30604"
 msgid "If location is [Remote path] select whether or not the the M3U file should be cached locally."
 msgstr ""
 
+#help: General - startNum
 msgctxt "#30605"
 msgid "The number to start numbering channels from. Only used when [Use backend channel numbers] from PVR settings is enabled and a channel number is not supplied in the M3U file."
 msgstr ""
 
+#help: General - numberByOrder
 msgctxt "#30606"
 msgid "Ignore any 'tvg-chno' tags and only number channels by the order in the M3U starting at 'Start channel number'."
 msgstr ""
 
+#help: General - m3uRefreshMode
 msgctxt "#30607"
 msgid "Select the auto refresh mode for the M3U/XMLTV files. Note that caching is disabled if auto refresh is used. The options are: [Disabled] - Don't auto refresh the files; [Repeated refresh] - Refresh the files on a minute based interval; [Once per day] - Refresh the files once per day."
 msgstr ""
 
+#help: General - m3uRefreshIntervalMins
 msgctxt "#30608"
 msgid "If M3U auto refresh mode is [Repeated refresh] refresh the files every time this number of minutes passes. Max 120 minutes."
 msgstr ""
 
+#help: General - m3uRefreshHour
 msgctxt "#30609"
 msgid "If auto refresh mode is [Once per day] refresh the files every time this hour of the day is reached"
 msgstr ""
 
 #empty strings from id 30610 to 30619
+
 #help info - EPG Settings
 
+#help-category: EPG Settings
 msgctxt "#30620"
 msgid "Settings related to the EPG."
 msgstr ""
 
+#help: EPG Settings - epgPathType
 msgctxt "#30621"
 msgid "Select where to find the XMLTV resource. The options are: [Local path] - A path to an XMLTV file whether it be on the device or the local network; [Remote path] - A URL specifying the location of the XMLTV file."
 msgstr ""
 
+#help: EPG Settings - epgPath
 msgctxt "#30622"
 msgid "If location is [Local Path] this setting should contain a valid path."
 msgstr ""
 
+#help: EPG Settings - epgUrl
 msgctxt "#30623"
 msgid "If location is [Remote Path] this setting should contain a valid URL."
 msgstr ""
 
+#help: EPG Settings - epgCache
 msgctxt "#30624"
 msgid "If location is [Remote path] select whether or not the the XMLTV file should be cached locally."
 msgstr ""
 
+#help: EPG Settings - epgTimeShift
 msgctxt "#30625"
 msgid "Adjust the EPG times by this value in minutes, range is from -720 mins to +840 mins (- 12 hours to +14 hours)."
 msgstr ""
 
+#help: EPG Settings - epgTSOverside
 msgctxt "#30626"
 msgid "Whether or not to override the time shift for all channels with `EPG time shift`. If not enabled `EPG time shift` plus the individual time shift per channel (if available) will be used."
 msgstr ""
 
 #empty strings from id 30627 to 30639
+
 #help info - Channel Logos
 
+#help-category: Channel Logos
 msgctxt "#30640"
 msgid "Settings related to Channel Logos."
 msgstr ""
 
+#help: Channel Logos - logoPathType
 msgctxt "#30641"
 msgid "Select where to find the channel logos. The options are: [Local path] - A path to a folder whether it be on the device or the local network; [Remote path] - A base URL specifying the location of the logos."
 msgstr ""
 
+#help: Channel Logos - logo Path
 msgctxt "#30642"
 msgid "If location is [Local Path] this setting should contain a valid folder."
 msgstr ""
 
+#help: Channel Logos - logoBaseUrl
 msgctxt "#30643"
 msgid "If location is [Remote Path] this setting should contain a valid base URL."
 msgstr ""
 
+#help: Channel Logos - logoFromEpg
 msgctxt "#30644"
 msgid "Preference on how to handle channel logos. The options are: [Ignore] - Don't use channel logos from an XMLTV file; [Prefer M3U] - Use the channel logo from the M3U if available otherwise use the XMLTV logo; [Prefer XMLTV] - Use the channel logo from the XMLTV file if available otherwise use the M3U logo."
 msgstr ""
 
 #empty strings from id 30645 to 30659
+
 #help info - Genres
 
+#help-category: Genres
 msgctxt "#30660"
 msgid "Settings related to genres."
 msgstr ""
 
+#help: Genres - useEpgGenreText
 msgctxt "#30661"
 msgid "If enabled, and a genre mapping file is used to get a genre type and sub type use the EPG's genre text (i.e. 'category' text) for the genre instead of the kodi default text."
 msgstr ""
 
+#help: Genres - genresPathType
 msgctxt "#30662"
 msgid "Select where to find the genres XML resource. The options are: [Local path] - A path to a genres XML file whether it be on the device or the local network; [Remote path] - A URL specifying the location of the genres XML file."
 msgstr ""
 
+#help: Genres - genresPath
 msgctxt "#30663"
 msgid "If location is [Local Path] this setting should contain a valid path."
 msgstr ""
 
+#help: Genres - genresUrl
 msgctxt "#30664"
 msgid "If location is [Remote Path] this setting should contain a valid URL."
 msgstr ""
 
 #empty strings from id 30665 to 30679
+
 #help info - Advanced
 
+#help-category: Advanced
 msgctxt "#30680"
 msgid "Advanced settings including multicast relays, streaming properties etc."
 msgstr ""
 
+#help: Advanced - transformMulticastStreamUrls
 msgctxt "#30681"
 msgid "Multicast (UDP/RTP) streams do not work well on Wifi networks. A multicast relay can convert the stream from UDP/RTP multicast to HTTP. Enabling this option will transform multicast stream URLs from the M3U file to HTTP addresses so they can be accesssed via a 'udpxy' relay on the local network. E.g. a UDP multicast stream URL like 'udp://@239.239.3.38:5239' would get transformed to something like 'http://192.168.1.1:4000/udp/239.239.3.38:5239'."
 msgstr ""
 
+#help: Advanced - udpxyHost
 msgctxt "#30682"
 msgid "The hostname or ip address of the multicast relay (udpxy) on the local network."
 msgstr ""
 
+#help: Advanced - udpxyPort
 msgctxt "#30683"
 msgid "The port of the multicast relay (udpxy) on the local network."
 msgstr ""
 
+#help: Advanced - useInputstreamAdaptiveforHls
 msgctxt "#30684"
 msgid "Use inputstream.adaptive instead of ffmpeg's libavformat for m3u8 (HLS) streams."
 msgstr ""
 
+#help: Advanced - useFFmpegReconnect
 msgctxt "#30685"
 msgid "Note this can only apply to http/https streams that are processed by libavformat (e.g. M3u8/HLS). Using libavformat can be specified in an M3U file by setting the property `inputstreamclass` as `inputstream.ffmpeg`. I.e. adding the line: `#KODIPROP:inputstreamclass=inputstream.ffmpeg`. If this opton is not enabled it can still be enabled per stream/channel by adding a kodi property, i.e.: `#KODIPROP:http-reconnect=true`."
 msgstr ""

--- a/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
@@ -16,536 +16,536 @@ msgstr ""
 "Language: en_GB\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#settings labels
+#. settings labels
 
-#label: General - m3uPathType
-#label: EPG Settings - epgPathType
-#label: Channel Logos - logoPathType
+#. label: General - m3uPathType
+#. label: EPG Settings - epgPathType
+#. label: Channel Logos - logoPathType
 msgctxt "#30000"
 msgid "Location"
 msgstr ""
 
-#label-option: General - m3uPathType
-#label-option: General - epgPathType
-#label-option: General - logoPathType
-#label-option: General - genresPathType
+#. label-option: General - m3uPathType
+#. label-option: General - epgPathType
+#. label-option: General - logoPathType
+#. label-option: General - genresPathType
 msgctxt "#30001"
 msgid "Local path (include local network)"
 msgstr ""
 
-#label-option: General - m3uPathType
-#label-option: General - epgPathType
-#label-option: General - logoPathType
-#label-option: General - genresPathType
+#. label-option: General - m3uPathType
+#. label-option: General - epgPathType
+#. label-option: General - logoPathType
+#. label-option: General - genresPathType
 msgctxt "#30002"
 msgid "Remote path (Internet address)"
 msgstr ""
 
-#label-option: General - m3uRefreshMode
+#. label-option: General - m3uRefreshMode
 msgctxt "#30003"
 msgid "Disabled"
 msgstr ""
 
-#label-option: General - m3uRefreshMode
+#. label-option: General - m3uRefreshMode
 msgctxt "#30004"
 msgid "Repeated refresh"
 msgstr ""
 
-#label-option: General - m3uRefreshMode
+#. label-option: General - m3uRefreshMode
 msgctxt "#30005"
 msgid "Once per day"
 msgstr ""
 
 #empty strings from id 30006 to 30009
 
-#label-category: general
-#label-group: General - General
+#. label-category: general
+#. label-group: General - General
 msgctxt "#30010"
 msgid "General"
 msgstr ""
 
-#label: General - m3uPath
+#. label: General - m3uPath
 msgctxt "#30011"
 msgid "M3U playlist path"
 msgstr ""
 
-#label: General - m3uUrl
+#. label: General - m3uUrl
 msgctxt "#30012"
 msgid "M3U playlist URL"
 msgstr ""
 
-#label: General - startNum
+#. label: General - startNum
 msgctxt "#30013"
 msgid "Start channel number"
 msgstr ""
 
-#label: General - numberByOrder
+#. label: General - numberByOrder
 msgctxt "#30014"
 msgid "Only number by channel order in M3U"
 msgstr ""
 
-#label: General - m3uRefreshMode
+#. label: General - m3uRefreshMode
 msgctxt "#30015"
 msgid "Auto refresh mode"
 msgstr ""
 
-#label: General - m3uRefreshIntervalMins
+#. label: General - m3uRefreshIntervalMins
 msgctxt "#30016"
 msgid "Refresh interval"
 msgstr ""
 
-#label: General - m3uRefreshHour
+#. label: General - m3uRefreshHour
 msgctxt "#30017"
 msgid "Refresh hour (24h)"
 msgstr ""
 
-#label-group: General - Refresh
+#. label-group: General - Refresh
 msgctxt "#30018"
 msgid "Refresh"
 msgstr ""
 
-#label-category: epgsettings
+#. label-category: epgsettings
 msgctxt "#30019"
 msgid "EPG Settings"
 msgstr ""
 
-#label-group: EPG Settings - EPG Settings
+#. label-group: EPG Settings - EPG Settings
 msgctxt "#30020"
 msgid "EPG"
 msgstr ""
 
-#label: EPG Settings - epgPath
+#. label: EPG Settings - epgPath
 msgctxt "#30021"
 msgid "XMLTV path"
 msgstr ""
 
-#label: EPG Settings - epgUrl
+#. label: EPG Settings - epgUrl
 msgctxt "#30022"
 msgid "XMLTV URL"
 msgstr ""
 
-#label: EPG Settings - epgTSOverride
+#. label: EPG Settings - epgTSOverride
 msgctxt "#30023"
 msgid "Apply time shift to all channels"
 msgstr ""
 
-#label: EPG Settings - epgTimeShift
+#. label: EPG Settings - epgTimeShift
 msgctxt "#30024"
 msgid "EPG time shift"
 msgstr ""
 
-#label: General - m3uCache
+#. label: General - m3uCache
 msgctxt "#30025"
 msgid "Cache m3u at local storage"
 msgstr ""
 
-#label: EPG Settings - epgCache
+#. label: EPG Settings - epgCache
 msgctxt "#30026"
 msgid "Cache XMLTV at local storage"
 msgstr ""
 
-#format-label: EPG Settings - epgTimeShift
+#. format-label: EPG Settings - epgTimeShift
 msgctxt "#30027"
 msgid "{0:.1f} hours"
 msgstr ""
 
 #empty strings from id 30028 to 30029
 
-#label-category: channellogos
-#label-group: Channel Logos - Channel Logos
+#. label-category: channellogos
+#. label-group: Channel Logos - Channel Logos
 msgctxt "#30030"
 msgid "Channel Logos"
 msgstr ""
 
-#label: Channel Logos - logoPath
+#. label: Channel Logos - logoPath
 msgctxt "#30031"
 msgid "Channel logos folder"
 msgstr ""
 
-#label: Channel Logos - logoBaseUrl
+#. label: Channel Logos - logoBaseUrl
 msgctxt "#30032"
 msgid "Channel logos base URL"
 msgstr ""
 
 #empty strings from id 30033 to 30039
 
-#label-group: Channel Logos - XMLTV Logos Options
+#. label-group: Channel Logos - XMLTV Logos Options
 msgctxt "#30040"
 msgid "XMLTV Logos Options"
 msgstr ""
 
-#label: Channel Logos - logoFromEpg
+#. label: Channel Logos - logoFromEpg
 msgctxt "#30041"
 msgid "Channels logos from XMLTV"
 msgstr ""
 
-#label-option: Channel Logos - logoFromEpg
+#. label-option: Channel Logos - logoFromEpg
 msgctxt "#30042"
 msgid "Ignore"
 msgstr ""
 
-#label-option: Channel Logos - logoFromEpg
+#. label-option: Channel Logos - logoFromEpg
 msgctxt "#30043"
 msgid "Prefer M3U"
 msgstr ""
 
-#label-option: Channel Logos - logoFromEpg
+#. label-option: Channel Logos - logoFromEpg
 msgctxt "#30044"
 msgid "Prefer XMLTV"
 msgstr ""
 
 #empty strings from id 30045 to 30049
 
-#label-category: genres
-#label-group: Genres - Genres
+#. label-category: genres
+#. label-group: Genres - Genres
 msgctxt "#30050"
 msgid "Genres"
 msgstr ""
 
-#label: Genres - useEpgGenreText
+#. label: Genres - useEpgGenreText
 msgctxt "#30051"
 msgid "Use genre text from XMLTV when mapping genres"
 msgstr ""
 
-#label: Genres - genresPath
+#. label: Genres - genresPath
 msgctxt "#30052"
 msgid "Genres path"
 msgstr ""
 
-#label: Genres - genresUrl
+#. label: Genres - genresUrl
 msgctxt "#30053"
 msgid "Genres URL"
 msgstr ""
 
 #empty strings from id 30054 to 30059
 
-#label-category: advanced
+#. label-category: advanced
 msgctxt "#30060"
 msgid "Advanced"
 msgstr ""
 
-#label-group: Advanced - Multicast relay
+#. label-group: Advanced - Multicast relay
 msgctxt "#30061"
 msgid "Multicast relay (udpxy)"
 msgstr ""
 
-#label: Advanced - transformMulticastStreamUrls
+#. label: Advanced - transformMulticastStreamUrls
 msgctxt "#30062"
 msgid "Transform multicast stream URLs"
 msgstr ""
 
-#label: Advanced - udpxyHost
+#. label: Advanced - udpxyHost
 msgctxt "#30063"
 msgid "Relay hostname or IP address"
 msgstr ""
 
-#label: Advanced - udpxyPort
+#. label: Advanced - udpxyPort
 msgctxt "#30064"
 msgid "Relay port"
 msgstr ""
 
-#label-group: Advanced - Streaming
+#. label-group: Advanced - Streaming
 msgctxt "#30065"
 msgid "Streaming"
 msgstr ""
 
-#label: Advanced - useInputstreamAdaptiveforHls
+#. label: Advanced - useInputstreamAdaptiveforHls
 msgctxt "#30066"
 msgid "Use inputstream.adaptive for m3u8 (HLS) streams"
 msgstr ""
 
-#label: Advanced - useFFmpegReconnect
+#. label: Advanced - useFFmpegReconnect
 msgctxt "#30067"
 msgid "Use FFMpeg http reconnect options if possible"
 msgstr ""
 
 #empty strings from id 30068 to 30099
 
-#label-category: catchup
-#label-group: Catchup - Catchup
+#. label-category: catchup
+#. label-group: Catchup - Catchup
 msgctxt "#30100"
 msgid "Catchup"
 msgstr ""
 
-#label: Catchup - enableCatchup
+#. label: Catchup - enableCatchup
 msgctxt "#30101"
 msgid "Enable catchup"
 msgstr ""
 
-#label: Catchup - catchupQueryFormat
+#. label: Catchup - catchupQueryFormat
 msgctxt "#30102"
 msgid "Query format string"
 msgstr ""
 
-#label: Catchup - catchupDays
+#. label: Catchup - catchupDays
 msgctxt "#30103"
 msgid "Catchup window"
 msgstr ""
 
-#label: Catchup - allChannelsSupportCatchup
+#. label: Catchup - allChannelsSupportCatchup
 msgctxt "#30104"
 msgid "All channels support catchup"
 msgstr ""
 
-#label-group: Catchup - Watch From EPG
+#. label-group: Catchup - Watch From EPG
 msgctxt "#30105"
 msgid "Watch From EPG"
 msgstr ""
 
-#label: Catchup - catchupPlayEpgAsLive
+#. label: Catchup - catchupPlayEpgAsLive
 msgctxt "#30106"
 msgid "Play from EPG in Live TV mode (using timeshift)"
 msgstr ""
 
-#label: Catchup - catchupWatchEpgBeginBuffer
+#. label: Catchup - catchupWatchEpgBeginBuffer
 msgctxt "#30107"
 msgid "Buffer before program start"
 msgstr ""
 
-#label: Catchup - catchupWatchEpgEndBuffer
+#. label: Catchup - catchupWatchEpgEndBuffer
 msgctxt "#30108"
 msgid "Buffer after program end"
 msgstr ""
 
-#label: Catchup - catchupOnlyOnFinishedProgrammes
+#. label: Catchup - catchupOnlyOnFinishedProgrammes
 msgctxt "#30109"
 msgid "Catchup only available on finished programmes"
 msgstr ""
 
 #empty strings from id 30110 to 30599
 
-#############
-# help info #
-#############
+#. ############
+#. help info #
+#. ############
 
-#help info - General
+#. help info - General
 
-#help-category: General
+#. help-category: General
 msgctxt "#30600"
 msgid "General settings required for the addon to function."
 msgstr ""
 
-#help: General - m3uPathType
+#. help: General - m3uPathType
 msgctxt "#30601"
 msgid "Select where to find the M3U resource. The options are: [Local path] - A path to an M3U file whether it be on the device or the local network; [Remote path] - A URL specifying the location of the M3U file."
 msgstr ""
 
-#help: General - m3uPath
+#. help: General - m3uPath
 msgctxt "#30602"
 msgid "If location is [Local path] this setting must contain a valid path for the addon to function."
 msgstr ""
 
-#help: General - m3uUrl
+#. help: General - m3uUrl
 msgctxt "#30603"
 msgid "If location is [Remote path] this setting must contain a valid URL for the addon to function."
 msgstr ""
 
-#help: General - m3uCache
+#. help: General - m3uCache
 msgctxt "#30604"
 msgid "If location is [Remote path] select whether or not the the M3U file should be cached locally."
 msgstr ""
 
-#help: General - startNum
+#. help: General - startNum
 msgctxt "#30605"
 msgid "The number to start numbering channels from. Only used when [Use backend channel numbers] from PVR settings is enabled and a channel number is not supplied in the M3U file."
 msgstr ""
 
-#help: General - numberByOrder
+#. help: General - numberByOrder
 msgctxt "#30606"
 msgid "Ignore any 'tvg-chno' tags and only number channels by the order in the M3U starting at 'Start channel number'."
 msgstr ""
 
-#help: General - m3uRefreshMode
+#. help: General - m3uRefreshMode
 msgctxt "#30607"
 msgid "Select the auto refresh mode for the M3U/XMLTV files. Note that caching is disabled if auto refresh is used. The options are: [Disabled] - Don't auto refresh the files; [Repeated refresh] - Refresh the files on a minute based interval; [Once per day] - Refresh the files once per day."
 msgstr ""
 
-#help: General - m3uRefreshIntervalMins
+#. help: General - m3uRefreshIntervalMins
 msgctxt "#30608"
 msgid "If M3U auto refresh mode is [Repeated refresh] refresh the files every time this number of minutes passes. Max 120 minutes."
 msgstr ""
 
-#help: General - m3uRefreshHour
+#. help: General - m3uRefreshHour
 msgctxt "#30609"
 msgid "If auto refresh mode is [Once per day] refresh the files every time this hour of the day is reached"
 msgstr ""
 
 #empty strings from id 30610 to 30619
 
-#help info - EPG Settings
+#. help info - EPG Settings
 
-#help-category: EPG Settings
+#. help-category: EPG Settings
 msgctxt "#30620"
 msgid "Settings related to the EPG."
 msgstr ""
 
-#help: EPG Settings - epgPathType
+#. help: EPG Settings - epgPathType
 msgctxt "#30621"
 msgid "Select where to find the XMLTV resource. The options are: [Local path] - A path to an XMLTV file whether it be on the device or the local network; [Remote path] - A URL specifying the location of the XMLTV file."
 msgstr ""
 
-#help: EPG Settings - epgPath
+#. help: EPG Settings - epgPath
 msgctxt "#30622"
 msgid "If location is [Local Path] this setting should contain a valid path."
 msgstr ""
 
-#help: EPG Settings - epgUrl
+#. help: EPG Settings - epgUrl
 msgctxt "#30623"
 msgid "If location is [Remote Path] this setting should contain a valid URL."
 msgstr ""
 
-#help: EPG Settings - epgCache
+#. help: EPG Settings - epgCache
 msgctxt "#30624"
 msgid "If location is [Remote path] select whether or not the the XMLTV file should be cached locally."
 msgstr ""
 
-#help: EPG Settings - epgTimeShift
+#. help: EPG Settings - epgTimeShift
 msgctxt "#30625"
 msgid "Adjust the EPG times by this value in minutes, range is from -720 mins to +840 mins (- 12 hours to +14 hours)."
 msgstr ""
 
-#help: EPG Settings - epgTSOverside
+#. help: EPG Settings - epgTSOverside
 msgctxt "#30626"
 msgid "Whether or not to override the time shift for all channels with `EPG time shift`. If not enabled `EPG time shift` plus the individual time shift per channel (if available) will be used."
 msgstr ""
 
 #empty strings from id 30627 to 30639
 
-#help info - Channel Logos
+#. help info - Channel Logos
 
-#help-category: Channel Logos
+#. help-category: Channel Logos
 msgctxt "#30640"
 msgid "Settings related to Channel Logos."
 msgstr ""
 
-#help: Channel Logos - logoPathType
+#. help: Channel Logos - logoPathType
 msgctxt "#30641"
 msgid "Select where to find the channel logos. The options are: [Local path] - A path to a folder whether it be on the device or the local network; [Remote path] - A base URL specifying the location of the logos."
 msgstr ""
 
-#help: Channel Logos - logo Path
+#. help: Channel Logos - logo Path
 msgctxt "#30642"
 msgid "If location is [Local Path] this setting should contain a valid folder."
 msgstr ""
 
-#help: Channel Logos - logoBaseUrl
+#. help: Channel Logos - logoBaseUrl
 msgctxt "#30643"
 msgid "If location is [Remote Path] this setting should contain a valid base URL."
 msgstr ""
 
-#help: Channel Logos - logoFromEpg
+#. help: Channel Logos - logoFromEpg
 msgctxt "#30644"
 msgid "Preference on how to handle channel logos. The options are: [Ignore] - Don't use channel logos from an XMLTV file; [Prefer M3U] - Use the channel logo from the M3U if available otherwise use the XMLTV logo; [Prefer XMLTV] - Use the channel logo from the XMLTV file if available otherwise use the M3U logo."
 msgstr ""
 
 #empty strings from id 30645 to 30659
 
-#help info - Genres
+#. help info - Genres
 
-#help-category: Genres
+#. help-category: Genres
 msgctxt "#30660"
 msgid "Settings related to genres."
 msgstr ""
 
-#help: Genres - useEpgGenreText
+#. help: Genres - useEpgGenreText
 msgctxt "#30661"
 msgid "If enabled, and a genre mapping file is used to get a genre type and sub type use the EPG's genre text (i.e. 'category' text) for the genre instead of the kodi default text."
 msgstr ""
 
-#help: Genres - genresPathType
+#. help: Genres - genresPathType
 msgctxt "#30662"
 msgid "Select where to find the genres XML resource. The options are: [Local path] - A path to a genres XML file whether it be on the device or the local network; [Remote path] - A URL specifying the location of the genres XML file."
 msgstr ""
 
-#help: Genres - genresPath
+#. help: Genres - genresPath
 msgctxt "#30663"
 msgid "If location is [Local Path] this setting should contain a valid path."
 msgstr ""
 
-#help: Genres - genresUrl
+#. help: Genres - genresUrl
 msgctxt "#30664"
 msgid "If location is [Remote Path] this setting should contain a valid URL."
 msgstr ""
 
 #empty strings from id 30665 to 30679
 
-#help info - Advanced
+#. help info - Advanced
 
-#help-category: Advanced
+#. help-category: Advanced
 msgctxt "#30680"
 msgid "Advanced settings including multicast relays, streaming properties etc."
 msgstr ""
 
-#help: Advanced - transformMulticastStreamUrls
+#. help: Advanced - transformMulticastStreamUrls
 msgctxt "#30681"
 msgid "Multicast (UDP/RTP) streams do not work well on Wifi networks. A multicast relay can convert the stream from UDP/RTP multicast to HTTP. Enabling this option will transform multicast stream URLs from the M3U file to HTTP addresses so they can be accesssed via a 'udpxy' relay on the local network. E.g. a UDP multicast stream URL like 'udp://@239.239.3.38:5239' would get transformed to something like 'http://192.168.1.1:4000/udp/239.239.3.38:5239'."
 msgstr ""
 
-#help: Advanced - udpxyHost
+#. help: Advanced - udpxyHost
 msgctxt "#30682"
 msgid "The hostname or ip address of the multicast relay (udpxy) on the local network."
 msgstr ""
 
-#help: Advanced - udpxyPort
+#. help: Advanced - udpxyPort
 msgctxt "#30683"
 msgid "The port of the multicast relay (udpxy) on the local network."
 msgstr ""
 
-#help: Advanced - useInputstreamAdaptiveforHls
+#. help: Advanced - useInputstreamAdaptiveforHls
 msgctxt "#30684"
 msgid "Use inputstream.adaptive instead of ffmpeg's libavformat for m3u8 (HLS) streams."
 msgstr ""
 
-#help: Advanced - useFFmpegReconnect
+#. help: Advanced - useFFmpegReconnect
 msgctxt "#30685"
 msgid "Note this can only apply to http/https streams that are processed by libavformat (e.g. M3u8/HLS). Using libavformat can be specified in an M3U file by setting the property `inputstreamclass` as `inputstream.ffmpeg` for kodi's internal implementation or `inputstream.ffmpegdirect` for addon version. I.e. adding the line: `#KODIPROP:inputstreamclass=inputstream.ffmpeg`. If this option is not enabled it can still be enabled per stream/channel by adding a kodi property, i.e.: `#KODIPROP:http-reconnect=true`."
 msgstr ""
 
 #empty strings from id 30686 to 30699
 
-#help info - Catchup
+#. help info - Catchup
 
-#help-category: Catchup
+#. help-category: Catchup
 msgctxt "#30700"
 msgid "Catchup settings for viewing archived live programmes. Allows the option of 'Play programme' when viewing EPG entry info."
 msgstr ""
 
-#help: Catchup - enableCatchup
+#. help: Catchup - enableCatchup
 msgctxt "#30701"
 msgid "Should be enabled if there are channels supporting catchup in your M3U list."
 msgstr ""
 
-#help: Catchup - catchupQueryFormat
+#. help: Catchup - catchupQueryFormat
 msgctxt "#30702"
 msgid "A query format string (provider dependent) allowing timestamp information to be appended to a URL to denote when to catchup from. E.g. `&cutv={Y}-{m}-{d}T{H}:{M}:{S}`, which allows year, month, day, hour minute and second to be inserted to give: `&cutv=2019-11-26T22:00:32`. If the M3U entry using has a catchup mode of 'default' or 'append' and a 'catchup-source' tag is provided in the M3U entry this setting will be ignored."
 msgstr ""
 
-#help: Catchup - catchupDays
+#. help: Catchup - catchupDays
 msgctxt "#30703"
 msgid "A number of days into the past in which it is possible to catchup on a programme. Can be overidden in an M3U entry using a 'catchup-days' tag."
 msgstr ""
 
-#help: Catchup - allChannelsSupportCatchup
+#. help: Catchup - allChannelsSupportCatchup
 msgctxt "#30704"
 msgid "If enabled it is assumed that all channels support catchup. If there are no catchup specific tags in the M3U entries then the stream URL will be used as the source, and the 'Query format string' and 'Catchup window' number of days will come from the addon settings. If this option is disabled then a M3U entry must have at least a 'catchup=\"default\"' or 'catchup=\"append\"' tag to enable catchup."
 msgstr ""
 
-#help: Catchup - catchupPlayEpgAsLive
+#. help: Catchup - catchupPlayEpgAsLive
 msgctxt "#30705"
 msgid "When disabled any catchup programme from the past will be played like a video (bounded by start and end times). If enabled, it will instead act like a live stream with timeshift, also allowing the ability to skip back and forward programmes."
 msgstr ""
 
-#help: Catchup - catchupWatchEpgBeginBuffer
+#. help: Catchup - catchupWatchEpgBeginBuffer
 msgctxt "#30706"
 msgid "The amount of buffer to give before the playback start point of an EPG entry that will be watched as a video."
 msgstr ""
 
-#help: Catchup - catchupWatchEpgEndBuffer
+#. help: Catchup - catchupWatchEpgEndBuffer
 msgctxt "#30707"
 msgid "The amount of buffer to give after the playback end point of an EPG entry that will be watched as a video."
 msgstr ""
 
-#help: Catchup - catchupOnlyOnFinishedProgrammes
+#. help: Catchup - catchupOnlyOnFinishedProgrammes
 msgctxt "#30708"
 msgid "When selected from the EPG the current live programme cannot be watched as catchup until finished."
 msgstr ""

--- a/pvr.iptvsimple/resources/settings.xml
+++ b/pvr.iptvsimple/resources/settings.xml
@@ -278,6 +278,106 @@
       </group>
     </category>
 
+    <!-- Catchup -->
+    <category id="catchup" label="30100" help="30700">
+      <group id="1" label="30100">
+        <setting id="catchupEnabled" type="boolean" label="30101" help="30701">
+          <level>0</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="catchupQueryFormat" type="string" parent="catchupEnabled" label="30102" help="30702">
+          <level>0</level>
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="catchupEnabled" operator="is">true</dependency>
+          </dependencies>
+          <control type="edit" format="string" />
+        </setting>
+        <setting id="catchupDays" type="integer" parent="catchupEnabled" label="30103" help="30703">
+          <level>0</level>
+          <constraints>
+            <minimum>1</minimum>
+            <step>1</step>
+            <maximum>7</maximum>
+          </constraints>
+          <default>5</default>
+          <dependencies>
+            <dependency type="enable" setting="catchupEnabled" operator="is">true</dependency>
+          </dependencies>
+          <control type="spinner" format="string">
+            <formatlabel>17999</formatlabel>
+          </control>
+        </setting>
+        <setting id="allChannelSupportCatchup" type="boolean" parent="catchupEnabled" label="30104" help="30704">
+          <level>2</level>
+          <default>false</default>
+          <dependencies>
+            <dependency type="enable" setting="catchupEnabled" operator="is">true</dependency>
+          </dependencies>
+          <control type="toggle" />
+        </setting>
+      </group>
+      <group id="2" label="30105">
+        <setting id="catchupPlayEpgAsLive" type="boolean" label="30106" help="30705">
+          <level>0</level>
+          <default>false</default>
+          <dependencies>
+            <dependency type="enable" setting="catchupEnabled" operator="is">true</dependency>
+          </dependencies>
+          <control type="toggle" />
+        </setting>
+        <setting id="catchupWatchEpgBeginBufferMins" type="integer" parent="catchupPlayEpgAsLive" label="30107" help="30706">
+          <level>0</level>
+          <default>5</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>60</maximum>
+          </constraints>
+          <dependencies>
+            <dependency type="enable">
+              <and>
+                <condition setting="catchupEnabled" operator="is">true</condition>
+                <condition setting="catchupPlayEpgAsLive" operator="!is">true</condition>
+              </and>
+            </dependency>
+          </dependencies>
+          <control type="spinner" format="string">
+            <formatlabel>14044</formatlabel>
+          </control>
+        </setting>
+        <setting id="catchupWatchEpgEndBufferMins" type="integer" parent="catchupPlayEpgAsLive" label="30108" help="30707">
+          <level>0</level>
+          <default>15</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>60</maximum>
+          </constraints>
+          <dependencies>
+            <dependency type="enable">
+              <and>
+                <condition setting="catchupEnabled" operator="is">true</condition>
+                <condition setting="catchupPlayEpgAsLive" operator="!is">true</condition>
+              </and>
+            </dependency>
+          </dependencies>
+          <control type="spinner" format="string">
+            <formatlabel>14044</formatlabel>
+          </control>
+        </setting>
+        <setting id="catchupOnlyOnFinishedProgrammes" type="boolean" label="30109" help="30708">
+          <level>0</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+      </group>
+    </category>
+
     <!-- Advanced -->
     <category id="advanced" label="30060" help="30680">
       <group id="1" label="30061">

--- a/src/PVRIptvData.cpp
+++ b/src/PVRIptvData.cpp
@@ -136,6 +136,13 @@ bool PVRIptvData::GetChannel(const PVR_CHANNEL& channel, Channel& myChannel)
   return m_channels.GetChannel(channel, myChannel);
 }
 
+bool PVRIptvData::GetChannel(unsigned int uniqueChannelId, iptvsimple::data::Channel& myChannel)
+{
+  std::lock_guard<std::mutex> lock(m_mutex);
+
+  return m_channels.GetChannel(uniqueChannelId, myChannel);
+}
+
 int PVRIptvData::GetChannelGroupsAmount()
 {
   std::lock_guard<std::mutex> lock(m_mutex);

--- a/src/PVRIptvData.h
+++ b/src/PVRIptvData.h
@@ -23,6 +23,7 @@
  *
  */
 
+#include "iptvsimple/CatchupController.h"
 #include "iptvsimple/Channels.h"
 #include "iptvsimple/ChannelGroups.h"
 #include "iptvsimple/Epg.h"
@@ -51,6 +52,10 @@ public:
   PVR_ERROR GetEPGForChannel(ADDON_HANDLE handle, int iChannelUid, time_t iStart, time_t iEnd);
   ADDON_STATUS SetSetting(const char* settingName, const void* settingValue);
 
+  // For catchup
+  bool GetChannel(unsigned int uniqueChannelId, iptvsimple::data::Channel& myChannel);
+  iptvsimple::CatchupController& GetCatchupController() { return m_catchupController; }
+
 protected:
   void Process();
 
@@ -61,6 +66,7 @@ private:
   iptvsimple::ChannelGroups m_channelGroups{m_channels};
   iptvsimple::PlaylistLoader m_playlistLoader{m_channels, m_channelGroups};
   iptvsimple::Epg m_epg{m_channels};
+  iptvsimple::CatchupController m_catchupController{m_epg, &m_mutex};
 
   std::atomic<bool> m_running{false};
   std::thread m_thread;

--- a/src/iptvsimple/CatchupController.cpp
+++ b/src/iptvsimple/CatchupController.cpp
@@ -1,0 +1,440 @@
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "CatchupController.h"
+
+#include "../client.h"
+#include "Channels.h"
+#include "Epg.h"
+#include "Settings.h"
+#include "data/Channel.h"
+#include "utilities/Logger.h"
+
+#include <regex>
+
+#include <p8-platform/util/StringUtils.h>
+
+using namespace iptvsimple;
+using namespace iptvsimple::data;
+using namespace iptvsimple::utilities;
+
+CatchupController::CatchupController(Epg& epg, std::mutex* mutex)
+  : m_epg(epg), m_mutex(mutex) {}
+
+void CatchupController::ProcessChannelForPlayback(Channel& channel, std::map<std::string, std::string>& catchupProperties) // TODO: should be a const channel, create a StreamManager instead
+{
+  TestAndStoreStreamType(channel); // TODO: StreamManager
+
+  // Anything from here is live!
+  m_playbackIsVideo = false; // TODO: possible time jitter on UI as this will effect get stream times
+
+  if (!m_fromEpgTag || m_controlsLiveStream)
+  {
+    EpgEntry* liveEpgEntry = GetLiveEPGEntry(channel);
+    if (liveEpgEntry && !Settings::GetInstance().CatchupOnlyOnFinishedProgrammes())
+    {
+      // Live with EPG entry
+      UpdateProgrammeFrom(*liveEpgEntry, channel.GetTvgShift());
+      m_catchupStartTime = liveEpgEntry->GetStartTime();
+      m_catchupEndTime = liveEpgEntry->GetEndTime();
+    }
+    else if (m_controlsLiveStream || !channel.IsCatchupSupported() ||
+             (channel.IsCatchupSupported() && Settings::GetInstance().CatchupOnlyOnFinishedProgrammes()))
+    {
+      // Live without EPG entry
+      ClearProgramme();
+      m_catchupStartTime = 0;
+      m_catchupEndTime = 0;
+    }
+    m_fromEpgTag = false;
+  }
+
+  if (m_controlsLiveStream)
+  {
+    if (m_resetCatchupState)
+    {
+      m_resetCatchupState = false;
+      if (channel.IsCatchupSupported())
+      {
+        m_timeshiftBufferOffset = Settings::GetInstance().GetCatchupDaysInSeconds(); //offset from now to start of catchup window
+        m_timeshiftBufferStartTime = std::time(nullptr) - Settings::GetInstance().GetCatchupDaysInSeconds(); // now - the window size
+      }
+      else
+      {
+        m_timeshiftBufferOffset = 0;
+        m_timeshiftBufferStartTime = 0;
+      }
+    }
+    else
+    {
+      EpgEntry* currentEpgEntry = GetEPGEntry(channel, m_timeshiftBufferStartTime + m_timeshiftBufferOffset);
+      if (currentEpgEntry)
+        UpdateProgrammeFrom(*currentEpgEntry, channel.GetTvgShift());
+    }
+
+    m_catchupStartTime = m_timeshiftBufferStartTime;
+
+    // TODO: Need a method of updating an inputstream if already running such as web call to stream etc.
+    // this will avoid inputstream restarts which are expensive, may be better placed in client.cpp
+    // this also mean knowing when a stream has stopped
+    SetCatchupInputStreamProperties(true, channel, catchupProperties);
+  }
+}
+
+void CatchupController::ProcessEPGTagForTimeshiftedPlayback(const EPG_TAG& epgTag, Channel& channel, std::map<std::string, std::string>& catchupProperties) // TODO: should be a const channel, create a StreamManager instead
+{
+  TestAndStoreStreamType(channel); // TODO: StreamManager
+
+  if (m_controlsLiveStream)
+  {
+    UpdateProgrammeFrom(epgTag, channel.GetTvgShift());
+    m_catchupStartTime = epgTag.startTime;
+    m_catchupEndTime = epgTag.endTime;
+
+    time_t timeNow = time(0);
+    time_t programmeOffset = timeNow - m_catchupStartTime;
+    time_t timeshiftBufferDuration = std::max(programmeOffset, Settings::GetInstance().GetCatchupDaysInSeconds());
+    m_timeshiftBufferStartTime = timeNow - timeshiftBufferDuration;
+    m_catchupStartTime = m_timeshiftBufferStartTime;
+    m_catchupEndTime = timeNow;
+    m_timeshiftBufferOffset = timeshiftBufferDuration - programmeOffset;
+
+    m_resetCatchupState = false;
+
+    // TODO: Need a method of updating an inputstream if already running such as web call to stream etc.
+    // this will avoid inputstream restarts which are expensive, may be better placed in client.cpp
+    // this also mean knowing when a stream has stopped
+    SetCatchupInputStreamProperties(true, channel, catchupProperties);
+  }
+  else
+  {
+    UpdateProgrammeFrom(epgTag, channel.GetTvgShift());
+    m_catchupStartTime = epgTag.startTime;
+    m_catchupEndTime = epgTag.endTime;
+
+    m_timeshiftBufferStartTime = 0;
+    m_timeshiftBufferOffset = 0;
+
+    m_fromEpgTag = true;
+  }
+}
+
+void CatchupController::ProcessEPGTagForVideoPlayback(const EPG_TAG& epgTag, Channel& channel, std::map<std::string, std::string>& catchupProperties) // TODO: should be a const channel, create a StreamManager instead
+{
+  TestAndStoreStreamType(channel); // TODO: StreamManager
+
+  if (m_controlsLiveStream)
+  {
+    if (m_resetCatchupState)
+    {
+      UpdateProgrammeFrom(epgTag, channel.GetTvgShift());
+      m_catchupStartTime = epgTag.startTime;
+      m_catchupEndTime = epgTag.endTime;
+
+      const time_t beginBuffer = Settings::GetInstance().GetCatchupWatchEpgBeginBufferSecs();
+      const time_t endBuffer = Settings::GetInstance().GetCatchupWatchEpgEndBufferSecs();
+      m_timeshiftBufferStartTime = m_catchupStartTime - beginBuffer;
+      m_catchupStartTime = m_timeshiftBufferStartTime;
+      m_catchupEndTime += endBuffer;
+      m_timeshiftBufferOffset = beginBuffer;
+
+      m_resetCatchupState = false;
+    }
+
+    // TODO: Need a method of updating an inputstream if already running such as web call to stream etc.
+    // this will avoid inputstream restarts which are expensive, may be better placed in client.cpp
+    // this also mean knowing when a stream has stopped
+    SetCatchupInputStreamProperties(false, channel, catchupProperties);
+  }
+  else
+  {
+    UpdateProgrammeFrom(epgTag, channel.GetTvgShift());
+    m_catchupStartTime = epgTag.startTime;
+    m_catchupEndTime = epgTag.endTime;
+
+    m_timeshiftBufferStartTime = 0;
+    m_timeshiftBufferOffset = 0;
+    m_catchupStartTime = m_catchupStartTime - Settings::GetInstance().GetCatchupWatchEpgBeginBufferSecs();
+    m_catchupEndTime += Settings::GetInstance().GetCatchupWatchEpgEndBufferSecs();
+  }
+
+  if (m_catchupStartTime > 0)
+    m_playbackIsVideo = true;
+}
+
+void CatchupController::SetCatchupInputStreamProperties(bool playbackAsLive, const Channel& channel, std::map<std::string, std::string>& catchupProperties)
+{
+  catchupProperties.insert({"epgplaybackaslive", playbackAsLive ? "true" : "false"});
+
+  catchupProperties.insert({"inputstream.ffmpegdirect.is_realtime_stream", "true"});
+  catchupProperties.insert({"inputstream.ffmpegdirect.stream_mode", "catchup"});
+
+  catchupProperties.insert({"inputstream.ffmpegdirect.default_url", channel.GetStreamURL()});
+  catchupProperties.insert({"inputstream.ffmpegdirect.playback_as_live", playbackAsLive ? "true" : "false"});
+  catchupProperties.insert({"inputstream.ffmpegdirect.catchup_url_format_string", GetCatchupUrlFormatString(channel)});
+  catchupProperties.insert({"inputstream.ffmpegdirect.catchup_buffer_start_time", std::to_string(m_catchupStartTime)});
+  catchupProperties.insert({"inputstream.ffmpegdirect.catchup_buffer_end_time", std::to_string(m_catchupEndTime)});
+  catchupProperties.insert({"inputstream.ffmpegdirect.catchup_buffer_offset", std::to_string(m_timeshiftBufferOffset)});
+  catchupProperties.insert({"inputstream.ffmpegdirect.timezone_shift", std::to_string(channel.GetTvgShift())});
+
+  // TODO: Should also send programme start and duration potentially
+  // When doing this don't forget to add Settings::GetInstance().GetCatchupWatchEpgBeginBufferSecs() + Settings::GetInstance().GetCatchupWatchEpgEndBufferSecs();
+  // if in video playbacl mode from epg, i.e. if if (!Settings::GetInstance().CatchupPlayEpgAsLive() && m_playbackIsVideo)s
+
+  Logger::Log(LEVEL_DEBUG, "default_url - %s", channel.GetStreamURL().c_str());
+  Logger::Log(LEVEL_DEBUG, "playback_as_live - %s", playbackAsLive ? "true" : "false");
+  Logger::Log(LEVEL_DEBUG, "catchup_url_format_string - %s", GetCatchupUrlFormatString(channel).c_str());
+  Logger::Log(LEVEL_DEBUG, "catchup_buffer_start_time - %s", std::to_string(m_catchupStartTime).c_str());
+  Logger::Log(LEVEL_DEBUG, "catchup_buffer_end_time - %s", std::to_string(m_catchupEndTime).c_str());
+  Logger::Log(LEVEL_DEBUG, "catchup_buffer_offset - %s", std::to_string(m_timeshiftBufferOffset).c_str());
+  Logger::Log(LEVEL_DEBUG, "timezone_shift - %s", std::to_string(channel.GetTvgShift()).c_str());
+}
+
+void CatchupController::TestAndStoreStreamType(Channel& channel)
+{
+  // We need to find out what type of stream this is, so let's construct a catchup URL to test with
+  const std::string streamTestUrl = GetStreamTestUrl(channel);
+  StreamType streamType = StreamUtils::GetStreamType(streamTestUrl, channel);
+  if (streamType == StreamType::OTHER_TYPE)
+    streamType = StreamUtils::InspectStreamType(streamTestUrl);
+
+  // TODO: we really want to store this in a file and load it on any restart
+  // using channel doesn't make sense as it's otherwise immutable.
+
+  // If we find a mimetype store it so we don't have to look it up again
+  if (!channel.GetProperty("mimetype").empty() && (streamType == StreamType::HLS || streamType == StreamType::DASH))
+  {
+    std::lock_guard<std::mutex> lock(*m_mutex);
+    channel.AddProperty("mimetype", StreamUtils::GetMimeType(streamType));
+  }
+
+  if (StreamUtils::GetEffectiveInputStreamClass(streamType, channel) == "inputstream.ffmpegdirect")
+    m_controlsLiveStream = true;
+  else
+    m_controlsLiveStream = false;
+}
+
+void CatchupController::UpdateProgrammeFrom(const EPG_TAG& epgTag, int tvgShift)
+{
+  m_programmeStartTime = epgTag.startTime;
+  m_programmeEndTime = epgTag.endTime;
+  m_programmeTitle = epgTag.strTitle;
+  m_programmeUniqueChannelId = epgTag.iUniqueChannelId;
+  m_programmeChannelTvgShift = tvgShift;
+}
+
+void CatchupController::UpdateProgrammeFrom(const data::EpgEntry& epgEntry, int tvgShift)
+{
+  m_programmeStartTime = epgEntry.GetStartTime();
+  m_programmeEndTime = epgEntry.GetEndTime();
+  m_programmeTitle = epgEntry.GetTitle();
+  m_programmeUniqueChannelId = epgEntry.GetChannelId();
+  m_programmeChannelTvgShift = tvgShift;
+}
+
+void CatchupController::ClearProgramme()
+{
+  m_programmeStartTime = 0;
+  m_programmeEndTime = 0;
+  m_programmeTitle.clear();
+  m_programmeUniqueChannelId = 0;
+  m_programmeChannelTvgShift = 0;
+}
+
+namespace
+{
+void FormatOffset(time_t tTime, std::string &urlFormatString)
+{
+  static const std::regex OFFSET_REGEX(".*(\\{offset:(\\d+)\\}).*");
+  std::cmatch mr;
+  if (std::regex_match(urlFormatString.c_str(), mr, OFFSET_REGEX) && mr.length() >= 3)
+  {
+    std::string offsetExp = mr[1].first;
+    std::string second = mr[1].second;
+    if (second.length() > 0)
+      offsetExp = offsetExp.erase(offsetExp.find(second));
+    std::string dividerStr = mr[2].first;
+    second = mr[2].second;
+    if (second.length() > 0)
+      dividerStr = dividerStr.erase(dividerStr.find(second));
+
+    const time_t divider = stoi(dividerStr);
+    if (divider != 0)
+    {
+      time_t offset = tTime / divider;
+      if (offset < 0)
+        offset = 0;
+      urlFormatString.replace(urlFormatString.find(offsetExp), offsetExp.length(), std::to_string(offset));
+    }
+  }
+}
+
+void FormatTime(const char ch, const struct tm *pTime, std::string &urlFormatString)
+{
+  char str[] = { '{', ch, '}', 0 };
+  auto pos = urlFormatString.find(str);
+  if (pos != std::string::npos)
+  {
+    char buff[256], timeFmt[3];
+    std::snprintf(timeFmt, sizeof(timeFmt), "%%%c", ch);
+    std::strftime(buff, sizeof(buff), timeFmt, pTime);
+    if (std::strlen(buff) > 0)
+      urlFormatString.replace(pos, 3, buff);
+  }
+}
+
+void FormatUtc(const char *str, time_t tTime, std::string &urlFormatString)
+{
+  auto pos = urlFormatString.find(str);
+  if (pos != std::string::npos)
+  {
+    char buff[256];
+    std::snprintf(buff, sizeof(buff), "%lu", tTime);
+    urlFormatString.replace(pos, std::strlen(str), buff);
+  }
+}
+
+std::string FormatDateTime(time_t dateTimeEpg, time_t duration, const std::string &urlFormatString)
+{
+  std::string fomrattedUrl = urlFormatString;
+
+  const time_t dateTimeNow = std::time(0);
+  tm* dateTime = std::localtime(&dateTimeEpg);
+
+  FormatTime('Y', dateTime, fomrattedUrl);
+  FormatTime('m', dateTime, fomrattedUrl);
+  FormatTime('d', dateTime, fomrattedUrl);
+  FormatTime('H', dateTime, fomrattedUrl);
+  FormatTime('M', dateTime, fomrattedUrl);
+  FormatTime('S', dateTime, fomrattedUrl);
+  FormatUtc("{utc}", dateTimeEpg, fomrattedUrl);
+  FormatUtc("${start}", dateTimeEpg, fomrattedUrl);
+  FormatUtc("{utcend}", dateTimeEpg + duration, fomrattedUrl);
+  FormatUtc("${end}", dateTimeEpg + duration, fomrattedUrl);
+  FormatUtc("{lutc}", dateTimeNow, fomrattedUrl);
+  FormatUtc("{duration}", duration, fomrattedUrl);
+  FormatOffset(dateTimeNow - dateTimeEpg, fomrattedUrl);
+
+  Logger::Log(LEVEL_DEBUG, "%s - \"%s\"", __FUNCTION__, fomrattedUrl.c_str());
+
+  return fomrattedUrl;
+}
+
+std::string AppendQueryStringAndPreserveOptions(const std::string &url, const std::string &postfixQueryString)
+{
+  std::string urlFormatString;
+  if (!postfixQueryString.empty())
+  {
+    // preserve any kodi protocol options after "|"
+    size_t found = url.find_first_of('|');
+    if (found != std::string::npos)
+      urlFormatString = url.substr(0, found) + postfixQueryString + url.substr(found, url.length());
+    else
+      urlFormatString = url + postfixQueryString;
+  }
+  else
+  {
+    urlFormatString = url;
+  }
+
+  return urlFormatString;
+}
+
+std::string BuildUrlFormatString(const Channel& channel)
+{
+  std::string urlFormatString;
+
+  if (!channel.GetCatchupSource().empty())
+  {
+    if (channel.GetCatchupMode() == CatchupMode::DEFAULT)
+      urlFormatString = channel.GetCatchupSource();
+    else // source is query to be appended
+      urlFormatString = AppendQueryStringAndPreserveOptions(channel.GetStreamURL(), channel.GetCatchupSource());
+  }
+  else
+  {
+    urlFormatString = AppendQueryStringAndPreserveOptions(channel.GetStreamURL(), Settings::GetInstance().GetCatchupQueryFormat());
+  }
+
+  return urlFormatString;
+}
+
+std::string BuildEpgTagUrl(time_t startTime, time_t duration, const Channel& channel, long long timeOffset)
+{
+  std::string startTimeUrl;
+  time_t timeNow = time(0);
+  time_t offset = startTime + timeOffset;
+
+  if (startTime > 0 && offset < (timeNow - 5))
+    startTimeUrl = FormatDateTime(offset - channel.GetTvgShift(), duration, BuildUrlFormatString(channel));
+  else
+    startTimeUrl = channel.GetStreamURL();
+
+  Logger::Log(LEVEL_DEBUG, "%s - %s", __FUNCTION__, startTimeUrl.c_str());
+
+  return startTimeUrl;
+}
+
+} // unnamed namespace
+
+std::string CatchupController::GetCatchupUrlFormatString(const Channel& channel) const
+{
+  if (m_catchupStartTime > 0)
+    return BuildUrlFormatString(channel);
+
+  return "";
+}
+
+std::string CatchupController::GetCatchupUrl(const Channel& channel) const
+{
+  if (m_catchupStartTime > 0)
+  {
+    time_t duration = static_cast<time_t>(m_programmeEndTime - m_programmeStartTime);
+
+    if (!Settings::GetInstance().CatchupPlayEpgAsLive() && m_playbackIsVideo)
+      duration += Settings::GetInstance().GetCatchupWatchEpgBeginBufferSecs() + Settings::GetInstance().GetCatchupWatchEpgEndBufferSecs();
+
+    return BuildEpgTagUrl(m_catchupStartTime, duration, channel, m_timeshiftBufferOffset);
+  }
+
+  return "";
+}
+
+std::string CatchupController::GetStreamTestUrl(const Channel& channel) const
+{
+  // Test URL from 2 hours ago for 1 hour duration.
+  return BuildEpgTagUrl(std::time(nullptr) - (2 * 60 * 60),  60 * 60, channel, 0);
+}
+
+EpgEntry* CatchupController::GetLiveEPGEntry(const Channel& myChannel)
+{
+  std::lock_guard<std::mutex> lock(*m_mutex);
+
+  return m_epg.GetLiveEPGEntry(myChannel);
+}
+
+EpgEntry* CatchupController::GetEPGEntry(const Channel& myChannel, time_t lookupTime)
+{
+  std::lock_guard<std::mutex> lock(*m_mutex);
+
+  return m_epg.GetEPGEntry(myChannel, lookupTime);
+}

--- a/src/iptvsimple/CatchupController.h
+++ b/src/iptvsimple/CatchupController.h
@@ -1,0 +1,87 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include <string>
+
+#include "data/Channel.h"
+#include "data/EpgEntry.h"
+#include "utilities/StreamUtils.h"
+
+#include <mutex>
+
+#include <kodi/libXBMC_pvr.h>
+
+namespace iptvsimple
+{
+  class Epg;
+
+  class CatchupController
+  {
+  public:
+    CatchupController(iptvsimple::Epg& epg, std::mutex* mutex);
+
+    void ProcessChannelForPlayback(data::Channel& channel, std::map<std::string, std::string>& catchupProperties); //should be const channel
+    void ProcessEPGTagForTimeshiftedPlayback(const EPG_TAG& epgTag, data::Channel& channel, std::map<std::string, std::string>& catchupProperties); //should be const channel
+    void ProcessEPGTagForVideoPlayback(const EPG_TAG& epgTag, data::Channel& channel, std::map<std::string, std::string>& catchupProperties); //should be const channel
+
+    std::string GetTimeshiftInputStreamClass(const utilities::StreamType& streamType);
+
+    std::string GetCatchupUrlFormatString(const data::Channel& channel) const;
+    std::string GetCatchupUrl(const data::Channel& channel) const;
+    std::string GetStreamTestUrl(const data::Channel& channel) const;
+
+    bool ControlsLiveStream() const { return m_controlsLiveStream; }
+    void ResetCatchupState() { m_resetCatchupState = true; }
+
+  private:
+    data::EpgEntry* GetLiveEPGEntry(const iptvsimple::data::Channel& myChannel);
+    data::EpgEntry* GetEPGEntry(const iptvsimple::data::Channel& myChannel, time_t lookupTime);
+    void SetCatchupInputStreamProperties(bool playbackAsLive, const iptvsimple::data::Channel& channel, std::map<std::string, std::string>& catchupProperties);
+    void TestAndStoreStreamType(data::Channel& channel);
+
+    // Programme helpers
+    void UpdateProgrammeFrom(const EPG_TAG& epgTag, int tvgShift);
+    void UpdateProgrammeFrom(const data::EpgEntry& epgEntry, int tvgShift);
+    void ClearProgramme();
+
+    // State of current stream
+    time_t m_catchupStartTime = 0;
+    time_t m_catchupEndTime = 0;
+    time_t m_timeshiftBufferStartTime = 0;
+    long long m_timeshiftBufferOffset = 0;
+    bool m_resetCatchupState = false;
+    bool m_playbackIsVideo = false;
+    bool m_fromEpgTag = false;
+
+    // Current programme details
+    time_t m_programmeStartTime = 0;
+    time_t m_programmeEndTime = 0;
+    std::string m_programmeTitle;
+    unsigned int m_programmeUniqueChannelId = 0;
+    int m_programmeChannelTvgShift = 0;
+
+    bool m_controlsLiveStream = false;
+    iptvsimple::Epg& m_epg;
+    std::mutex* m_mutex = nullptr;
+  };
+} //namespace iptvsimple

--- a/src/iptvsimple/Channels.cpp
+++ b/src/iptvsimple/Channels.cpp
@@ -72,11 +72,16 @@ void Channels::GetChannels(std::vector<PVR_CHANNEL>& kodiChannels, bool radio) c
   }
 }
 
-bool Channels::GetChannel(const PVR_CHANNEL& channel, Channel& myChannel)
+bool Channels::GetChannel(const PVR_CHANNEL& channel, Channel& myChannel) const
+{
+  return GetChannel(static_cast<int>(channel.iUniqueId), myChannel);
+}
+
+bool Channels::GetChannel(int uniqueId, Channel& myChannel) const
 {
   for (const auto& thisChannel : m_channels)
   {
-    if (thisChannel.GetUniqueId() == static_cast<int>(channel.iUniqueId))
+    if (thisChannel.GetUniqueId() == uniqueId)
     {
       thisChannel.UpdateTo(myChannel);
 

--- a/src/iptvsimple/Channels.h
+++ b/src/iptvsimple/Channels.h
@@ -44,7 +44,8 @@ namespace iptvsimple
 
     int GetChannelsAmount() const;
     void GetChannels(std::vector<PVR_CHANNEL>& kodiChannels, bool radio) const;
-    bool GetChannel(const PVR_CHANNEL& channel, iptvsimple::data::Channel& myChannel);
+    bool GetChannel(const PVR_CHANNEL& channel, iptvsimple::data::Channel& myChannel) const;
+    bool GetChannel(int uniqueId, iptvsimple::data::Channel& myChannel) const;
 
     void AddChannel(iptvsimple::data::Channel& channel, std::vector<int>& groupIdList, iptvsimple::ChannelGroups& channelGroups);
     iptvsimple::data::Channel* GetChannel(int uniqueId);

--- a/src/iptvsimple/Epg.cpp
+++ b/src/iptvsimple/Epg.cpp
@@ -355,23 +355,23 @@ PVR_ERROR Epg::GetEPGForChannel(ADDON_HANDLE handle, int iChannelUid, time_t sta
   return PVR_ERROR_NO_ERROR;
 }
 
-ChannelEpg* Epg::FindEpgForChannel(const std::string& id)
+ChannelEpg* Epg::FindEpgForChannel(const std::string& id) const
 {
   for (auto& myChannelEpg : m_channelEpgs)
   {
     if (StringUtils::EqualsNoCase(myChannelEpg.GetId(), id))
-      return &myChannelEpg;
+      return const_cast<ChannelEpg*>(&myChannelEpg);
   }
 
   return nullptr;
 }
 
-ChannelEpg* Epg::FindEpgForChannel(const Channel& channel)
+ChannelEpg* Epg::FindEpgForChannel(const Channel& channel) const
 {
   for (auto& myChannelEpg : m_channelEpgs)
   {
     if (StringUtils::EqualsNoCase(myChannelEpg.GetId(), channel.GetTvgId()))
-      return &myChannelEpg;
+      return const_cast<ChannelEpg*>(&myChannelEpg);
   }
 
   for (auto& myChannelEpg : m_channelEpgs)
@@ -381,7 +381,7 @@ ChannelEpg* Epg::FindEpgForChannel(const Channel& channel)
       const std::string convertedDisplayName = std::regex_replace(displayName, std::regex(" "), "_");
       if (StringUtils::EqualsNoCase(convertedDisplayName, channel.GetTvgName()) ||
           StringUtils::EqualsNoCase(displayName, channel.GetTvgName()))
-        return &myChannelEpg;
+        return const_cast<ChannelEpg*>(&myChannelEpg);
     }
   }
 
@@ -390,7 +390,7 @@ ChannelEpg* Epg::FindEpgForChannel(const Channel& channel)
     for (const std::string& displayName : myChannelEpg.GetNames())
     {
       if (StringUtils::EqualsNoCase(displayName, channel.GetChannelName()))
-        return &myChannelEpg;
+        return const_cast<ChannelEpg*>(&myChannelEpg);
     }
   }
 
@@ -481,4 +481,30 @@ void Epg::MoveOldGenresXMLFileToNewLocation()
 
   FileUtils::DeleteFile(ADDON_DATA_BASE_DIR + "/" + GENRES_MAP_FILENAME.c_str());
   FileUtils::DeleteFile(FileUtils::GetSystemAddonPath() + "/" + GENRES_MAP_FILENAME.c_str());
+}
+
+EpgEntry* Epg::GetLiveEPGEntry(const Channel& myChannel) const
+{
+  return GetEPGEntry(myChannel, time(nullptr));
+}
+
+EpgEntry* Epg::GetEPGEntry(const Channel& myChannel, time_t lookupTime) const
+{
+  ChannelEpg* channelEpg = FindEpgForChannel(myChannel);
+  if (!channelEpg || channelEpg->GetEpgEntries().size() == 0)
+    return nullptr;
+
+  int shift = m_tsOverride ? m_epgTimeShift : myChannel.GetTvgShift() + m_epgTimeShift;
+
+  for (auto& epgEntry : channelEpg->GetEpgEntries())
+  {
+    time_t startTime = epgEntry.GetStartTime() + shift;
+    time_t endTime = epgEntry.GetEndTime() + shift;
+    if (startTime <= lookupTime && endTime > lookupTime)
+      return &epgEntry;
+    else if (startTime > lookupTime)
+      break;
+  }
+
+  return nullptr;
 }

--- a/src/iptvsimple/Epg.h
+++ b/src/iptvsimple/Epg.h
@@ -54,6 +54,9 @@ namespace iptvsimple
     void Clear();
     void ReloadEPG();
 
+    data::EpgEntry* GetLiveEPGEntry(const data::Channel& myChannel) const;
+    data::EpgEntry* GetEPGEntry(const data::Channel& myChannel, time_t lookupTime) const;
+
   private:
     static const XmltvFileFormat GetXMLTVFileFormat(const char* buffer);
     static void MoveOldGenresXMLFileToNewLocation();
@@ -65,8 +68,8 @@ namespace iptvsimple
     void LoadEpgEntries(const pugi::xml_node& rootElement, int start, int end);
     bool LoadGenres();
 
-    data::ChannelEpg* FindEpgForChannel(const std::string& id);
-    data::ChannelEpg* FindEpgForChannel(const data::Channel& channel);
+    data::ChannelEpg* FindEpgForChannel(const std::string& id) const;
+    data::ChannelEpg* FindEpgForChannel(const data::Channel& channel) const;
     void ApplyChannelsLogosFromEPG();
 
     std::string m_xmltvLocation;

--- a/src/iptvsimple/PlaylistLoader.cpp
+++ b/src/iptvsimple/PlaylistLoader.cpp
@@ -196,6 +196,9 @@ std::string PlaylistLoader::ParseIntoChannel(const std::string& line, Channel& c
     std::string strChnlNo     = ReadMarkerValue(infoLine, TVG_INFO_CHNO_MARKER);
     std::string strRadio      = ReadMarkerValue(infoLine, RADIO_MARKER);
     std::string strTvgShift   = ReadMarkerValue(infoLine, TVG_INFO_SHIFT_MARKER);
+    std::string strCatchup       = ReadMarkerValue(infoLine, CATCHUP);
+    std::string strCatchupDays   = ReadMarkerValue(infoLine, CATCHUP_DAYS);
+    std::string strCatchupSource = ReadMarkerValue(infoLine, CATCHUP_SOURCE);
 
     if (strTvgId.empty())
       strTvgId = ReadMarkerValue(infoLine, TVG_INFO_ID_MARKER_UC);
@@ -215,11 +218,25 @@ std::string PlaylistLoader::ParseIntoChannel(const std::string& line, Channel& c
     bool isRadio = StringUtils::EqualsNoCase(strRadio, "true");
     channel.SetTvgId(strTvgId);
     channel.SetTvgName(XBMC->UnknownToUTF8(strTvgName.c_str()));
+    channel.SetCatchupSource(XBMC->UnknownToUTF8(strCatchupSource.c_str()));
     channel.SetTvgShift(static_cast<int>(tvgShiftDecimal * 3600.0));
     channel.SetRadio(isRadio);
     channel.SetIconPathFromTvgLogo(strTvgLogo, channelName);
     if (strTvgShift.empty())
       channel.SetTvgShift(epgTimeShift);
+    if (!strCatchupDays.empty())
+      channel.SetCatchupDays(atoi(strCatchupDays.c_str()));
+    else
+      channel.SetCatchupDays(Settings::GetInstance().GetCatchupDays());
+
+    if (StringUtils::EqualsNoCase(strCatchup, "default") || StringUtils::EqualsNoCase(strCatchup, "append") ||
+        !strCatchupDays.empty() || !strCatchupSource.empty())
+      channel.SetHasCatchup(true);
+
+    if (StringUtils::EqualsNoCase(strCatchup, "default"))
+      channel.SetCatchupMode(CatchupMode::DEFAULT);
+    else if (StringUtils::EqualsNoCase(strCatchup, "append"))
+      channel.SetCatchupMode(CatchupMode::APPEND);
 
     return ReadMarkerValue(infoLine, GROUP_NAME_MARKER);
   }

--- a/src/iptvsimple/PlaylistLoader.h
+++ b/src/iptvsimple/PlaylistLoader.h
@@ -41,6 +41,9 @@ namespace iptvsimple
   static const std::string TVG_INFO_SHIFT_MARKER   = "tvg-shift=";
   static const std::string TVG_INFO_CHNO_MARKER    = "tvg-chno=";
   static const std::string GROUP_NAME_MARKER       = "group-title=";
+  static const std::string CATCHUP                 = "catchup=";
+  static const std::string CATCHUP_DAYS            = "catchup-days=";
+  static const std::string CATCHUP_SOURCE          = "catchup-source=";
   static const std::string KODIPROP_MARKER         = "#KODIPROP:";
   static const std::string EXTVLCOPT_MARKER        = "#EXTVLCOPT:";
   static const std::string EXTVLCOPT_DASH_MARKER   = "#EXTVLCOPT--";

--- a/src/iptvsimple/Settings.cpp
+++ b/src/iptvsimple/Settings.cpp
@@ -93,6 +93,24 @@ void Settings::ReadFromAddon(const std::string& userPath, const std::string clie
   if (!XBMC->GetSetting("logoFromEpg", &m_epgLogosMode))
     m_epgLogosMode = EpgLogosMode::IGNORE_XMLTV;
 
+  // Catchup
+  if (!XBMC->GetSetting("catchupEnabled", &m_catchupEnabled))
+    m_catchupEnabled = false;
+  if (XBMC->GetSetting("catchupQueryFormat", &buffer))
+    m_catchupQueryFormat = buffer;
+  if (!XBMC->GetSetting("catchupDays", &m_catchupDays))
+    m_catchupDays = 5;
+  if (!XBMC->GetSetting("allChannelSupportCatchup", &m_allChannelsSupportCatchup))
+    m_allChannelsSupportCatchup = false;
+  if (!XBMC->GetSetting("catchupPlayEpgAsLive", &m_catchupPlayEpgAsLive))
+    m_catchupPlayEpgAsLive = false;
+  if (!XBMC->GetSetting("catchupWatchEpgBeginBufferMins", &m_catchupWatchEpgBeginBufferMins))
+    m_catchupWatchEpgBeginBufferMins = 5;
+  if (!XBMC->GetSetting("catchupWatchEpgEndBufferMins", &m_catchupWatchEpgEndBufferMins))
+    m_catchupWatchEpgEndBufferMins = 15;
+  if (!XBMC->GetSetting("catchupOnlyOnFinishedProgrammes", &m_catchupOnlyOnFinishedProgrammes))
+    m_catchupOnlyOnFinishedProgrammes = false;
+
   // Advanced
   if (!XBMC->GetSetting("transformMulticastStreamUrls", &m_transformMulticastStreamUrls))
     m_transformMulticastStreamUrls = false;
@@ -171,6 +189,24 @@ ADDON_STATUS Settings::SetValue(const std::string& settingName, const void* sett
     return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_logoBaseUrl, ADDON_STATUS_OK, ADDON_STATUS_OK);
   if (settingName == "logoFromEpg")
     return SetSetting<EpgLogosMode, ADDON_STATUS>(settingName, settingValue, m_epgLogosMode, ADDON_STATUS_OK, ADDON_STATUS_OK);
+
+  // Catchup
+  if (settingName == "catchupEnabled")
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_catchupEnabled, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  if (settingName == "catchupQueryFormat")
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_catchupQueryFormat, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  if (settingName == "catchupDays")
+    return SetSetting<int, ADDON_STATUS>(settingName, settingValue, m_catchupDays, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  if (settingName == "allChannelSupportCatchup")
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_allChannelsSupportCatchup, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  if (settingName == "catchupPlayEpgAsLive")
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_catchupPlayEpgAsLive, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  if (settingName == "catchupWatchEpgBeginBufferMins")
+    return SetSetting<int, ADDON_STATUS>(settingName, settingValue, m_catchupWatchEpgBeginBufferMins, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  if (settingName == "catchupWatchEpgEndBufferMins")
+    return SetSetting<int, ADDON_STATUS>(settingName, settingValue, m_catchupWatchEpgEndBufferMins, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  if (settingName == "catchupOnlyOnFinishedProgrammes")
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_catchupOnlyOnFinishedProgrammes, ADDON_STATUS_OK, ADDON_STATUS_OK);
 
   // Advanced
   if (settingName == "transformMulticastStreamUrls")

--- a/src/iptvsimple/Settings.h
+++ b/src/iptvsimple/Settings.h
@@ -113,6 +113,18 @@ namespace iptvsimple
     const std::string& GetLogoBaseUrl() const { return m_logoBaseUrl; }
     const EpgLogosMode& GetEpgLogosMode() const { return m_epgLogosMode; }
 
+    bool IsCatchupEnabled() const { return m_catchupEnabled; }
+    const std::string& GetCatchupQueryFormat() const { return m_catchupQueryFormat; }
+    int GetCatchupDays() const { return m_catchupDays; }
+    time_t GetCatchupDaysInSeconds() const { return static_cast<time_t>(m_catchupDays) * 24 * 60 * 60; }
+    bool AllChannelsSupportCatchup() const { return m_allChannelsSupportCatchup; }
+    bool CatchupPlayEpgAsLive() const { return m_catchupPlayEpgAsLive; }
+    int GetCatchupWatchEpgBeginBufferMins() const { return m_catchupWatchEpgBeginBufferMins; }
+    time_t GetCatchupWatchEpgBeginBufferSecs() const { return static_cast<time_t>(m_catchupWatchEpgBeginBufferMins) * 60; }
+    int GetCatchupWatchEpgEndBufferMins() const { return m_catchupWatchEpgEndBufferMins; }
+    time_t GetCatchupWatchEpgEndBufferSecs() const { return static_cast<time_t>(m_catchupWatchEpgEndBufferMins) * 60; }
+    bool CatchupOnlyOnFinishedProgrammes() const { return m_catchupOnlyOnFinishedProgrammes; }
+
     bool TransformMulticastStreamUrls() const { return m_transformMulticastStreamUrls; }
     const std::string& GetUdpxyHost() const { return m_udpxyHost; }
     int GetUdpxyPort() const { return m_udpxyPort; }
@@ -189,6 +201,15 @@ namespace iptvsimple
     std::string m_logoPath;
     std::string m_logoBaseUrl;
     EpgLogosMode m_epgLogosMode = EpgLogosMode::IGNORE_XMLTV;
+
+    bool m_catchupEnabled = false;
+    std::string m_catchupQueryFormat;
+    int m_catchupDays = 3;
+    bool m_allChannelsSupportCatchup = false;
+    bool m_catchupPlayEpgAsLive = false;
+    int m_catchupWatchEpgBeginBufferMins = 5;
+    int m_catchupWatchEpgEndBufferMins = 15;
+    bool m_catchupOnlyOnFinishedProgrammes = false;
 
     bool m_transformMulticastStreamUrls = false;
     std::string m_udpxyHost;

--- a/src/iptvsimple/data/Channel.h
+++ b/src/iptvsimple/data/Channel.h
@@ -28,6 +28,13 @@
 
 namespace iptvsimple
 {
+  enum class CatchupMode
+    : int // same type as addon settings
+  {
+    DEFAULT = 0,
+    APPEND
+  };
+
   namespace data
   {
     static const std::string CHANNEL_LOGO_EXTENSION = ".png";
@@ -39,8 +46,10 @@ namespace iptvsimple
       Channel(const Channel &c) : m_radio(c.IsRadio()), m_uniqueId(c.GetUniqueId()),
         m_channelNumber(c.GetChannelNumber()), m_encryptionSystem(c.GetEncryptionSystem()),
         m_tvgShift(c.GetTvgShift()), m_channelName(c.GetChannelName()), m_iconPath(c.GetIconPath()),
-        m_streamURL(c.GetStreamURL()), m_tvgId(c.GetTvgId()), m_tvgName(c.GetTvgName()),
-        m_properties(c.GetProperties()) {};
+        m_streamURL(c.GetStreamURL()), m_hasCatchup(c.HasCatchup()), m_catchupMode(c.GetCatchupMode()),
+        m_catchupDays(c.GetCatchupDays()), m_catchupSource(c.GetCatchupSource()),
+        m_tvgId(c.GetTvgId()), m_tvgName(c.GetTvgName()), m_properties(c.GetProperties()),
+        m_inputStreamClass(c.GetInputStreamClass()) {};
       ~Channel() = default;
 
       bool IsRadio() const { return m_radio; }
@@ -67,6 +76,19 @@ namespace iptvsimple
       const std::string& GetStreamURL() const { return m_streamURL; }
       void SetStreamURL(const std::string& url);
 
+      bool IsCatchupSupported() const; // Does the M3U entry or default settings denote catchup support
+      bool HasCatchup() const { return m_hasCatchup; } // Does the M3U entry denote catchup support
+      void SetHasCatchup(bool value) { m_hasCatchup = value; }
+      const CatchupMode& GetCatchupMode() const { return m_catchupMode; }
+      void SetCatchupMode(const CatchupMode& value) { m_catchupMode = value; }
+
+      int GetCatchupDays() const { return m_catchupDays; }
+      void SetCatchupDays(int catchupDays);
+      int GetCatchupDaysInSeconds() const { return m_catchupDays * 24 * 60 * 60; }
+
+      const std::string& GetCatchupSource() const { return m_catchupSource; }
+      void SetCatchupSource(const std::string& value) { m_catchupSource = value; }
+
       const std::string& GetTvgId() const { return m_tvgId; }
       void SetTvgId(const std::string& value) { m_tvgId = value; }
 
@@ -77,6 +99,9 @@ namespace iptvsimple
       void SetProperties(std::map<std::string, std::string>& value) { m_properties = value; }
       void AddProperty(const std::string& prop, const std::string& value) { m_properties.insert({prop, value}); }
       std::string GetProperty(const std::string& propName) const;
+
+      const std::string& GetInputStreamClass() const { return m_inputStreamClass; };
+      void SetInputStreamClass(const std::string& value) { m_inputStreamClass = value; }
 
       void UpdateTo(Channel& left) const;
       void UpdateTo(PVR_CHANNEL& left) const;
@@ -95,9 +120,14 @@ namespace iptvsimple
       std::string m_channelName = "";
       std::string m_iconPath = "";
       std::string m_streamURL = "";
+      bool m_hasCatchup = false;
+      CatchupMode m_catchupMode = CatchupMode::DEFAULT;
+      int m_catchupDays = 0;
+      std::string m_catchupSource = "";
       std::string m_tvgId = "";
       std::string m_tvgName = "";
       std::map<std::string, std::string> m_properties;
+      std::string m_inputStreamClass;
     };
   } //namespace data
 } //namespace iptvsimple

--- a/src/iptvsimple/data/EpgEntry.cpp
+++ b/src/iptvsimple/data/EpgEntry.cpp
@@ -36,7 +36,7 @@ using namespace iptvsimple;
 using namespace iptvsimple::data;
 using namespace pugi;
 
-void EpgEntry::UpdateTo(EPG_TAG& left, int iChannelUid, int timeShift, std::vector<EpgGenre>& genreMappings)
+void EpgEntry::UpdateTo(EPG_TAG& left, int iChannelUid, int timeShift, const std::vector<EpgGenre>& genreMappings)
 {
   left.iUniqueBroadcastId  = m_broadcastId;
   left.strTitle            = m_title.c_str();
@@ -84,7 +84,7 @@ void EpgEntry::UpdateTo(EPG_TAG& left, int iChannelUid, int timeShift, std::vect
   left.firstAired          = m_firstAired;
 }
 
-bool EpgEntry::SetEpgGenre(std::vector<EpgGenre> genreMappings)
+bool EpgEntry::SetEpgGenre(const std::vector<EpgGenre> genreMappings)
 {
   if (genreMappings.empty())
     return false;

--- a/src/iptvsimple/data/EpgEntry.h
+++ b/src/iptvsimple/data/EpgEntry.h
@@ -102,7 +102,7 @@ namespace iptvsimple
       const std::string& GetWriter() const { return m_writer; }
       void SetWriter(const std::string& value) { m_writer = value; }
 
-      void UpdateTo(EPG_TAG& left, int iChannelUid, int timeShift, std::vector<EpgGenre>& genres);
+      void UpdateTo(EPG_TAG& left, int iChannelUid, int timeShift, const std::vector<EpgGenre>& genres);
       bool UpdateFrom(const pugi::xml_node& channelNode, const std::string& id, int broadcastId,
                       int start, int end, int minShiftTime, int maxShiftTime);
 

--- a/src/iptvsimple/utilities/StreamUtils.cpp
+++ b/src/iptvsimple/utilities/StreamUtils.cpp
@@ -74,7 +74,7 @@ const StreamType StreamUtils::InspectStreamType(const std::string& url)
 
   if (httpCode == 200)
   {
-    if (StringUtils::StartsWith(source, "#EXTM3U") && source.find("#EXT-X-STREAM-INF") != std::string::npos)
+    if (StringUtils::StartsWith(source, "#EXTM3U") && (source.find("#EXT-X-STREAM-INF") != std::string::npos || source.find("#EXT-X-VERSION") != std::string::npos))
       return StreamType::HLS;
 
     if (source.find("<MPD") != std::string::npos)

--- a/src/iptvsimple/utilities/StreamUtils.cpp
+++ b/src/iptvsimple/utilities/StreamUtils.cpp
@@ -46,6 +46,84 @@ void StreamUtils::SetStreamProperty(PVR_NAMED_VALUE* properties, unsigned int* p
   }
 }
 
+void StreamUtils::SetAllStreamProperties(PVR_NAMED_VALUE* properties, unsigned int* propertiesCount, unsigned int propertiesMax, const iptvsimple::data::Channel& channel, const std::string& streamURL, std::map<std::string, std::string>& catchupProperties)
+{
+  if (ChannelSpecifiesInputstream(channel))
+  {
+    // Channel has an inputstream class set so we only set the stream URL
+    StreamUtils::SetStreamProperty(properties, propertiesCount, propertiesMax, PVR_STREAM_PROPERTY_STREAMURL, streamURL);
+  }
+  else
+  {
+    StreamType streamType = StreamUtils::GetStreamType(streamURL, channel);
+    if (streamType == StreamType::OTHER_TYPE)
+      streamType = StreamUtils::InspectStreamType(streamURL);
+
+    // Using kodi's built in inputstreams
+    if (StreamUtils::UseKodiInputstreams(streamType))
+    {
+      std::string ffmpegStreamURL = StreamUtils::GetURLWithFFmpegReconnectOptions(streamURL, streamType, channel);
+
+      StreamUtils::SetStreamProperty(properties, propertiesCount, propertiesMax, PVR_STREAM_PROPERTY_STREAMURL, streamURL);
+
+      if (streamType == StreamType::HLS)
+      {
+        if (channel.IsCatchupSupported())
+          StreamUtils::SetStreamProperty(properties, propertiesCount, propertiesMax, PVR_STREAM_PROPERTY_INPUTSTREAMCLASS, CATCHUP_INPUTSTREAMCLASS);
+        else
+          StreamUtils::SetStreamProperty(properties, propertiesCount, propertiesMax, PVR_STREAM_PROPERTY_INPUTSTREAMCLASS, PVR_STREAM_PROPERTY_VALUE_INPUTSTREAMFFMPEG);
+      }
+    }
+    else // inputstream.adpative
+    {
+      StreamUtils::SetStreamProperty(properties, propertiesCount, propertiesMax, PVR_STREAM_PROPERTY_STREAMURL, streamURL);
+      StreamUtils::SetStreamProperty(properties, propertiesCount, propertiesMax, PVR_STREAM_PROPERTY_INPUTSTREAMCLASS, "inputstream.adaptive");
+      StreamUtils::SetStreamProperty(properties, propertiesCount, propertiesMax, "inputstream.adaptive.manifest_type", StreamUtils::GetManifestType(streamType));
+      if (streamType == StreamType::HLS || streamType == StreamType::DASH)
+        StreamUtils::SetStreamProperty(properties, propertiesCount, propertiesMax, PVR_STREAM_PROPERTY_MIMETYPE, StreamUtils::GetMimeType(streamType));
+      if (streamType == StreamType::DASH)
+        StreamUtils::SetStreamProperty(properties, propertiesCount, propertiesMax, "inputstream.adaptive.manifest_update_parameter", "full");
+    }
+  }
+
+  if (!channel.GetProperties().empty())
+  {
+    for (auto& prop : channel.GetProperties())
+      StreamUtils::SetStreamProperty(properties, propertiesCount, propertiesMax, prop.first, prop.second);
+  }
+
+  if (!catchupProperties.empty())
+  {
+    for (auto& prop : catchupProperties)
+      StreamUtils::SetStreamProperty(properties, propertiesCount, propertiesMax, prop.first, prop.second);
+  }
+}
+
+std::string StreamUtils::GetEffectiveInputStreamClass(const StreamType& streamType, const iptvsimple::data::Channel& channel)
+{
+  std::string inputStreamClass = channel.GetInputStreamClass();
+
+  if (inputStreamClass.empty())
+  {
+    if (StreamUtils::UseKodiInputstreams(streamType))
+    {
+      if (streamType == StreamType::HLS)
+      {
+        if (channel.IsCatchupSupported())
+          inputStreamClass = CATCHUP_INPUTSTREAMCLASS;
+        else
+          inputStreamClass = PVR_STREAM_PROPERTY_VALUE_INPUTSTREAMFFMPEG;
+      }
+    }
+    else // inputstream.adpative
+    {
+      inputStreamClass = "inputstream.adaptive";
+    }
+  }
+
+  return inputStreamClass;
+}
+
 const StreamType StreamUtils::GetStreamType(const std::string& url, const Channel& channel)
 {
   if (url.find(".m3u8") != std::string::npos ||
@@ -168,7 +246,7 @@ bool StreamUtils::UseKodiInputstreams(const StreamType& streamType)
 
 bool StreamUtils::ChannelSpecifiesInputstream(const iptvsimple::data::Channel& channel)
 {
-  return !(channel.GetProperty(PVR_STREAM_PROPERTY_INPUTSTREAMCLASS).empty() && channel.GetProperty(PVR_STREAM_PROPERTY_INPUTSTREAMADDON).empty());
+  return !channel.GetInputStreamClass().empty();
 }
 
 bool StreamUtils::SupportsFFmpegReconnect(const StreamType& streamType, const iptvsimple::data::Channel& channel)

--- a/src/iptvsimple/utilities/StreamUtils.h
+++ b/src/iptvsimple/utilities/StreamUtils.h
@@ -41,9 +41,12 @@ namespace iptvsimple
       OTHER_TYPE
     };
 
+    static const std::string CATCHUP_INPUTSTREAMCLASS = "inputstream.ffmpegdirect";
+
     class StreamUtils
     {
     public:
+      static void SetAllStreamProperties(PVR_NAMED_VALUE* properties, unsigned int* propertiesCount, unsigned int propertiesMax, const iptvsimple::data::Channel& channel, const std::string& streamUrl, std::map<std::string, std::string>& catchupProperties);
       static void SetStreamProperty(PVR_NAMED_VALUE* properties, unsigned int* propertiesCount, unsigned int propertiesMax, const std::string& name, const std::string& value);
       static const StreamType GetStreamType(const std::string& url, const iptvsimple::data::Channel& channel);
       static const StreamType InspectStreamType(const std::string& url);
@@ -53,6 +56,8 @@ namespace iptvsimple
       static std::string AddHeaderToStreamUrl(const std::string& streamUrl, const std::string& headerName, const std::string& headerValue);
       static bool UseKodiInputstreams(const StreamType& streamType);
       static bool ChannelSpecifiesInputstream(const iptvsimple::data::Channel& channe);
+
+      static std::string GetEffectiveInputStreamClass(const StreamType& streamType, const iptvsimple::data::Channel& channel);
 
     private:
       static bool SupportsFFmpegReconnect(const StreamType& streamType, const iptvsimple::data::Channel& channel);


### PR DESCRIPTION
v4.9.0
- Added: Catchup support (a.k.a Archive)
- Added: Missing check for HLS stream type
- Update: Readme
- Fixed: strings.po comments
