### PR TITLE
User-Agent choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ General settings required for the addon to function.
 * **M3U Play List URL**: If location is `Remote path` this setting must contain a valid URL for the addon to function.
 * **Cache M3U at local storage**: If location is `Remote path` select whether or not the the M3U file should be cached locally.
 * **Numbering channel starts at**: The number to start numbering channels from.
+* **User-Agent**: Select which User-Agent to use if there is not one supplied as a property or as part of the channel stream URL.
 
 ### EPG Settings
 Settings related to the EPG.

--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="3.8.8"
+  version="3.9.8"
   name="PVR IPTV Simple Client"
   provider-name="nightik">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v3.9.8
+- Added: User-Agent support from advanced addon setting
+
 v3.8.8
 - Fixed: tvg-ID not accepted as an M3U tag
 

--- a/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
@@ -113,3 +113,7 @@ msgstr ""
 msgctxt "#30044"
 msgid "Prefer XMLTV"
 msgstr ""
+
+msgctxt "#30045"
+msgid "Change User-Agent"
+msgstr ""

--- a/pvr.iptvsimple/resources/settings.xml
+++ b/pvr.iptvsimple/resources/settings.xml
@@ -8,6 +8,7 @@
     <setting id="m3uUrl" type="text" label="30012" default="" visible="eq(-2,1)"/>
     <setting id="m3uCache" type="bool" label="30025" default="true" visible="eq(-3,1)"/>
     <setting id="startNum" type="number" label="30013" default="1" />
+    <setting id="userAgent" type="text" label="30045" />
   </category>
 
   <!-- EPG -->

--- a/src/PVRIptvData.cpp
+++ b/src/PVRIptvData.cpp
@@ -802,7 +802,21 @@ bool PVRIptvData::LoadPlayList(void)
       channel.iTvgShift         = tmpChannel.iTvgShift;
       channel.bRadio            = tmpChannel.bRadio;
       channel.properties        = tmpChannel.properties;
-      channel.strStreamURL      = strLine;
+      
+      auto propPair = channel.properties.find("http-user-agent");
+      if (propPair != channel.properties.end())
+      {
+        channel.strStreamURL = AddHeaderToStreamUrl(strLine, "user-agent", propPair->second);
+      }
+      else if (!g_userAgent.empty())
+      {
+        channel.strStreamURL = AddHeaderToStreamUrl(strLine, "user-agent", g_userAgent);
+      }
+      else
+      {
+        channel.strStreamURL = strLine;
+      }
+      
       channel.iEncryptionSystem = 0;
 
       iChannelNum++;
@@ -1481,4 +1495,24 @@ int PVRIptvData::GetChannelId(const char * strChannelName, const char * strStrea
     iId = ((iId << 5) + iId) + c; /* iId * 33 + c */
 
   return abs(iId);
+}
+
+std::string PVRIptvData::AddHeaderToStreamUrl (const std::string& url, const std::string& header, const std::string& value) const
+{
+  char separator = '|';
+  size_t found = url.find('|');
+
+  if (found != std::string::npos)
+  {
+    if (url.find(header + '=', found + 1) != std::string::npos)
+    {
+      return url;
+    }
+    else
+    {
+      separator = '&';
+    }
+  }
+
+  return url + separator + header + '=' + value;
 }

--- a/src/PVRIptvData.h
+++ b/src/PVRIptvData.h
@@ -121,13 +121,14 @@ protected:
   PVRIptvEpgChannel* FindEpgForChannel(const std::string& id);
   virtual PVRIptvEpgChannel*   FindEpgForChannel(PVRIptvChannel &channel);
   virtual bool                 FindEpgGenre(const std::string& strGenre, int& iType, int& iSubType);
-  virtual bool                 GzipInflate( const std::string &compressedBytes, std::string &uncompressedBytes);
+  virtual bool                 GzipInflate(const std::string &compressedBytes, std::string &uncompressedBytes);
   virtual int                  GetCachedFileContents(const std::string &strCachedName, const std::string &strFilePath,
                                                      std::string &strContent, const bool bUseCache = false);
   virtual void                 ApplyChannelsLogos();
   virtual void                 ApplyChannelsLogosFromEPG();
   virtual std::string          ReadMarkerValue(std::string &strLine, const char * strMarkerName);
   virtual int                  GetChannelId(const char * strChannelName, const char * strStreamUrl);
+  virtual std::string          AddHeaderToStreamUrl(const std::string& url, const std::string& header, const std::string& value) const;
 
 protected:
   virtual void *Process(void);

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -57,6 +57,7 @@ CHelper_libXBMC_pvr   *PVR  = NULL;
 std::string g_strTvgPath    = "";
 std::string g_strM3UPath    = "";
 std::string g_strLogoPath   = "";
+std::string g_userAgent     = "";
 int         g_logoPathType  = 0;
 int         g_iEPGTimeShift = 0;
 int         g_iStartNumber  = 1;
@@ -165,6 +166,10 @@ void ADDON_ReadSettings(void)
   if (XBMC->GetSetting(iPathType ? "logoBaseUrl" : "logoPath", &buffer))
   {
     g_strLogoPath = buffer;
+  }
+  if (XBMC->GetSetting("userAgent", &buffer))
+  {
+    g_userAgent = buffer;
   }
 
   // Logos from EPG

--- a/src/client.h
+++ b/src/client.h
@@ -44,6 +44,7 @@ extern CHelper_libXBMC_pvr          *PVR;
 extern std::string g_strM3UPath;
 extern std::string g_strTvgPath;
 extern std::string g_strLogoPath;
+extern std::string g_userAgent;
 extern int         g_logoPathType;
 extern int         g_iEPGTimeShift;
 extern int         g_iStartNumber;


### PR DESCRIPTION
Hi, using the headers passing option found an easy solution for the problem. Simply added on the fly the User-Agent during the stream parsing. From the addon settings you can choose the User-Agent you like. I didn't update all the strings yet for the new UI feature...
Keep in mind that User-Agent change it's only for the channels included in the playlist, so Kodi keeps it's own identity. I am open to discussion, let me know.