### PR TITLE
New catchup modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ The format specifiers are substitution based and work as follows:
 - `{M}`: The minute (00-59) of the start date\time.
 - `{S}`: The second (00-59) of the start date\time.
 - `{offset:X}`: The current offset (now - start time) divided by X seconds. Allows conversion to minutes and other time units. The minimum divider is 1, it must be an integer (not 1.5 or 2.25 etc.) and it must be a positive value. E.g. If you need an offset of 720 for a start time of 2 hours ago (2 hours is 7200 seconds), it means your divider is 10: `{offset:10}`. If you need minutes for the same offset you could use: `{offset:60}` which would result in a value of 120.
+- `{catchup-id}`: A programme specific identifier required in the catchup URL, value loaded from XMLTV programme entries. 
 
 Here’s some examples of how the different formats would look:
 - `?utc={utc}&lutc={lutc}`
@@ -253,7 +254,7 @@ General information on the XMLTV format can be found [here](http://wiki.xmltv.or
 
 **Programme elements**
 ```
-  <programme start="20080715003000 -0600" stop="20080715010000 -0600" channel="channel-x">
+  <programme start="20080715003000 -0600" stop="20080715010000 -0600" channel="channel-x" catchup-id="34534590">
     <title>My Show</title>
     <desc>Description of My Show</desc>
     <category>Drama</category>
@@ -273,7 +274,7 @@ General information on the XMLTV format can be found [here](http://wiki.xmltv.or
     <icon src="http://path-to-icons/my-show.png"/>
   </programme>
 ```
-The `programme` element supports the attributes `start`/`stop` in the format `YYYmmddHHMMSS +/-HHMM` and the attribute `channel` which needs to match the `channel` element's attribute `id`.
+The `programme` element supports the attributes `start`/`stop` in the format `YYYmmddHHMMSS +/-HHMM` and the attribute `channel` which needs to match the `channel` element's attribute `id`. There is an extra attribute which is not part of the XMLTV specification called `catchup-id`. Some providers require a programme specific id, this value can be used as part of the [catchup query format string specifiers](#catchup-format-specifiers).
 
 - `title`: The title of the prgramme.
 - `desc`: A descption of the programme.

--- a/README.md
+++ b/README.md
@@ -188,12 +188,15 @@ http://path-to-stream/live/channel-a.ts
 http://path-to-stream/live/channel-b.ts
 #EXTINF:0 catchup="append" catchup-source="&cutv={Y}-{m}-{d}T{H}:{M}:{S}" catchup-days="3",Channel C
 http://path-to-stream/live/channel-c.ts
+#EXTINF:0 tvg-id="channel-d" tvg-name="Channel-D" catchup="default" catchup-days="1" catchup-source="http://yoururl/channeld/video-{utc}-{duration}.m3u8",Channel D
+http://yoururl/channeld/video.m3u8
 ```
 
 *Explanation for Catchup entries*
 - For `Channel A` the stream URL will be used and the Query format string from the addon settings will be appended to construct the  catchup URL.
 - For `Channel B` the stream URL will not be used, instead using catchup-source as the catchup URL.
 - For `Channel C` the stream URL will be used and catchup-source will be appended to form the catchup URL.
+- For `Channel D` this is example of a flussonic style entry.
 
 Note: The minimum required for a channel/stream is an `#EXTINF` line with a channel name and the `URL` line. E.g. a minimal version of the exmaple file above would be:
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ The format specifiers are substitution based and work as follows:
 - `{utc}`: The start time of the programme in UTC format.
 - `${start}`: Same as `{utc}`.
 - `{lutc}`: Current time in UTC format.
+- `${timestamp}`: Same as `{lutc}`.
 - `{utcend}`: The start time of the programme in UTC format + `${duration}`.
 - `${end}`: Same as `{utcend}`.
 - `{duration}`: The programme duration + any start and end buffer (if set).

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ The format specifiers are substitution based and work as follows:
 - `{lutc}`: Current time in UTC format.
 - `{utcend}`: The start time of the programme in UTC format + `${duration}`.
 - `${end}`: Same as `{utcend}`.
-- `${duration}`: The programme duration + any start and end buffer (if set).
+- `{duration}`: The programme duration + any start and end buffer (if set).
 - `{Y}`: The 4-digit year (YYYY) of the start date\time.
 - `{m}`: The month (01-12) of the start date\time.
 - `{d}`: The day (01-31) of the start date\time.
@@ -181,7 +181,18 @@ http://path-to-stream/live/channel-x-hd.ts
 http://path-to-stream/live/channel-y.ts
 #EXTINF:0,Channel Z
 http://path-to-stream/live/channel-z.ts
+#EXTINF:0 catchup="default",Channel A
+http://path-to-stream/live/channel-a.ts
+#EXTINF:0 catchup="default" catchup-source="http://path-to-stream/live/catchup-b.ts&cutv={Y}-{m}-{d}T{H}:{M}:{S}" catchup-days="3",Channel B
+http://path-to-stream/live/channel-b.ts
+#EXTINF:0 catchup="append" catchup-source="&cutv={Y}-{m}-{d}T{H}:{M}:{S}" catchup-days="3",Channel C
+http://path-to-stream/live/channel-c.ts
 ```
+
+*Explanation for Catchup entries*
+- For `Channel A` the stream URL will be used and the Query format string from the addon settings will be appended to construct the  catchup URL.
+- For `Channel B` the stream URL will not be used, instead using catchup-source as the catchup URL.
+- For `Channel C` the stream URL will be used and catchup-source will be appended to form the catchup URL.
 
 Note: The minimum required for a channel/stream is an `#EXTINF` line with a channel name and the `URL` line. E.g. a minimal version of the exmaple file above would be:
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,13 @@ Addon settings for catchup:
 * **Query format string**: A format string (provider dependent) allowing timestamp information to be appended to a URL to denote when to catchup from. E.g. `&cutv={Y}-{m}-{d}T{H}:{M}:{S}`, which allows year, month, day, hour minute and second to be inserted to give: `&cutv=2019-11-26T22:00:32`. If the M3U entry using has a catchup mode of `default` or `append` and a `catchup-source` tag is provided in the M3U entry this setting will be ignored.
 * **Catchup window**: The number of days into the past in which it is possible to catchup on a show. Can be overidden in an M3U entry using a 'catchup-days' tag.
 * **All channels support catchup**: If enabled it is assumed that all channels support catchup. If there are no catchup specific tags in the M3U entries then the stream URL will be used as the source, and the URL format and catchup days will come from the addon settings. If this option is disabled then a M3U entry must have at least a `catchup="true"` or `catchup="default"` tag to enable catchup.
-* **All channels support catchup**: If enabled it is assumed that all channels support catchup. If there are no catchup specific tags in the M3U entries then the stream URL will be used as the source, and the `Query format string` and `Catchup window` number of days will come from the addon settings. If this option is disabled then a M3U entry must have at least a `catchup="default"` or `catchup="append"` tag to enable catchup.
+* **All channels support catchup using mode**: If enabled it is assumed that all channels support catchup using the selected mode if they do not have catchup tags. In this case the 'Query format string' and 'Catchup window' number of days will come from the addon settings if needed. If this option is disabled then an M3U entry must have at least a `catchup=` tag to enable catchup. The options for how to build the catch URL are:
+    - `Disabled` - Do not assume all channel support catchup.
+    - `Default` - Use catchup source as the full catchup URL, if there is no catchup source use Append mode.
+    - `Append` - Append the catchup source to the channel URL, if there is no catchup source append the `Query format string` instead.
+    - `Shift (SIPTV)` - Append the standard SIPTV catchup string to the channel URL.
+    - `Flussonic` - Build a flussonic URL from the channel URL.
+    - `Xtream codes` - Build an Xtream codes URL from the channel URL.
 * **Play from EPG in Live TV mode (using timeshift)**: When disabled any catchup show from the past will be played like a video (bounded by start and end times). If enabled, it will instead act like a live stream with timeshift, also allowing the ability to skip back and forward programmes.
 * **Buffer before programme start**: The amount of buffer to give before the playback start point of an EPG entry that will be watched as a video.
 * **Buffer after programme end**: The amount of buffer to give after the playback end point of an EPG entry that will be watched as a video.
@@ -151,15 +157,16 @@ The format specifiers are substitution based and work as follows:
 - `${timestamp}`: Same as `{lutc}`.
 - `{utcend}`: The start time of the programme in UTC format + `${duration}`.
 - `${end}`: Same as `{utcend}`.
-- `{duration}`: The programme duration + any start and end buffer (if set).
 - `{Y}`: The 4-digit year (YYYY) of the start date\time.
 - `{m}`: The month (01-12) of the start date\time.
 - `{d}`: The day (01-31) of the start date\time.
 - `{H}`: The hour (00-23) of the start date\time.
 - `{M}`: The minute (00-59) of the start date\time.
 - `{S}`: The second (00-59) of the start date\time.
+- `{duration}`: The programme duration + any start and end buffer (if set).
+- `{duration:X}`: The programme duration (as above) divided by X seconds. Allows conversion to minutes and other time units. The minimum divider is 1, it must be an integer (not 1.5 or 2.25 etc.) and it must be a positive value. E.g. If you have a duration of 7200 seconds and you need 2 hours (2 hours is 7200 seconds), it means your divider is 3600: `{offset:3600}`. If you need minutes for the same duration you could use: `{offset:60}` which would result in a value of 120.
 - `{offset:X}`: The current offset (now - start time) divided by X seconds. Allows conversion to minutes and other time units. The minimum divider is 1, it must be an integer (not 1.5 or 2.25 etc.) and it must be a positive value. E.g. If you need an offset of 720 for a start time of 2 hours ago (2 hours is 7200 seconds), it means your divider is 10: `{offset:10}`. If you need minutes for the same offset you could use: `{offset:60}` which would result in a value of 120.
-- `{catchup-id}`: A programme specific identifier required in the catchup URL, value loaded from XMLTV programme entries. 
+- `{catchup-id}`: A programme specific identifier required in the catchup URL, value loaded from XMLTV programme entries.
 
 Here’s some examples of how the different formats would look:
 - `?utc={utc}&lutc={lutc}`
@@ -189,15 +196,30 @@ http://path-to-stream/live/channel-a.ts
 http://path-to-stream/live/channel-b.ts
 #EXTINF:0 catchup="append" catchup-source="&cutv={Y}-{m}-{d}T{H}:{M}:{S}" catchup-days="3",Channel C
 http://path-to-stream/live/channel-c.ts
-#EXTINF:0 tvg-id="channel-d" tvg-name="Channel-D" catchup="default" catchup-days="1" catchup-source="http://yoururl/channeld/video-{utc}-{duration}.m3u8",Channel D
+#EXTINF:0 tvg-id="channel-d" tvg-name="Channel-D" catchup="shift" catchup-days="3",Channel D
+http://path-to-stream/live/channel-d.ts
+#EXTINF:0 tvg-id="channel-e" tvg-name="Channel-E" timeshift="3",Channel E
+http://path-to-stream/live/channel-e.ts
+#EXTINF:0 tvg-id="channel-f" tvg-name="Channel-F" catchup="default" catchup-days="1" catchup-source="http://yoururl/channeld/video-{utc}-{duration}.m3u8",Channel F
 http://yoururl/channeld/video.m3u8
+#EXTINF:-1 catchup="fs",Channel G
+http://list.tv:8888/325/mono.m3u8?token=secret
+#EXTINF:-1 catchup="fs",Channel H
+http://list.tv:8080/my@account.xc/my_password/1477
+#EXTINF:-1 catchup="fs",Channel I
+http://list.tv:8080/live/my@account.xc/my_password/1477.m3u8
 ```
 
 *Explanation for Catchup entries*
-- For `Channel A` the stream URL will be used and the Query format string from the addon settings will be appended to construct the  catchup URL.
+- For `Channel A` the stream URL will be used and the Query format string from the addon settings will be appended to construct the catchup URL.
 - For `Channel B` the stream URL will not be used, instead using catchup-source as the catchup URL.
 - For `Channel C` the stream URL will be used and catchup-source will be appended to form the catchup URL.
-- For `Channel D` this is example of a flussonic style entry.
+- For `Channel D` this is an example of a siptv style entry which auto generates the catchup-source by appending `?utc={utc}&lutc={lutc}` or `&utc={utc}&lutc={lutc}` to the channel URL.
+- For `Channel E` this is an example of the old siptv style entry which uses a `timeshift` tag to combine shift and days into one field. The catchup-source output will be the same as channel D.
+- For `Channel F` this is an example of a flussonic style entry manually specifying the catcup-source. Note that the mode is still `default`.
+- For `Channel G` this is an example of a flussonic style entry which auto generates the catchup-source.
+- For `Channel H` this is an example of a xtream codes style entry which auto generates the catchup-source for `ts` streams.
+- For `Channel I` this is an example of a xtream codes style entry which auto generates the catchup-source for `m3u8` streams.
 
 Note: The minimum required for a channel/stream is an `#EXTINF` line with a channel name and the `URL` line. E.g. a minimal version of the exmaple file above would be:
 

--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="4.10.0"
+  version="4.11.0"
   name="PVR IPTV Simple Client"
   provider-name="nightik">
   <requires>@ADDON_DEPENDS@</requires>
@@ -159,6 +159,15 @@
     <disclaimer lang="zh_TW">這是測試中的軟體！原創作者無法針對以下情況負責：包括播放失敗，不正確的電子節目表，多餘的時數，或任何不可預期的不良影響。</disclaimer>
     <platform>@PLATFORM@</platform>
     <news>
+v4.11.0
+- Added: Support new catchup providers, shift, xc and fs including TS stream support
+- Added: Support for timestamp catchup format specifier
+- Added: Optional catchup-id per programme from XMLTV
+- Added: Add catchup M3U8 examples to README
+- Fixed: Live catchup streams that don't support timeshift
+- Fixed: Don't build test catchup url for non catchup streams
+- Added: Support for offset catchup format specifier
+- Update: Add p8-platform to addon depends instead of from kodi
 
 v4.10.0
 - Added: User-Agent support from advanced addon setting

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,13 @@
+v4.11.0
+- Added: Support new catchup providers, shift, xc and fs including TS stream support
+- Added: Support for timestamp catchup format specifier
+- Added: Optional catchup-id per programme from XMLTV
+- Added: Add catchup M3U8 examples to README
+- Fixed: Live catchup streams that don't support timeshift
+- Fixed: Don't build test catchup url for non catchup streams
+- Added: Support for offset catchup format specifier
+- Update: Add p8-platform to addon depends instead of from kodi
+
 v4.10.0
 - Added: User-Agent support from advanced addon setting
 

--- a/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
@@ -287,9 +287,9 @@ msgctxt "#30103"
 msgid "Catchup window"
 msgstr ""
 
-#. label: Catchup - allChannelsSupportCatchup
+#. label: Catchup - allChannelsCatchupMode
 msgctxt "#30104"
-msgid "All channels support catchup"
+msgid "All channels support catchup using mode"
 msgstr ""
 
 #. label-group: Catchup - Watch From EPG
@@ -317,7 +317,37 @@ msgctxt "#30109"
 msgid "Catchup only available on finished programmes"
 msgstr ""
 
-#empty strings from id 30110 to 30599
+#. label-option: Catchup - allChannelsCatchupMode
+msgctxt "#30110"
+msgid "Disabled"
+msgstr ""
+
+#. label-option: Catchup - allChannelsCatchupMode
+msgctxt "#30111"
+msgid "Default"
+msgstr ""
+
+#. label-option: Catchup - allChannelsCatchupMode
+msgctxt "#30112"
+msgid "Append"
+msgstr ""
+
+#. label-option: Catchup - allChannelsCatchupMode
+msgctxt "#30113"
+msgid "Shift (SIPTV)"
+msgstr ""
+
+#. label-option: Catchup - allChannelsCatchupMode
+msgctxt "#30114"
+msgid "Flussonic"
+msgstr ""
+
+#. label-option: Catchup - allChannelsCatchupMode
+msgctxt "#30115"
+msgid "Xtream codes"
+msgstr ""
+
+#empty strings from id 30116 to 30599
 
 #. ############
 #. help info #
@@ -535,9 +565,9 @@ msgctxt "#30703"
 msgid "A number of days into the past in which it is possible to catchup on a programme. Can be overidden in an M3U entry using a 'catchup-days' tag."
 msgstr ""
 
-#. help: Catchup - allChannelsSupportCatchup
+#. help: Catchup - allChannelsCatchupMode
 msgctxt "#30704"
-msgid "If enabled it is assumed that all channels support catchup. If there are no catchup specific tags in the M3U entries then the stream URL will be used as the source, and the 'Query format string' and 'Catchup window' number of days will come from the addon settings. If this option is disabled then a M3U entry must have at least a 'catchup=\"default\"' or 'catchup=\"append\"' tag to enable catchup."
+msgid "If enabled it is assumed that all channels support catchup using the selected mode if they do not have catchup tags. In this case the 'Query format string' and 'Catchup window' number of days will come from the addon settings if needed. If this option is disabled then an M3U entry must have at least a 'catchup=' tag to enable catchup. The options for how to build the catch URL are: [Disabled] - Do not assume all channel support catchup; [Default] - Use catchup source as the full catchup URL, if there is no catchup source use Append mode; [Append] - Append the catchup source to the channel URL, if there is no catchup source using the 'Query format string'; [Shift (SIPTV)] - Append the standard SIPTV catchup string to the channel URL; [Flussonic] - Build a flussonic URL from the channel URL; [Xtream codes] - Build an Xtream codes URL from the channel URL."
 msgstr ""
 
 #. help: Catchup - catchupPlayEpgAsLive

--- a/pvr.iptvsimple/resources/settings.xml
+++ b/pvr.iptvsimple/resources/settings.xml
@@ -312,13 +312,20 @@
             <formatlabel>17999</formatlabel>
           </control>
         </setting>
-        <setting id="allChannelSupportCatchup" type="boolean" parent="catchupEnabled" label="30104" help="30704">
-          <level>2</level>
-          <default>false</default>
-          <dependencies>
-            <dependency type="enable" setting="catchupEnabled" operator="is">true</dependency>
-          </dependencies>
-          <control type="toggle" />
+        <setting id="allChannelsCatchupMode" type="integer" label="30104" help="30704">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="30110">0</option> <!-- DISABLED -->
+              <option label="30111">1</option> <!-- DEFAULT -->
+              <option label="30112">2</option> <!-- APPEND -->
+              <option label="30113">3</option> <!-- SHIFT -->
+              <option label="30114">4</option> <!-- FLUSSONIC -->
+              <option label="30115">5</option> <!-- XTREAM_CODES -->
+            </options>
+          </constraints>
+          <control type="list" format="integer" />
         </setting>
       </group>
       <group id="2" label="30105">

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -270,7 +270,7 @@ PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL* channel, PVR_NAMED_VALUE
 
     StreamUtils::SetAllStreamProperties(properties, iPropertiesCount, propertiesMax, m_currentChannel, streamURL, catchupProperties);
 
-    Logger::Log(LogLevel::LEVEL_NOTICE, "%s - Live %s URL: %s", __FUNCTION__, !catchupUrl.empty() ? "Stream" : "Catchup", streamURL.c_str());
+    Logger::Log(LogLevel::LEVEL_NOTICE, "%s - Live %s URL: %s", __FUNCTION__, catchupUrl.empty() ? "Stream" : "Catchup", streamURL.c_str());
 
     return PVR_ERROR_NO_ERROR;
   }

--- a/src/iptvsimple/CatchupController.cpp
+++ b/src/iptvsimple/CatchupController.cpp
@@ -329,29 +329,29 @@ void FormatUtc(const char *str, time_t tTime, std::string &urlFormatString)
 
 std::string FormatDateTime(time_t dateTimeEpg, time_t duration, const std::string &urlFormatString)
 {
-  std::string fomrattedUrl = urlFormatString;
+  std::string formattedUrl = urlFormatString;
 
   const time_t dateTimeNow = std::time(0);
   tm* dateTime = std::localtime(&dateTimeEpg);
 
-  FormatTime('Y', dateTime, fomrattedUrl);
-  FormatTime('m', dateTime, fomrattedUrl);
-  FormatTime('d', dateTime, fomrattedUrl);
-  FormatTime('H', dateTime, fomrattedUrl);
-  FormatTime('M', dateTime, fomrattedUrl);
-  FormatTime('S', dateTime, fomrattedUrl);
-  FormatUtc("{utc}", dateTimeEpg, fomrattedUrl);
-  FormatUtc("${start}", dateTimeEpg, fomrattedUrl);
-  FormatUtc("{utcend}", dateTimeEpg + duration, fomrattedUrl);
-  FormatUtc("${end}", dateTimeEpg + duration, fomrattedUrl);
-  FormatUtc("{lutc}", dateTimeNow, fomrattedUrl);
-  FormatUtc("${timestamp}", dateTimeNow, fomrattedUrl);
-  FormatUtc("{duration}", duration, fomrattedUrl);
-  FormatOffset(dateTimeNow - dateTimeEpg, fomrattedUrl);
+  FormatTime('Y', dateTime, formattedUrl);
+  FormatTime('m', dateTime, formattedUrl);
+  FormatTime('d', dateTime, formattedUrl);
+  FormatTime('H', dateTime, formattedUrl);
+  FormatTime('M', dateTime, formattedUrl);
+  FormatTime('S', dateTime, formattedUrl);
+  FormatUtc("{utc}", dateTimeEpg, formattedUrl);
+  FormatUtc("${start}", dateTimeEpg, formattedUrl);
+  FormatUtc("{utcend}", dateTimeEpg + duration, formattedUrl);
+  FormatUtc("${end}", dateTimeEpg + duration, formattedUrl);
+  FormatUtc("{lutc}", dateTimeNow, formattedUrl);
+  FormatUtc("${timestamp}", dateTimeNow, formattedUrl);
+  FormatUtc("{duration}", duration, formattedUrl);
+  FormatOffset(dateTimeNow - dateTimeEpg, formattedUrl);
 
-  Logger::Log(LEVEL_DEBUG, "%s - \"%s\"", __FUNCTION__, fomrattedUrl.c_str());
+  Logger::Log(LEVEL_DEBUG, "%s - \"%s\"", __FUNCTION__, formattedUrl.c_str());
 
-  return fomrattedUrl;
+  return formattedUrl;
 }
 
 std::string AppendQueryStringAndPreserveOptions(const std::string &url, const std::string &postfixQueryString)

--- a/src/iptvsimple/CatchupController.cpp
+++ b/src/iptvsimple/CatchupController.cpp
@@ -433,8 +433,11 @@ std::string CatchupController::GetCatchupUrl(const Channel& channel) const
 
 std::string CatchupController::GetStreamTestUrl(const Channel& channel) const
 {
-  // Test URL from 2 hours ago for 1 hour duration.
-  return BuildEpgTagUrl(std::time(nullptr) - (2 * 60 * 60),  60 * 60, channel, 0, m_programmeCatchupId);
+  if (m_catchupStartTime > 0)
+    // Test URL from 2 hours ago for 1 hour duration.
+    return BuildEpgTagUrl(std::time(nullptr) - (2 * 60 * 60), 60 * 60, channel, 0, m_programmeCatchupId);
+  else
+    return channel.GetStreamURL();
 }
 
 EpgEntry* CatchupController::GetLiveEPGEntry(const Channel& myChannel)

--- a/src/iptvsimple/CatchupController.cpp
+++ b/src/iptvsimple/CatchupController.cpp
@@ -348,6 +348,7 @@ std::string FormatDateTime(time_t dateTimeEpg, time_t duration, const std::strin
   FormatUtc("${timestamp}", dateTimeNow, formattedUrl);
   FormatUtc("{duration}", duration, formattedUrl);
   FormatUnits(duration, "duration", formattedUrl);
+  FormatUtc("${offset}", dateTimeNow - dateTimeEpg, formattedUrl);
   FormatUnits(dateTimeNow - dateTimeEpg, "offset", formattedUrl);
 
   Logger::Log(LEVEL_DEBUG, "%s - \"%s\"", __FUNCTION__, formattedUrl.c_str());

--- a/src/iptvsimple/CatchupController.cpp
+++ b/src/iptvsimple/CatchupController.cpp
@@ -345,6 +345,7 @@ std::string FormatDateTime(time_t dateTimeEpg, time_t duration, const std::strin
   FormatUtc("{utcend}", dateTimeEpg + duration, fomrattedUrl);
   FormatUtc("${end}", dateTimeEpg + duration, fomrattedUrl);
   FormatUtc("{lutc}", dateTimeNow, fomrattedUrl);
+  FormatUtc("${timestamp}", dateTimeNow, fomrattedUrl);
   FormatUtc("{duration}", duration, fomrattedUrl);
   FormatOffset(dateTimeNow - dateTimeEpg, fomrattedUrl);
 

--- a/src/iptvsimple/CatchupController.cpp
+++ b/src/iptvsimple/CatchupController.cpp
@@ -58,7 +58,7 @@ void CatchupController::ProcessChannelForPlayback(Channel& channel, std::map<std
       m_catchupEndTime = liveEpgEntry->GetEndTime();
     }
     else if (m_controlsLiveStream || !channel.IsCatchupSupported() ||
-             (channel.IsCatchupSupported() && Settings::GetInstance().CatchupOnlyOnFinishedProgrammes()))
+             (!m_controlsLiveStream && channel.IsCatchupSupported()))
     {
       // Live without EPG entry
       ClearProgramme();

--- a/src/iptvsimple/CatchupController.h
+++ b/src/iptvsimple/CatchupController.h
@@ -79,6 +79,7 @@ namespace iptvsimple
     std::string m_programmeTitle;
     unsigned int m_programmeUniqueChannelId = 0;
     int m_programmeChannelTvgShift = 0;
+    std::string m_programmeCatchupId;
 
     bool m_controlsLiveStream = false;
     iptvsimple::Epg& m_epg;

--- a/src/iptvsimple/PlaylistLoader.h
+++ b/src/iptvsimple/PlaylistLoader.h
@@ -44,6 +44,7 @@ namespace iptvsimple
   static const std::string CATCHUP                 = "catchup=";
   static const std::string CATCHUP_DAYS            = "catchup-days=";
   static const std::string CATCHUP_SOURCE          = "catchup-source=";
+  static const std::string CATCHUP_SIPTV           = "timeshift=";
   static const std::string KODIPROP_MARKER         = "#KODIPROP:";
   static const std::string EXTVLCOPT_MARKER        = "#EXTVLCOPT:";
   static const std::string EXTVLCOPT_DASH_MARKER   = "#EXTVLCOPT--";

--- a/src/iptvsimple/Settings.cpp
+++ b/src/iptvsimple/Settings.cpp
@@ -100,8 +100,8 @@ void Settings::ReadFromAddon(const std::string& userPath, const std::string clie
     m_catchupQueryFormat = buffer;
   if (!XBMC->GetSetting("catchupDays", &m_catchupDays))
     m_catchupDays = 5;
-  if (!XBMC->GetSetting("allChannelSupportCatchup", &m_allChannelsSupportCatchup))
-    m_allChannelsSupportCatchup = false;
+  if (!XBMC->GetSetting("allChannelsCatchupMode", &m_allChannelsCatchupMode))
+    m_allChannelsCatchupMode = CatchupMode::DISABLED;
   if (!XBMC->GetSetting("catchupPlayEpgAsLive", &m_catchupPlayEpgAsLive))
     m_catchupPlayEpgAsLive = false;
   if (!XBMC->GetSetting("catchupWatchEpgBeginBufferMins", &m_catchupWatchEpgBeginBufferMins))
@@ -199,8 +199,8 @@ ADDON_STATUS Settings::SetValue(const std::string& settingName, const void* sett
     return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_catchupQueryFormat, ADDON_STATUS_OK, ADDON_STATUS_OK);
   if (settingName == "catchupDays")
     return SetSetting<int, ADDON_STATUS>(settingName, settingValue, m_catchupDays, ADDON_STATUS_OK, ADDON_STATUS_OK);
-  if (settingName == "allChannelSupportCatchup")
-    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_allChannelsSupportCatchup, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  if (settingName == "allChannelsCatchupMode")
+    return SetSetting<CatchupMode, ADDON_STATUS>(settingName, settingValue, m_allChannelsCatchupMode, ADDON_STATUS_OK, ADDON_STATUS_OK);
   if (settingName == "catchupPlayEpgAsLive")
     return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_catchupPlayEpgAsLive, ADDON_STATUS_OK, ADDON_STATUS_OK);
   if (settingName == "catchupWatchEpgBeginBufferMins")

--- a/src/iptvsimple/Settings.h
+++ b/src/iptvsimple/Settings.h
@@ -21,6 +21,7 @@
  *
  */
 
+#include "data/Channel.h"
 #include "utilities/Logger.h"
 
 #include <string>
@@ -117,7 +118,7 @@ namespace iptvsimple
     const std::string& GetCatchupQueryFormat() const { return m_catchupQueryFormat; }
     int GetCatchupDays() const { return m_catchupDays; }
     time_t GetCatchupDaysInSeconds() const { return static_cast<time_t>(m_catchupDays) * 24 * 60 * 60; }
-    bool AllChannelsSupportCatchup() const { return m_allChannelsSupportCatchup; }
+    const CatchupMode& GetAllChannelsCatchupMode() const { return m_allChannelsCatchupMode; }
     bool CatchupPlayEpgAsLive() const { return m_catchupPlayEpgAsLive; }
     int GetCatchupWatchEpgBeginBufferMins() const { return m_catchupWatchEpgBeginBufferMins; }
     time_t GetCatchupWatchEpgBeginBufferSecs() const { return static_cast<time_t>(m_catchupWatchEpgBeginBufferMins) * 60; }
@@ -206,7 +207,7 @@ namespace iptvsimple
     bool m_catchupEnabled = false;
     std::string m_catchupQueryFormat;
     int m_catchupDays = 3;
-    bool m_allChannelsSupportCatchup = false;
+    CatchupMode m_allChannelsCatchupMode = CatchupMode::DISABLED;
     bool m_catchupPlayEpgAsLive = false;
     int m_catchupWatchEpgBeginBufferMins = 5;
     int m_catchupWatchEpgEndBufferMins = 15;

--- a/src/iptvsimple/data/EpgEntry.cpp
+++ b/src/iptvsimple/data/EpgEntry.cpp
@@ -187,6 +187,9 @@ bool EpgEntry::UpdateFrom(const xml_node& channelNode, const std::string& id, in
   long long tmpStart = ParseDateTime(strStart);
   long long tmpEnd = ParseDateTime(strStop);
 
+  GetAttributeValue(channelNode, "catchup-id", m_catchupId);
+  m_catchupId = StringUtils::Trim(m_catchupId);
+
   if ((tmpEnd + maxShiftTime < start) || (tmpStart + minShiftTime > end))
     return false;
 

--- a/src/iptvsimple/data/EpgEntry.h
+++ b/src/iptvsimple/data/EpgEntry.h
@@ -102,6 +102,9 @@ namespace iptvsimple
       const std::string& GetWriter() const { return m_writer; }
       void SetWriter(const std::string& value) { m_writer = value; }
 
+      const std::string& GetCatchupId() const { return m_catchupId; }
+      void SetCatchupId(const std::string& value) { m_catchupId = value; }
+
       void UpdateTo(EPG_TAG& left, int iChannelUid, int timeShift, const std::vector<EpgGenre>& genres);
       bool UpdateFrom(const pugi::xml_node& channelNode, const std::string& id, int broadcastId,
                       int start, int end, int minShiftTime, int maxShiftTime);
@@ -133,6 +136,7 @@ namespace iptvsimple
       std::string m_cast;
       std::string m_director;
       std::string m_writer;
+      std::string m_catchupId;
     };
   } //namespace data
 } //namespace iptvsimple

--- a/src/iptvsimple/utilities/StreamUtils.h
+++ b/src/iptvsimple/utilities/StreamUtils.h
@@ -38,6 +38,7 @@ namespace iptvsimple
       HLS = 0,
       DASH,
       SMOOTH_STREAMING,
+      TS,
       OTHER_TYPE
     };
 


### PR DESCRIPTION
v4.11.0
- Added: Support new catchup providers, shift, xc and fs including TS stream support
- Added: Support for timestamp catchup format specifier
- Added: Optional catchup-id per programme from XMLTV
- Added: Add catchup M3U8 examples to README
- Fixed: Live catchup streams that don't support timeshift
- Fixed: Don't build test catchup url for non catchup streams
- Added: Support for offset catchup format specifier
- Update: Add p8-platform to addon depends instead of from kodi