### PR TITLE
Catchup mimetype fixes

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="4.11.0"
+  version="4.11.1"
   name="PVR IPTV Simple Client"
   provider-name="nightik">
   <requires>@ADDON_DEPENDS@</requires>
@@ -159,6 +159,11 @@
     <disclaimer lang="zh_TW">這是測試中的軟體！原創作者無法針對以下情況負責：包括播放失敗，不正確的電子節目表，多餘的時數，或任何不可預期的不良影響。</disclaimer>
     <platform>@PLATFORM@</platform>
     <news>
+v4.11.1
+- Fixed: Also check for ffmpegdirect mime type when checking stream type
+- Fixed: Pass mime type to ffmpegdirect if available
+- Fixed: Inspecting stream type for catchup mode shift should default to TS
+
 v4.11.0
 - Added: Support new catchup providers, shift, xc and fs including TS stream support
 - Added: Support for timestamp catchup format specifier

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,8 @@
+v4.11.1
+- Fixed: Also check for ffmpegdirect mime type when checking stream type
+- Fixed: Pass mime type to ffmpegdirect if available
+- Fixed: Inspecting stream type for catchup mode shift should default to TS
+
 v4.11.0
 - Added: Support new catchup providers, shift, xc and fs including TS stream support
 - Added: Support for timestamp catchup format specifier

--- a/src/iptvsimple/CatchupController.cpp
+++ b/src/iptvsimple/CatchupController.cpp
@@ -209,6 +209,10 @@ void CatchupController::SetCatchupInputStreamProperties(bool playbackAsLive, con
   if (!m_programmeCatchupId.empty())
     catchupProperties.insert({"inputstream.ffmpegdirect.programme_catchup_id", m_programmeCatchupId});
 
+  const std::string mimeType = channel.GetProperty("mimetype");
+  if (!mimeType.empty() && channel.GetProperty("inputstream.ffmpegdirect.mime_type").empty())
+    catchupProperties.insert({"inputstream.ffmpegdirect.mime_type", mimeType});
+
   // TODO: Should also send programme start and duration potentially
   // When doing this don't forget to add Settings::GetInstance().GetCatchupWatchEpgBeginBufferSecs() + Settings::GetInstance().GetCatchupWatchEpgEndBufferSecs();
   // if in video playbacl mode from epg, i.e. if if (!Settings::GetInstance().CatchupPlayEpgAsLive() && m_playbackIsVideo)s
@@ -221,6 +225,7 @@ void CatchupController::SetCatchupInputStreamProperties(bool playbackAsLive, con
   Logger::Log(LEVEL_DEBUG, "catchup_buffer_offset - %s", std::to_string(m_timeshiftBufferOffset).c_str());
   Logger::Log(LEVEL_DEBUG, "timezone_shift - %s", std::to_string(channel.GetTvgShift()).c_str());
   Logger::Log(LEVEL_DEBUG, "programme_catchup_id - '%s'", m_programmeCatchupId.c_str());
+  Logger::Log(LEVEL_DEBUG, "mime_type - '%s'", mimeType.c_str());
 }
 
 void CatchupController::TestAndStoreStreamType(Channel& channel)

--- a/src/iptvsimple/CatchupController.cpp
+++ b/src/iptvsimple/CatchupController.cpp
@@ -234,7 +234,7 @@ void CatchupController::TestAndStoreStreamType(Channel& channel)
   const std::string streamTestUrl = GetStreamTestUrl(channel);
   StreamType streamType = StreamUtils::GetStreamType(streamTestUrl, channel);
   if (streamType == StreamType::OTHER_TYPE)
-    streamType = StreamUtils::InspectStreamType(streamTestUrl);
+    streamType = StreamUtils::InspectStreamType(streamTestUrl, channel);
 
   // TODO: we really want to store this in a file and load it on any restart
   // using channel doesn't make sense as it's otherwise immutable.

--- a/src/iptvsimple/utilities/StreamUtils.cpp
+++ b/src/iptvsimple/utilities/StreamUtils.cpp
@@ -57,7 +57,7 @@ void StreamUtils::SetAllStreamProperties(PVR_NAMED_VALUE* properties, unsigned i
   {
     StreamType streamType = StreamUtils::GetStreamType(streamURL, channel);
     if (streamType == StreamType::OTHER_TYPE)
-      streamType = StreamUtils::InspectStreamType(streamURL);
+      streamType = StreamUtils::InspectStreamType(streamURL, channel);
 
     // Using kodi's built in inputstreams
     if (StreamUtils::UseKodiInputstreams(streamType))
@@ -148,7 +148,7 @@ const StreamType StreamUtils::GetStreamType(const std::string& url, const Channe
   return StreamType::OTHER_TYPE;
 }
 
-const StreamType StreamUtils::InspectStreamType(const std::string& url)
+const StreamType StreamUtils::InspectStreamType(const std::string& url, const Channel& channel)
 {
   if (!FileUtils::FileExists(url))
     return StreamType::OTHER_TYPE;
@@ -167,6 +167,11 @@ const StreamType StreamUtils::InspectStreamType(const std::string& url)
     if (source.find("<SmoothStreamingMedia") != std::string::npos)
       return StreamType::SMOOTH_STREAMING;
   }
+
+  // If we can't inspect the stream type the only option left for shift mode is TS
+  if (channel.GetCatchupMode() == CatchupMode::SHIFT ||
+      channel.GetCatchupMode() == CatchupMode::TIMESHIFT)
+    return StreamType::TS;
 
   return StreamType::OTHER_TYPE;
 }

--- a/src/iptvsimple/utilities/StreamUtils.cpp
+++ b/src/iptvsimple/utilities/StreamUtils.cpp
@@ -126,21 +126,23 @@ std::string StreamUtils::GetEffectiveInputStreamClass(const StreamType& streamTy
 
 const StreamType StreamUtils::GetStreamType(const std::string& url, const Channel& channel)
 {
+  std::string mimeType = channel.GetProperty(PVR_STREAM_PROPERTY_MIMETYPE);
+  if (mimeType.empty())
+    mimeType = channel.GetProperty("inputstream.ffmpegdirect.mime_type");
+
   if (url.find(".m3u8") != std::string::npos ||
-      channel.GetProperty(PVR_STREAM_PROPERTY_MIMETYPE) == "application/x-mpegURL" ||
-      channel.GetProperty(PVR_STREAM_PROPERTY_MIMETYPE) == "application/vnd.apple.mpegurl")
+      mimeType == "application/x-mpegURL" ||
+      mimeType == "application/vnd.apple.mpegurl")
     return StreamType::HLS;
 
-  if (url.find(".mpd") != std::string::npos ||
-      channel.GetProperty(PVR_STREAM_PROPERTY_MIMETYPE) == "application/xml+dash")
+  if (url.find(".mpd") != std::string::npos || mimeType == "application/xml+dash")
     return StreamType::DASH;
 
   if (url.find(".ism") != std::string::npos &&
       !(url.find(".ismv") != std::string::npos || url.find(".isma") != std::string::npos))
     return StreamType::SMOOTH_STREAMING;
 
-  if (channel.GetProperty(PVR_STREAM_PROPERTY_MIMETYPE) == "video/mp2t" ||
-      channel.IsCatchupTSStream())
+  if (mimeType == "video/mp2t" || channel.IsCatchupTSStream())
     return StreamType::TS;
 
   return StreamType::OTHER_TYPE;

--- a/src/iptvsimple/utilities/StreamUtils.h
+++ b/src/iptvsimple/utilities/StreamUtils.h
@@ -50,7 +50,7 @@ namespace iptvsimple
       static void SetAllStreamProperties(PVR_NAMED_VALUE* properties, unsigned int* propertiesCount, unsigned int propertiesMax, const iptvsimple::data::Channel& channel, const std::string& streamUrl, std::map<std::string, std::string>& catchupProperties);
       static void SetStreamProperty(PVR_NAMED_VALUE* properties, unsigned int* propertiesCount, unsigned int propertiesMax, const std::string& name, const std::string& value);
       static const StreamType GetStreamType(const std::string& url, const iptvsimple::data::Channel& channel);
-      static const StreamType InspectStreamType(const std::string& url);
+      static const StreamType InspectStreamType(const std::string& url, const iptvsimple::data::Channel& channel);
       static const std::string GetManifestType(const StreamType& streamType);
       static const std::string GetMimeType(const StreamType& streamType);
       static std::string GetURLWithFFmpegReconnectOptions(const std::string& streamUrl, const StreamType& streamType, const iptvsimple::data::Channel& channel);


### PR DESCRIPTION
v4.11.1
- Fixed: Also check for ffmpegdirect mime type when checking stream type
- Fixed: Pass mime type to ffmpegdirect if available
- Fixed: Inspecting stream type for catchup mode shift should default to TS