### PR TITLE
Fix typo in date regex, caused failure to load EPG on some platforms

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="4.11.4"
+  version="4.11.5"
   name="PVR IPTV Simple Client"
   provider-name="nightik">
   <requires>@ADDON_DEPENDS@</requires>
@@ -165,6 +165,9 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v4.11.5
+- Fixed: Typo in date regex, caused failure to load EPG on some platforms
+
 v4.11.4
 - Fixed: EPG performance
 - Update: PVR API 6.3.0

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v4.11.5
+- Fixed: Typo in date regex, caused failure to load EPG on some platforms
+
 v4.11.4
 - Fixed: EPG performance
 - Update: PVR API 6.3.0

--- a/src/iptvsimple/data/EpgEntry.cpp
+++ b/src/iptvsimple/data/EpgEntry.cpp
@@ -223,7 +223,7 @@ bool EpgEntry::UpdateFrom(const xml_node& channelNode, const std::string& id,
   const std::string dateString = GetNodeValue(channelNode, "date");
   if (!dateString.empty())
   {
-    static const std::regex dateRegex("^[1-9][0-9][0-9][0-9][0-9][0-9][0-9][0s-9]");
+    static const std::regex dateRegex("^[1-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]");
     if (std::regex_match(dateString, dateRegex))
     {
       m_firstAired = ParseAsW3CDateString(dateString);


### PR DESCRIPTION
v4.11.5
- Fixed: Typo in date regex, caused failure to load EPG on some platforms