### PR TITLE
Fix incorrect live URL selection for standard (no timeshift) catchup streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Settings related to Channel Logos.
 ### Catchup
 Catchup settings for viewing archived live programmes. Allows the option of 'Play programme' when viewing EPG entry info. Only works if your provider supports catchup.
 
-Note that catchup functionality can work one of two ways. The first is where a standard inputstream is used, allowing the use of the EPG to view a programme from within the catchup window like a video. The second is where the `inputstream.ffmpegdirect` addon is installed which allows timeshift, either as a video or with playback as live. When playback as live is enabled it's possible to skip back/forward programme by programme and jump to other channel and programmes via the OSD menus.
+Note that catchup functionality can work one of two ways. The first is where a standard inputstream is used, allowing the use of the EPG to view a programme from within the catchup window like a video. The second is where the `inputstream.ffmpegdirect` addon is installed which allows timeshift, either as a video or with playback as live. When playback as live is enabled it's possible to skip back/forward programme by programme and jump to other channel and programmes via the OSD menus. Also note that using `inputstream.ffmpegdirect` is automatic if using TS/M3U8 streams that support catchup. If this inputstream is incorrectly chosen it's possible to override this by adding a `#KODIPROP:inputstreamclass=inputstream.ffmpeg` line before the channel's M3U entry (or any alternative inputstream instead).
 
 Catchup tags can be specified in the M3U entries and these tags override any values configured in the Catchup settings. The supported M3U catchup tags are `catchup`, `catchup-source` and `catchup-days`. See the [Supported M3U elements section](#m3u-format-elements) below for further details. The full catchup URL or a query to be appended to the stream URL is either provided in the `catchup-source` tag (i.e. complete with format specifiers) or in the case this is not provided the `Query format string` setting is appended to stream URL. See the [Catchup format specifiers section](#catchup-format-specifiers) below for a more detailed explanation and further examples.
 
@@ -133,9 +133,10 @@ Addon settings for catchup:
     - `Shift (SIPTV)` - Append the standard SIPTV catchup string to the channel URL.
     - `Flussonic` - Build a flussonic URL from the channel URL.
     - `Xtream codes` - Build an Xtream codes URL from the channel URL.
-* **Play from EPG in Live TV mode (using timeshift)**: When disabled any catchup show from the past will be played like a video (bounded by start and end times). If enabled, it will instead act like a live stream with timeshift, also allowing the ability to skip back and forward programmes.
+* **Play from EPG in Live TV mode (using timeshift)**: When disabled any catchup show from the past will be played like a video (bounded by start and end times). If enabled, it will instead act like a live stream with timeshift, also allowing the ability to skip back and forward programmes. Note that the only effect this option has on streams that do not support timeshifting is whether or not to apply the before/after buffer.
 * **Buffer before programme start**: The amount of buffer to give before the playback start point of an EPG entry that will be watched as a video.
 * **Buffer after programme end**: The amount of buffer to give after the playback end point of an EPG entry that will be watched as a video.
+* **Catchup only available on finished programmes**: When selected from the EPG the current live programme cannot be watched as catchup until finished.
 
 ### Advanced
 Advanced settings such as multicast relays.

--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="4.11.5"
+  version="4.11.6"
   name="PVR IPTV Simple Client"
   provider-name="nightik">
   <requires>@ADDON_DEPENDS@</requires>
@@ -165,6 +165,10 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v4.11.6
+- Fixed: Fix incorrect live URL selection and inputstream for standard (no timeshift) catchup streams
+- Fixed: Correctly cache mime_type for streams
+
 v4.11.5
 - Fixed: Typo in date regex, caused failure to load EPG on some platforms
 

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,7 @@
+v4.11.6
+- Fixed: Fix incorrect live URL selection and inputstream for standard (no timeshift) catchup streams
+- Fixed: Correctly cache mime_type for streams
+
 v4.11.5
 - Fixed: Typo in date regex, caused failure to load EPG on some platforms
 

--- a/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
@@ -572,7 +572,7 @@ msgstr ""
 
 #. help: Catchup - catchupPlayEpgAsLive
 msgctxt "#30705"
-msgid "When disabled any catchup programme from the past will be played like a video (bounded by start and end times). If enabled, it will instead act like a live stream with timeshift, also allowing the ability to skip back and forward programmes."
+msgid "When disabled any catchup programme from the past will be played like a video (bounded by start and end times). If enabled, it will instead act like a live stream with timeshift, also allowing the ability to skip back and forward programmes. Note that the only effect this option has on streams that do not support timeshifting is whether or not to apply the before/after buffer."
 msgstr ""
 
 #. help: Catchup - catchupWatchEpgBeginBuffer

--- a/src/iptvsimple/CatchupController.cpp
+++ b/src/iptvsimple/CatchupController.cpp
@@ -225,8 +225,8 @@ void CatchupController::TestAndStoreStreamType(Channel& channel, bool fromEpg /*
   // TODO: we really want to store this in a file and load it on any restart
   // using channel doesn't make sense as it's otherwise immutable.
 
-  // If we find a mimetype store it so we don't have to look it up again
-  if (!channel.GetProperty("mimetype").empty() && (streamType == StreamType::HLS || streamType == StreamType::DASH))
+  // If we find a mimetype store it so we don't have to look it up again (Other and Smoothing streaming don't have one)
+  if (channel.GetProperty("mimetype").empty() && (streamType != StreamType::OTHER_TYPE && streamType != StreamType::SMOOTH_STREAMING))
   {
     std::lock_guard<std::mutex> lock(*m_mutex);
     channel.AddProperty("mimetype", StreamUtils::GetMimeType(streamType));

--- a/src/iptvsimple/CatchupController.h
+++ b/src/iptvsimple/CatchupController.h
@@ -35,7 +35,6 @@ namespace iptvsimple
 
     std::string GetCatchupUrlFormatString(const data::Channel& channel) const;
     std::string GetCatchupUrl(const data::Channel& channel) const;
-    std::string GetStreamTestUrl(const data::Channel& channel) const;
 
     bool ControlsLiveStream() const { return m_controlsLiveStream; }
     void ResetCatchupState() { m_resetCatchupState = true; }
@@ -44,7 +43,8 @@ namespace iptvsimple
     data::EpgEntry* GetLiveEPGEntry(const iptvsimple::data::Channel& myChannel);
     data::EpgEntry* GetEPGEntry(const iptvsimple::data::Channel& myChannel, time_t lookupTime);
     void SetCatchupInputStreamProperties(bool playbackAsLive, const iptvsimple::data::Channel& channel, std::map<std::string, std::string>& catchupProperties);
-    void TestAndStoreStreamType(data::Channel& channel);
+    void TestAndStoreStreamType(data::Channel& channel, bool fromEpg = false);
+    std::string GetStreamTestUrl(const data::Channel& channel, bool fromEpg) const;
 
     // Programme helpers
     void UpdateProgrammeFrom(const EPG_TAG& epgTag, int tvgShift);

--- a/src/iptvsimple/data/Channel.h
+++ b/src/iptvsimple/data/Channel.h
@@ -42,7 +42,8 @@ namespace iptvsimple
         m_tvgShift(c.GetTvgShift()), m_channelName(c.GetChannelName()), m_iconPath(c.GetIconPath()),
         m_streamURL(c.GetStreamURL()), m_hasCatchup(c.HasCatchup()), m_catchupMode(c.GetCatchupMode()),
         m_catchupDays(c.GetCatchupDays()), m_catchupSource(c.GetCatchupSource()),
-        m_isCatchupTSStream(c.IsCatchupTSStream()), m_tvgId(c.GetTvgId()), m_tvgName(c.GetTvgName()),
+        m_isCatchupTSStream(c.IsCatchupTSStream()), m_catchupSupportsTimeshifting(c.CatchupSupportsTimeshifting()),
+        m_tvgId(c.GetTvgId()), m_tvgName(c.GetTvgName()),
         m_properties(c.GetProperties()), m_inputStreamClass(c.GetInputStreamClass()) {};
       ~Channel() = default;
 
@@ -86,6 +87,9 @@ namespace iptvsimple
       bool IsCatchupTSStream() const { return m_isCatchupTSStream; }
       void SetCatchupTSStream(bool value) { m_isCatchupTSStream = value; }
 
+      bool CatchupSupportsTimeshifting() const { return m_catchupSupportsTimeshifting; }
+      void SetCatchupSupportsTimeshifting(bool value) { m_catchupSupportsTimeshifting = value; }
+
       const std::string& GetTvgId() const { return m_tvgId; }
       void SetTvgId(const std::string& value) { m_tvgId = value; }
 
@@ -128,6 +132,7 @@ namespace iptvsimple
       int m_catchupDays = 0;
       std::string m_catchupSource = "";
       bool m_isCatchupTSStream = false;
+      bool m_catchupSupportsTimeshifting = false;
       std::string m_tvgId = "";
       std::string m_tvgName = "";
       std::map<std::string, std::string> m_properties;

--- a/src/iptvsimple/data/EpgEntry.cpp
+++ b/src/iptvsimple/data/EpgEntry.cpp
@@ -201,7 +201,7 @@ bool EpgEntry::UpdateFrom(const xml_node& channelNode, const std::string& id,
   if ((tmpEnd + maxShiftTime < start) || (tmpStart + minShiftTime > end))
     return false;
 
-  m_broadcastId = static_cast<int>(tmpStart);;
+  m_broadcastId = static_cast<int>(tmpStart);
   m_channelId = std::atoi(id.c_str());
   m_genreType = 0;
   m_genreSubType = 0;

--- a/src/iptvsimple/utilities/StreamUtils.cpp
+++ b/src/iptvsimple/utilities/StreamUtils.cpp
@@ -96,7 +96,7 @@ std::string StreamUtils::GetEffectiveInputStreamClass(const StreamType& streamTy
     {
       if (streamType == StreamType::HLS || streamType == StreamType::TS)
       {
-        if (channel.IsCatchupSupported())
+        if (channel.IsCatchupSupported() && channel.CatchupSupportsTimeshifting())
           inputStreamClass = CATCHUP_INPUTSTREAMCLASS;
         else
           inputStreamClass = PVR_STREAM_PROPERTY_VALUE_INPUTSTREAMFFMPEG;


### PR DESCRIPTION
v4.11.6
- Fixed: Fix incorrect live URL selection and inputstream for standard (no timeshift) catchup streams
- Fixed: Correctly cache mime_type for streams