### PR TITLE
Provide media headers to inputstream.adaptive if channel does not explicitly set them.

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="4.11.6"
+  version="4.11.7"
   name="PVR IPTV Simple Client"
   provider-name="nightik">
   <requires>@ADDON_DEPENDS@</requires>
@@ -165,6 +165,9 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v4.11.7
+- Fixed: stream media headers not set when inputstream.adaptive is used for HLS streams
+
 v4.11.6
 - Fixed: Fix incorrect live URL selection and inputstream for standard (no timeshift) catchup streams
 - Fixed: Correctly cache mime_type for streams

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v4.11.7
+- Fixed: stream media headers not set when inputstream.adaptive is used for HLS streams
+
 v4.11.6
 - Fixed: Fix incorrect live URL selection and inputstream for standard (no timeshift) catchup streams
 - Fixed: Correctly cache mime_type for streams

--- a/src/iptvsimple/utilities/StreamUtils.h
+++ b/src/iptvsimple/utilities/StreamUtils.h
@@ -41,10 +41,11 @@ namespace iptvsimple
       static const std::string GetManifestType(const StreamType& streamType);
       static const std::string GetMimeType(const StreamType& streamType);
       static std::string GetURLWithFFmpegReconnectOptions(const std::string& streamUrl, const StreamType& streamType, const iptvsimple::data::Channel& channel);
+      static std::string AddHeader(const std::string& headerTarget, const std::string& headerName, const std::string& headerValue, bool encodeHeaderValue);
       static std::string AddHeaderToStreamUrl(const std::string& streamUrl, const std::string& headerName, const std::string& headerValue);
       static bool UseKodiInputstreams(const StreamType& streamType);
       static bool ChannelSpecifiesInputstream(const iptvsimple::data::Channel& channe);
-
+      static std::string GetUrlEncodedProtocolOptions(const std::string& protocolOptions);
       static std::string GetEffectiveInputStreamClass(const StreamType& streamType, const iptvsimple::data::Channel& channel);
 
     private:


### PR DESCRIPTION
Fixes the HTTP 403 error on segment download with several
IPTV providers, as suggested by Markus Pfau (@peak3d)
here: https://github.com/peak3d/inputstream.adaptive/issues/411