### PR TITLE
Add support for terminating catchup streams property for ffmpegdirect

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="4.11.7"
+  version="4.12.0"
   name="PVR IPTV Simple Client"
   provider-name="nightik">
   <requires>@ADDON_DEPENDS@</requires>
@@ -165,6 +165,10 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v4.12.0
+- Added: Add support for terminating catchup streams property for ffmpegdirect
+- Update: Convert kodiprop names inputstreamaddon and inputstreamclass to inputstream on load
+
 v4.11.7
 - Fixed: stream media headers not set when inputstream.adaptive is used for HLS streams
 

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,7 @@
+v4.12.0
+- Added: Add support for terminating catchup streams property for ffmpegdirect
+- Update: Convert kodiprop names inputstreamaddon and inputstreamclass to inputstream on load
+
 v4.11.7
 - Fixed: stream media headers not set when inputstream.adaptive is used for HLS streams
 

--- a/src/iptvsimple/CatchupController.cpp
+++ b/src/iptvsimple/CatchupController.cpp
@@ -194,6 +194,7 @@ void CatchupController::SetCatchupInputStreamProperties(bool playbackAsLive, con
   catchupProperties.insert({"inputstream.ffmpegdirect.timezone_shift", std::to_string(channel.GetTvgShift())});
   if (!m_programmeCatchupId.empty())
     catchupProperties.insert({"inputstream.ffmpegdirect.programme_catchup_id", m_programmeCatchupId});
+  catchupProperties.insert({"inputstream.ffmpegdirect.catchup_terminates", channel.CatchupSourceTerminates() ? "true" : "false"});
 
   const std::string mimeType = channel.GetProperty("mimetype");
   if (!mimeType.empty() && channel.GetProperty("inputstream.ffmpegdirect.mime_type").empty())
@@ -211,6 +212,7 @@ void CatchupController::SetCatchupInputStreamProperties(bool playbackAsLive, con
   Logger::Log(LEVEL_DEBUG, "catchup_buffer_offset - %s", std::to_string(m_timeshiftBufferOffset).c_str());
   Logger::Log(LEVEL_DEBUG, "timezone_shift - %s", std::to_string(channel.GetTvgShift()).c_str());
   Logger::Log(LEVEL_DEBUG, "programme_catchup_id - '%s'", m_programmeCatchupId.c_str());
+  Logger::Log(LEVEL_DEBUG, "catchup_terminates - %s", channel.CatchupSourceTerminates() ? "true" : "false");
   Logger::Log(LEVEL_DEBUG, "mime_type - '%s'", mimeType.c_str());
 }
 

--- a/src/iptvsimple/CatchupController.cpp
+++ b/src/iptvsimple/CatchupController.cpp
@@ -234,7 +234,7 @@ void CatchupController::TestAndStoreStreamType(Channel& channel, bool fromEpg /*
     channel.AddProperty("mimetype", StreamUtils::GetMimeType(streamType));
   }
 
-  if (StreamUtils::GetEffectiveInputStreamClass(streamType, channel) == "inputstream.ffmpegdirect")
+  if (StreamUtils::GetEffectiveInputStreamName(streamType, channel) == "inputstream.ffmpegdirect")
     m_controlsLiveStream = true;
   else
     m_controlsLiveStream = false;

--- a/src/iptvsimple/CatchupController.h
+++ b/src/iptvsimple/CatchupController.h
@@ -31,8 +31,6 @@ namespace iptvsimple
     void ProcessEPGTagForTimeshiftedPlayback(const EPG_TAG& epgTag, data::Channel& channel, std::map<std::string, std::string>& catchupProperties); //should be const channel
     void ProcessEPGTagForVideoPlayback(const EPG_TAG& epgTag, data::Channel& channel, std::map<std::string, std::string>& catchupProperties); //should be const channel
 
-    std::string GetTimeshiftInputStreamClass(const utilities::StreamType& streamType);
-
     std::string GetCatchupUrlFormatString(const data::Channel& channel) const;
     std::string GetCatchupUrl(const data::Channel& channel) const;
 

--- a/src/iptvsimple/PlaylistLoader.cpp
+++ b/src/iptvsimple/PlaylistLoader.cpp
@@ -293,6 +293,10 @@ void PlaylistLoader::ParseSinglePropertyIntoChannel(const std::string& line, Cha
     {
       addProperty &= prop == "http-user-agent" || prop == "http-referrer" || prop == "program";
     }
+    else if (markerName == KODIPROP_MARKER && (prop == "inputstreamaddon" || prop == "inputstreamclass"))
+    {
+      prop = "inputstream";
+    }    
 
     if (addProperty)
       channel.AddProperty(prop, propValue);

--- a/src/iptvsimple/data/Channel.cpp
+++ b/src/iptvsimple/data/Channel.cpp
@@ -59,6 +59,7 @@ void Channel::UpdateTo(Channel& left) const
   left.m_catchupSource    = m_catchupSource;
   left.m_isCatchupTSStream = m_isCatchupTSStream;
   left.m_catchupSupportsTimeshifting = m_catchupSupportsTimeshifting;
+  left.m_catchupSourceTerminates = m_catchupSourceTerminates;
   left.m_tvgId            = m_tvgId;
   left.m_tvgName          = m_tvgName;
   left.m_properties       = m_properties;
@@ -92,6 +93,7 @@ void Channel::Reset()
   m_catchupDays = 0;
   m_catchupSource.clear();
   m_catchupSupportsTimeshifting = false;
+  m_catchupSourceTerminates = false;
   m_isCatchupTSStream = false;
   m_tvgId.clear();
   m_tvgName.clear();
@@ -220,6 +222,19 @@ bool IsValidTimeshiftingCatchupSource(const std::string& formatString)
   return false;
 }
 
+bool IsTerminatingCatchupSource(const std::string& formatString)
+{
+  // A catchup stream terminates if it has an end time specifier
+  if (formatString.find("{duration}") != std::string::npos ||
+      formatString.find("{lutc}") != std::string::npos ||
+      formatString.find("${timestamp}") != std::string::npos ||
+      formatString.find("{utcend}") != std::string::npos ||
+      formatString.find("${end}") != std::string::npos)
+    return true;
+
+  return false;
+}
+
 } // unnamed namespace
 
 void Channel::ConfigureCatchupMode()
@@ -291,6 +306,7 @@ void Channel::ConfigureCatchupMode()
       m_catchupSource += protocolOptions;
 
     m_catchupSupportsTimeshifting = IsValidTimeshiftingCatchupSource(m_catchupSource);
+    m_catchupSourceTerminates = IsTerminatingCatchupSource(m_catchupSource);
   }
 
   if (m_catchupMode != CatchupMode::DISABLED)

--- a/src/iptvsimple/data/Channel.cpp
+++ b/src/iptvsimple/data/Channel.cpp
@@ -63,7 +63,7 @@ void Channel::UpdateTo(Channel& left) const
   left.m_tvgId            = m_tvgId;
   left.m_tvgName          = m_tvgName;
   left.m_properties       = m_properties;
-  left.m_inputStreamClass = m_inputStreamClass;
+  left.m_inputStreamName = m_inputStreamName;
 }
 
 void Channel::UpdateTo(PVR_CHANNEL& left) const
@@ -98,7 +98,7 @@ void Channel::Reset()
   m_tvgId.clear();
   m_tvgName.clear();
   m_properties.clear();
-  m_inputStreamClass.clear();
+  m_inputStreamName.clear();
 }
 
 void Channel::SetIconPathFromTvgLogo(const std::string& tvgLogo, std::string& channelName)
@@ -155,9 +155,9 @@ void Channel::SetStreamURL(const std::string& url)
     Logger::Log(LEVEL_DEBUG, "%s - Transformed multicast stream URL to local relay url: %s", __FUNCTION__, m_streamURL.c_str());
   }
 
-  m_inputStreamClass = GetProperty(PVR_STREAM_PROPERTY_INPUTSTREAMCLASS);
-  if (m_inputStreamClass.empty())
-    m_inputStreamClass = GetProperty(PVR_STREAM_PROPERTY_INPUTSTREAMADDON);
+  m_inputStreamName = GetProperty(PVR_STREAM_PROPERTY_INPUTSTREAMCLASS);
+  if (m_inputStreamName.empty())
+    m_inputStreamName = GetProperty(PVR_STREAM_PROPERTY_INPUTSTREAMADDON);
 }
 
 std::string Channel::GetProperty(const std::string& propName) const

--- a/src/iptvsimple/data/Channel.h
+++ b/src/iptvsimple/data/Channel.h
@@ -43,7 +43,7 @@ namespace iptvsimple
         m_streamURL(c.GetStreamURL()), m_hasCatchup(c.HasCatchup()), m_catchupMode(c.GetCatchupMode()),
         m_catchupDays(c.GetCatchupDays()), m_catchupSource(c.GetCatchupSource()),
         m_isCatchupTSStream(c.IsCatchupTSStream()), m_catchupSupportsTimeshifting(c.CatchupSupportsTimeshifting()),
-        m_tvgId(c.GetTvgId()), m_tvgName(c.GetTvgName()),
+        m_catchupSourceTerminates(c.CatchupSourceTerminates()), m_tvgId(c.GetTvgId()), m_tvgName(c.GetTvgName()),
         m_properties(c.GetProperties()), m_inputStreamClass(c.GetInputStreamClass()) {};
       ~Channel() = default;
 
@@ -90,6 +90,9 @@ namespace iptvsimple
       bool CatchupSupportsTimeshifting() const { return m_catchupSupportsTimeshifting; }
       void SetCatchupSupportsTimeshifting(bool value) { m_catchupSupportsTimeshifting = value; }
 
+      bool CatchupSourceTerminates() const { return m_catchupSourceTerminates; }
+      void SetCatchupSourceTerminates(bool value) { m_catchupSourceTerminates = value; }
+
       const std::string& GetTvgId() const { return m_tvgId; }
       void SetTvgId(const std::string& value) { m_tvgId = value; }
 
@@ -133,6 +136,7 @@ namespace iptvsimple
       std::string m_catchupSource = "";
       bool m_isCatchupTSStream = false;
       bool m_catchupSupportsTimeshifting = false;
+      bool m_catchupSourceTerminates = false;
       std::string m_tvgId = "";
       std::string m_tvgName = "";
       std::map<std::string, std::string> m_properties;

--- a/src/iptvsimple/data/Channel.h
+++ b/src/iptvsimple/data/Channel.h
@@ -44,7 +44,7 @@ namespace iptvsimple
         m_catchupDays(c.GetCatchupDays()), m_catchupSource(c.GetCatchupSource()),
         m_isCatchupTSStream(c.IsCatchupTSStream()), m_catchupSupportsTimeshifting(c.CatchupSupportsTimeshifting()),
         m_catchupSourceTerminates(c.CatchupSourceTerminates()), m_tvgId(c.GetTvgId()), m_tvgName(c.GetTvgName()),
-        m_properties(c.GetProperties()), m_inputStreamClass(c.GetInputStreamClass()) {};
+        m_properties(c.GetProperties()), m_inputStreamName(c.GetInputStreamName()) {};
       ~Channel() = default;
 
       bool IsRadio() const { return m_radio; }
@@ -104,8 +104,8 @@ namespace iptvsimple
       void AddProperty(const std::string& prop, const std::string& value) { m_properties.insert({prop, value}); }
       std::string GetProperty(const std::string& propName) const;
 
-      const std::string& GetInputStreamClass() const { return m_inputStreamClass; };
-      void SetInputStreamClass(const std::string& value) { m_inputStreamClass = value; }
+      const std::string& GetInputStreamName() const { return m_inputStreamName; };
+      void SetInputStreamName(const std::string& value) { m_inputStreamName = value; }
 
       void UpdateTo(Channel& left) const;
       void UpdateTo(PVR_CHANNEL& left) const;
@@ -140,7 +140,7 @@ namespace iptvsimple
       std::string m_tvgId = "";
       std::string m_tvgName = "";
       std::map<std::string, std::string> m_properties;
-      std::string m_inputStreamClass;
+      std::string m_inputStreamName;
     };
   } //namespace data
 } //namespace iptvsimple

--- a/src/iptvsimple/utilities/StreamUtils.cpp
+++ b/src/iptvsimple/utilities/StreamUtils.cpp
@@ -56,7 +56,7 @@ void StreamUtils::SetAllStreamProperties(PVR_NAMED_VALUE* properties, unsigned i
       if (streamType == StreamType::HLS || streamType == StreamType::TS)
       {
         if (channel.IsCatchupSupported())
-          StreamUtils::SetStreamProperty(properties, propertiesCount, propertiesMax, PVR_STREAM_PROPERTY_INPUTSTREAMCLASS, CATCHUP_INPUTSTREAMCLASS);
+          StreamUtils::SetStreamProperty(properties, propertiesCount, propertiesMax, PVR_STREAM_PROPERTY_INPUTSTREAMCLASS, CATCHUP_INPUTSTREAM_NAME);
         else
           StreamUtils::SetStreamProperty(properties, propertiesCount, propertiesMax, PVR_STREAM_PROPERTY_INPUTSTREAMCLASS, PVR_STREAM_PROPERTY_VALUE_INPUTSTREAMFFMPEG);
       }
@@ -112,29 +112,29 @@ void StreamUtils::SetAllStreamProperties(PVR_NAMED_VALUE* properties, unsigned i
   }
 }
 
-std::string StreamUtils::GetEffectiveInputStreamClass(const StreamType& streamType, const iptvsimple::data::Channel& channel)
+std::string StreamUtils::GetEffectiveInputStreamName(const StreamType& streamType, const iptvsimple::data::Channel& channel)
 {
-  std::string inputStreamClass = channel.GetInputStreamClass();
+  std::string inputStreamName = channel.GetInputStreamName();
 
-  if (inputStreamClass.empty())
+  if (inputStreamName.empty())
   {
     if (StreamUtils::UseKodiInputstreams(streamType))
     {
       if (streamType == StreamType::HLS || streamType == StreamType::TS)
       {
         if (channel.IsCatchupSupported() && channel.CatchupSupportsTimeshifting())
-          inputStreamClass = CATCHUP_INPUTSTREAMCLASS;
+          inputStreamName = CATCHUP_INPUTSTREAM_NAME;
         else
-          inputStreamClass = PVR_STREAM_PROPERTY_VALUE_INPUTSTREAMFFMPEG;
+          inputStreamName = PVR_STREAM_PROPERTY_VALUE_INPUTSTREAMFFMPEG;
       }
     }
     else // inputstream.adpative
     {
-      inputStreamClass = "inputstream.adaptive";
+      inputStreamName = "inputstream.adaptive";
     }
   }
 
-  return inputStreamClass;
+  return inputStreamName;
 }
 
 const StreamType StreamUtils::GetStreamType(const std::string& url, const Channel& channel)
@@ -278,7 +278,7 @@ bool StreamUtils::UseKodiInputstreams(const StreamType& streamType)
 
 bool StreamUtils::ChannelSpecifiesInputstream(const iptvsimple::data::Channel& channel)
 {
-  return !channel.GetInputStreamClass().empty();
+  return !channel.GetInputStreamName().empty();
 }
 
 bool StreamUtils::SupportsFFmpegReconnect(const StreamType& streamType, const iptvsimple::data::Channel& channel)

--- a/src/iptvsimple/utilities/StreamUtils.h
+++ b/src/iptvsimple/utilities/StreamUtils.h
@@ -29,7 +29,7 @@ namespace iptvsimple
       OTHER_TYPE
     };
 
-    static const std::string CATCHUP_INPUTSTREAMCLASS = "inputstream.ffmpegdirect";
+    static const std::string CATCHUP_INPUTSTREAM_NAME = "inputstream.ffmpegdirect";
 
     class StreamUtils
     {
@@ -46,7 +46,7 @@ namespace iptvsimple
       static bool UseKodiInputstreams(const StreamType& streamType);
       static bool ChannelSpecifiesInputstream(const iptvsimple::data::Channel& channe);
       static std::string GetUrlEncodedProtocolOptions(const std::string& protocolOptions);
-      static std::string GetEffectiveInputStreamClass(const StreamType& streamType, const iptvsimple::data::Channel& channel);
+      static std::string GetEffectiveInputStreamName(const StreamType& streamType, const iptvsimple::data::Channel& channel);
 
     private:
       static bool SupportsFFmpegReconnect(const StreamType& streamType, const iptvsimple::data::Channel& channel);


### PR DESCRIPTION
v4.12.0
- Added: Add support for terminating catchup streams property for ffmpegdirect
- Update: Convert kodiprop names inputstreamaddon and inputstreamclass to inputstream on load