### PR TITLE
Add support for catchup stream granularity property for ffmpegdirect

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="4.12.0"
+  version="4.13.0"
   name="PVR IPTV Simple Client"
   provider-name="nightik">
   <requires>@ADDON_DEPENDS@</requires>
@@ -165,6 +165,10 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v4.13.0
+- Added: Add support for catchup stream granularity property for ffmpegdirect
+- Fixed: Terminating catchup stream check missing use case
+
 v4.12.0
 - Added: Add support for terminating catchup streams property for ffmpegdirect
 - Update: Convert kodiprop names inputstreamaddon and inputstreamclass to inputstream on load

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,7 @@
+v4.13.0
+- Added: Add support for catchup stream granularity property for ffmpegdirect
+- Fixed: Terminating catchup stream check missing use case
+
 v4.12.0
 - Added: Add support for terminating catchup streams property for ffmpegdirect
 - Update: Convert kodiprop names inputstreamaddon and inputstreamclass to inputstream on load

--- a/src/iptvsimple/CatchupController.cpp
+++ b/src/iptvsimple/CatchupController.cpp
@@ -195,6 +195,7 @@ void CatchupController::SetCatchupInputStreamProperties(bool playbackAsLive, con
   if (!m_programmeCatchupId.empty())
     catchupProperties.insert({"inputstream.ffmpegdirect.programme_catchup_id", m_programmeCatchupId});
   catchupProperties.insert({"inputstream.ffmpegdirect.catchup_terminates", channel.CatchupSourceTerminates() ? "true" : "false"});
+  catchupProperties.insert({"inputstream.ffmpegdirect.catchup_granularity", std::to_string(channel.GetCatchupGranularitySeconds())});
 
   const std::string mimeType = channel.GetProperty("mimetype");
   if (!mimeType.empty() && channel.GetProperty("inputstream.ffmpegdirect.mime_type").empty())
@@ -213,6 +214,7 @@ void CatchupController::SetCatchupInputStreamProperties(bool playbackAsLive, con
   Logger::Log(LEVEL_DEBUG, "timezone_shift - %s", std::to_string(channel.GetTvgShift()).c_str());
   Logger::Log(LEVEL_DEBUG, "programme_catchup_id - '%s'", m_programmeCatchupId.c_str());
   Logger::Log(LEVEL_DEBUG, "catchup_terminates - %s", channel.CatchupSourceTerminates() ? "true" : "false");
+  Logger::Log(LEVEL_DEBUG, "catchup_granularity - %s", std::to_string(channel.GetCatchupGranularitySeconds()).c_str());
   Logger::Log(LEVEL_DEBUG, "mime_type - '%s'", mimeType.c_str());
 }
 

--- a/src/iptvsimple/data/Channel.cpp
+++ b/src/iptvsimple/data/Channel.cpp
@@ -226,6 +226,7 @@ bool IsTerminatingCatchupSource(const std::string& formatString)
 {
   // A catchup stream terminates if it has an end time specifier
   if (formatString.find("{duration}") != std::string::npos ||
+      formatString.find("{duration:") != std::string::npos ||
       formatString.find("{lutc}") != std::string::npos ||
       formatString.find("${timestamp}") != std::string::npos ||
       formatString.find("{utcend}") != std::string::npos ||
@@ -307,6 +308,8 @@ void Channel::ConfigureCatchupMode()
 
     m_catchupSupportsTimeshifting = IsValidTimeshiftingCatchupSource(m_catchupSource);
     m_catchupSourceTerminates = IsTerminatingCatchupSource(m_catchupSource);
+    Logger::Log(LEVEL_DEBUG, "Channel Catchup Format string properties: %s, valid timeshifting source: %s, terminating source: %s", 
+                m_channelName.c_str(), m_catchupSupportsTimeshifting ? "true" : "false", m_catchupSourceTerminates ? "true" : "false");
   }
 
   if (m_catchupMode != CatchupMode::DISABLED)

--- a/src/iptvsimple/data/Channel.h
+++ b/src/iptvsimple/data/Channel.h
@@ -43,7 +43,8 @@ namespace iptvsimple
         m_streamURL(c.GetStreamURL()), m_hasCatchup(c.HasCatchup()), m_catchupMode(c.GetCatchupMode()),
         m_catchupDays(c.GetCatchupDays()), m_catchupSource(c.GetCatchupSource()),
         m_isCatchupTSStream(c.IsCatchupTSStream()), m_catchupSupportsTimeshifting(c.CatchupSupportsTimeshifting()),
-        m_catchupSourceTerminates(c.CatchupSourceTerminates()), m_tvgId(c.GetTvgId()), m_tvgName(c.GetTvgName()),
+        m_catchupSourceTerminates(c.CatchupSourceTerminates()), m_catchupGranularitySeconds(c.GetCatchupGranularitySeconds()),
+        m_tvgId(c.GetTvgId()), m_tvgName(c.GetTvgName()),
         m_properties(c.GetProperties()), m_inputStreamName(c.GetInputStreamName()) {};
       ~Channel() = default;
 
@@ -93,6 +94,9 @@ namespace iptvsimple
       bool CatchupSourceTerminates() const { return m_catchupSourceTerminates; }
       void SetCatchupSourceTerminates(bool value) { m_catchupSourceTerminates = value; }
 
+      int GetCatchupGranularitySeconds() const { return m_catchupGranularitySeconds; }
+      void SetCatchupGranularitySeconds(int value) { m_catchupGranularitySeconds = value; }
+
       const std::string& GetTvgId() const { return m_tvgId; }
       void SetTvgId(const std::string& value) { m_tvgId = value; }
 
@@ -137,6 +141,7 @@ namespace iptvsimple
       bool m_isCatchupTSStream = false;
       bool m_catchupSupportsTimeshifting = false;
       bool m_catchupSourceTerminates = false;
+      int m_catchupGranularitySeconds = 1;
       std::string m_tvgId = "";
       std::string m_tvgName = "";
       std::map<std::string, std::string> m_properties;


### PR DESCRIPTION
v4.13.0
- Added: Add support for catchup stream granularity property for ffmpegdirect
- Fixed: Terminating catchup stream check missing use case