### PR TITLE
Install ffmpegdirect dependency by default 

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,8 @@ Source: kodi-pvr-iptvsimple
 Priority: extra
 Maintainer: Anton Fedchin <anightik@gmail.com>
 Build-Depends: debhelper (>= 9.0.0), cmake, libp8-platform-dev,
-               kodi-addon-dev, zlib1g-dev, libpugixml-dev
+               kodi-addon-dev, zlib1g-dev, libpugixml-dev,
+               kodi-inputstream-ffmpegdirect
 Standards-Version: 4.1.2
 Section: libs
 Homepage: <http://kodi.tv>

--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="4.13.0"
+  version="4.13.1"
   name="PVR IPTV Simple Client"
-  provider-name="nightik">
-  <requires>@ADDON_DEPENDS@</requires>
+  provider-name="nightik and Ross Nicholson">
+  <requires>@ADDON_DEPENDS@
+    <import addon="inputstream.ffmpegdirect" minversion="1.9.0" optional="true"/>
+  </requires>
   <extension
     point="xbmc.pvrclient"
     library_@PLATFORM@="@LIBRARY_FILENAME@"/>
@@ -165,6 +167,9 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v4.13.1
+- Fixed: Install ffmpegdirect dependency by default.
+
 v4.13.0
 - Added: Add support for catchup stream granularity property for ffmpegdirect
 - Fixed: Terminating catchup stream check missing use case

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v4.13.1
+- Fixed: Install ffmpegdirect dependency by default.
+
 v4.13.0
 - Added: Add support for catchup stream granularity property for ffmpegdirect
 - Fixed: Terminating catchup stream check missing use case


### PR DESCRIPTION
v4.13.1
- Fixed: Install ffmpegdirect dependency by default.