### PR TITLE
Add all inputstreams as dependencies and fix debian control file

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,17 +1,19 @@
 Source: kodi-pvr-iptvsimple
 Priority: extra
-Maintainer: Anton Fedchin <anightik@gmail.com>
+Maintainer: Ross Nicholson <phunkyfish@gmail.com>
 Build-Depends: debhelper (>= 9.0.0), cmake, libp8-platform-dev,
-               kodi-addon-dev, zlib1g-dev, libpugixml-dev,
-               kodi-inputstream-ffmpegdirect
+               kodi-addon-dev, zlib1g-dev, libpugixml-dev
 Standards-Version: 4.1.2
 Section: libs
-Homepage: <http://kodi.tv>
+Homepage: <https://kodi.tv>
 
 Package: kodi-pvr-iptvsimple
 Section: libs
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
+Recommends: kodi-inputstream-adaptive,
+            kodi-inputstream-ffmpegdirect,
+            kodi-inputstream-rtmp
 Description: Simple IPTV PVR for Kodi
  Simple IPTV PVR for Kodi
 

--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="4.13.1"
+  version="4.13.2"
   name="PVR IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@
     <import addon="inputstream.ffmpegdirect" minversion="1.9.0" optional="true"/>
+    <import addon="inputstream.adaptive" minversion="2.5.5" optional="true"/>
+    <import addon="inputstream.rtmp" minversion="3.0.3" optional="true"/>
   </requires>
   <extension
     point="xbmc.pvrclient"
@@ -167,6 +169,10 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v4.13.2
+- Fixed: Install all inputstream dependencies by default.
+- Fixed: Debian control files for run-time dependencies.
+
 v4.13.1
 - Fixed: Install ffmpegdirect dependency by default.
 

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,7 @@
+v4.13.2
+- Fixed: Install all inputstream dependencies by default.
+- Fixed: Debian control files for run-time dependencies.
+
 v4.13.1
 - Fixed: Install ffmpegdirect dependency by default.
 


### PR DESCRIPTION
v4.13.2
- Fixed: Install all inputstream dependencies by default.
- Fixed: Debian control files for run-time dependencies.