### PR TITLE
Only allow timeshifting catchup from EPG if channel supports it

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="4.13.3"
+  version="4.13.4"
   name="PVR IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@
@@ -169,6 +169,9 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v4.13.4
+- Fixed: Only allow timeshifting catchup from EPG if channel supports it
+
 v4.13.3
 - Update: PVR API 6.4.0
 - Update: Minor cleanups

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v4.13.4
+- Fixed: Only allow timeshifting catchup from EPG if channel supports it
+
 v4.13.3
 - Update: PVR API 6.4.0
 - Update: Minor cleanups

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -337,7 +337,7 @@ PVR_ERROR GetEPGTagStreamProperties(const EPG_TAG* tag, PVR_NAMED_VALUE* propert
     Logger::Log(LEVEL_DEBUG, "%s - GetPlayEpgAsLive is %s", __FUNCTION__, settings.CatchupPlayEpgAsLive() ? "enabled" : "disabled");
 
     std::map<std::string, std::string> catchupProperties;
-    if (settings.CatchupPlayEpgAsLive())
+    if (settings.CatchupPlayEpgAsLive() && m_currentChannel.CatchupSupportsTimeshifting())
     {
       m_catchupController->ProcessEPGTagForTimeshiftedPlayback(*tag, m_currentChannel, catchupProperties);
     }

--- a/src/iptvsimple/CatchupController.cpp
+++ b/src/iptvsimple/CatchupController.cpp
@@ -203,7 +203,7 @@ void CatchupController::SetCatchupInputStreamProperties(bool playbackAsLive, con
 
   // TODO: Should also send programme start and duration potentially
   // When doing this don't forget to add Settings::GetInstance().GetCatchupWatchEpgBeginBufferSecs() + Settings::GetInstance().GetCatchupWatchEpgEndBufferSecs();
-  // if in video playbacl mode from epg, i.e. if if (!Settings::GetInstance().CatchupPlayEpgAsLive() && m_playbackIsVideo)s
+  // if in video playback mode from epg, i.e. if (!Settings::GetInstance().CatchupPlayEpgAsLive() && m_playbackIsVideo)s
 
   Logger::Log(LEVEL_DEBUG, "default_url - %s", channel.GetStreamURL().c_str());
   Logger::Log(LEVEL_DEBUG, "playback_as_live - %s", playbackAsLive ? "true" : "false");
@@ -407,7 +407,7 @@ std::string CatchupController::GetCatchupUrl(const Channel& channel) const
   {
     time_t duration = 60 * 60; // default one hour
 
-    // // use the programme duration if it's valid
+    // use the programme duration if it's valid
     if (m_programmeStartTime > 0 && m_programmeStartTime < m_programmeEndTime)
     {
       duration = static_cast<time_t>(m_programmeEndTime - m_programmeStartTime);


### PR DESCRIPTION
v4.13.4
- Fixed: Only allow timeshifting catchup from EPG if channel supports it

Use case missing from: https://github.com/kodi-pvr/pvr.iptvsimple/pull/346