### PR TITLE
Stream Manager for runtime caching of stream/mime types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ set(IPTV_SOURCES src/client.cpp
                  src/iptvsimple/Epg.cpp
                  src/iptvsimple/PlaylistLoader.cpp
                  src/iptvsimple/Settings.cpp
+                 src/iptvsimple/StreamManager.cpp
                  src/iptvsimple/data/Channel.cpp
                  src/iptvsimple/data/ChannelEpg.cpp
                  src/iptvsimple/data/ChannelGroup.cpp
@@ -46,11 +47,13 @@ set(IPTV_HEADERS src/client.h
                  src/iptvsimple/Epg.h
                  src/iptvsimple/PlaylistLoader.h
                  src/iptvsimple/Settings.h
+                 src/iptvsimple/StreamManager.h
                  src/iptvsimple/data/Channel.h
                  src/iptvsimple/data/ChannelEpg.h
                  src/iptvsimple/data/ChannelGroup.h
                  src/iptvsimple/data/EpgEntry.h
                  src/iptvsimple/data/EpgGenre.h
+                 src/iptvsimple/data/StreamEntry.h
                  src/iptvsimple/utilities/FileUtils.h
                  src/iptvsimple/utilities/Logger.h
                  src/iptvsimple/utilities/StreamUtils.h

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Here’s some examples of how the different formats would look:
 #### M3U format elements:
 
 ```
-#EXTM3U tvg-shift="-4.5" x-tvg-url="http://path-to-xmltv/guide.xml"
+#EXTM3U tvg-shift="-4.5" x-tvg-url="http://path-to-xmltv/guide.xml catchup-correction="-2.5"
 #EXTINF:0 tvg-id="channel-x" tvg-name="Channel_X" group-title="Entertainment" tvg-chno="10" tvg-logo="http://path-to-icons/channel-x.png" radio="true" tvg-shift="-3.5",Channel X
 #EXTVLCOPT:program=745
 #KODIPROP:key=val
@@ -201,7 +201,7 @@ http://path-to-stream/live/channel-z.ts
 http://path-to-stream/live/channel-a.ts
 #EXTINF:0 catchup="default" catchup-source="http://path-to-stream/live/catchup-b.ts&cutv={Y}-{m}-{d}T{H}:{M}:{S}" catchup-days="3",Channel B
 http://path-to-stream/live/channel-b.ts
-#EXTINF:0 catchup="append" catchup-source="&cutv={Y}-{m}-{d}T{H}:{M}:{S}" catchup-days="3",Channel C
+#EXTINF:0 catchup="append" catchup-source="&cutv={Y}-{m}-{d}T{H}:{M}:{S}" catchup-days="3" catchup-correction="-4.0",Channel C
 http://path-to-stream/live/channel-c.ts
 #EXTINF:0 tvg-id="channel-d" tvg-name="Channel-D" catchup="shift" catchup-days="3",Channel D
 http://path-to-stream/live/channel-d.ts
@@ -220,7 +220,7 @@ http://list.tv:8080/live/my@account.xc/my_password/1477.m3u8
 *Explanation for Catchup entries*
 - For `Channel A` the stream URL will be used and the Query format string from the addon settings will be appended to construct the catchup URL.
 - For `Channel B` the stream URL will not be used, instead using catchup-source as the catchup URL.
-- For `Channel C` the stream URL will be used and catchup-source will be appended to form the catchup URL.
+- For `Channel C` the stream URL will be used and catchup-source will be appended to form the catchup URL. The time used for the URL generation will corrected by -4.0 hours.
 - For `Channel D` this is an example of a siptv style entry which auto generates the catchup-source by appending `?utc={utc}&lutc={lutc}` or `&utc={utc}&lutc={lutc}` to the channel URL.
 - For `Channel E` this is an example of the old siptv style entry which uses a `timeshift` tag to combine shift and days into one field. The catchup-source output will be the same as channel D.
 - For `Channel F` this is an example of a flussonic style entry manually specifying the catcup-source. Note that the mode is still `default`.
@@ -245,6 +245,7 @@ http://path-to-stream/live/channel-z.ts
 - `#EXTM3U`: Marker for the start of an M3U file.
   - `tvg-shift`: Value that will be used for all channels if a `tvg-shift` value is not supplied per channel.
   - `x-tvg-url`: URL for the XMLTV data. Only used if the addon settings do not contain an EPG location for XMLTV data.
+  - `catchup-correction`: Value that will be used for all channels if a `catchup-correction` value is not supplied per channel.
 - `#EXTINF`: Contains a set of values, ending with a comma followed by the `channel name`.
   - `tvg-id`: A unique identifier for this channel used to map to the EPG XMLTV data.
   - `tvg-name`: A name for this channel in the EPG XMLTV data.
@@ -252,10 +253,11 @@ http://path-to-stream/live/channel-z.ts
   - `tvg-chno`: The number to be used for this channel.
   - `tvg-logo`: A URL pointing to the logo for this channel. For relative URLs `.png` will be appended if not provided, absolute URLs will not be modified.
   - `radio`: If the value matches "true" (case insensitive) this is a radio channel.
-  - `tvg-shift`: Channel specific shift value in hours.
+  - `tvg-shift`: Channel specific timezone shift value in hours for epg entries.
   - `catchup`: Which mode of catchup to use. Supported modes of `default` and `append`. Required unless the setting `All channels support catchup` is enabled.
   - `catchup-source`: Can contain the full catchup URL (complete with format specifiers) if in `default` mode. Or if the mode is `append` just the query string with format specifiers which will be appended to the channel URL. If omitted the `Query format string` from settings will be appended.
   - `catchup-days`: The number of days in the past catchup is available for.
+  - `catchup-correction`: A correction to the time used for catchup stream URL generation. Useful for catchup streams which are geo mis-matched to the wrong time.
 - `#EXTGRP`: A semi-colon separted list of channel groups that this channel belongs to.
 - `#KODIPROP`: A single property in the format `key=value` that can be passed to Kodi. Multiple can be passed each on a separate line.
 - `#EXTVLCOPT`: A single property in the format `key=value` that can be passed to Kodi. Multiple can be passed each on a separate line. Note that if either a `http-user-agent` or a `http-referrer` property is found it will added to the URL as a HTTP header as `user-agent` or `referrer` respectively if not already provided in the URL. These two fields specifically will be dropped as properties whether or not they are added as header values. They will be added in the same format as the `URL` below.

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ Advanced settings such as multicast relays.
 * **Use FFMpeg http reconnect options if possible**: Note this can only apply to http/https streams that are processed by libavformat (e.g. M3u8/HLS). Using libavformat can be specified in an M3U file by setting the property `inputstreamclass` as `inputstream.ffmpeg`. I.e. adding the line: `#KODIPROP:inputstreamclass=inputstream.ffmpeg`. If this opton is not enabled it can still be enabled per stream/channel by adding a kodi property, i.e.: `#KODIPROP:http-reconnect=true`.
 * **Use inputstream.adaptive for m3u8 (HLS) streams**: Use inputstream.adaptive instead of ffmpeg's libavformat for m3u8 (HLS) streams.
 * **User-Agent**: Select which User-Agent to use if there is not one supplied as a property or as part of the channel stream URL.
+* **Inputstream name**: Use this inputsream as the default if there is not one supplied as a property (KODIPROP) of the channel. Use with care as this will disable any use of the addon's default stream inspection behaviour.
+* **MIME type**: Use this MIME type as the default if there is not one supplied as a property (KODIPROP) of the channel. Use with care as this will disable any use of the addon's default stream inspection behaviour.
 
 ## Appendix
 

--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -5,7 +5,7 @@
   name="PVR IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@
-    <import addon="inputstream.ffmpegdirect" minversion="1.9.0" optional="true"/>
+    <import addon="inputstream.ffmpegdirect" minversion="1.9.2" optional="true"/>
     <import addon="inputstream.adaptive" minversion="2.5.5" optional="true"/>
     <import addon="inputstream.rtmp" minversion="3.0.3" optional="true"/>
   </requires>

--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="4.13.6"
+  version="4.14.0"
   name="PVR IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@
@@ -169,6 +169,13 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v4.14.0
+- Added: Stream Manager for runtime caching of stream/mime types for speeding up channel switches
+- Added: Deprecate use of inputstream.ffmpegdirect.mime_type and use mimetype property instead
+- Added: Support advanced setting to set a default inputstream and/or MIME type for channels without them
+- Fixed: Fix full timeshift calc not being applied to catchup streams
+- Added: Suppport catchup-correction value in M3U file for catchup streams geo mismatched to wrong time
+
 v4.13.6
 - Update: PVR API 6.5.0
 

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,10 @@
+v4.14.0
+- Added: Stream Manager for runtime caching of stream/mime types for speeding up channel switches
+- Added: Deprecate use of inputstream.ffmpegdirect.mime_type and use mimetype property instead
+- Added: Support advanced setting to set a default inputstream and/or MIME type for channels without them
+- Fixed: Fix full timeshift calc not being applied to catchup streams
+- Added: Suppport catchup-correction value in M3U file for catchup streams geo mismatched to wrong time
+
 v4.13.6
 - Update: PVR API 6.5.0
 

--- a/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
@@ -256,15 +256,30 @@ msgstr ""
 
 #. label: Advanced - useFFmpegReconnect
 msgctxt "#30067"
-msgid "Use FFMpeg http reconnect options if possible"
+msgid "Use FFmpeg http reconnect options if possible"
 msgstr ""
 
-#. label: Advanced - userAgent
+#. label: Advanced - defaultUserAgent
 msgctxt "#30068"
 msgid "User-Agent"
 msgstr ""
 
-#empty strings from id 30069 to 30099
+#. label: Advanced - defaultInputstream
+msgctxt "#30069"
+msgid "Inputstream name"
+msgstr ""
+
+#. label: Advanced - defaultMimeType
+msgctxt "#30070"
+msgid "MIME type"
+msgstr ""
+
+#. label-group: Advanced - Channel defaults
+msgctxt "#30071"
+msgid "Channel defaults"
+msgstr ""
+
+#empty strings from id 30072 to 30099
 
 #. label-category: catchup
 #. label-group: Catchup - Catchup
@@ -536,12 +551,22 @@ msgctxt "#30685"
 msgid "Note this can only apply to http/https streams that are processed by libavformat (e.g. M3u8/HLS). Using libavformat can be specified in an M3U file by setting the property `inputstreamclass` as `inputstream.ffmpeg` for kodi's internal implementation or `inputstream.ffmpegdirect` for addon version. I.e. adding the line: `#KODIPROP:inputstreamclass=inputstream.ffmpeg`. If this option is not enabled it can still be enabled per stream/channel by adding a kodi property, i.e.: `#KODIPROP:http-reconnect=true`."
 msgstr ""
 
-#. help: Advanced - userAgent
+#. help: Advanced - defaultUserAgent
 msgctxt "#30686"
 msgid "Use this User-Agent if there is not one supplied as a property or as part of the channel stream URL."
 msgstr ""
 
-#empty strings from id 30687 to 30699
+#. help: Advanced - defaultInputstream
+msgctxt "#30687"
+msgid "Use this inputsream as the default if there is not one supplied as a property (KODIPROP) of the channel. Use with care as this will disable any use of the addon's default stream inspection behaviour."
+msgstr ""
+
+#. help: Advanced - defaultMimeType
+msgctxt "#30688"
+msgid "Use this MIME type as the default if there is not one supplied as a property (KODIPROP) of the channel. Use with care as this will disable any use of the addon's default stream inspection behaviour."
+msgstr ""
+
+#empty strings from id 30689 to 30699
 
 #. help info - Catchup
 

--- a/pvr.iptvsimple/resources/settings.xml
+++ b/pvr.iptvsimple/resources/settings.xml
@@ -426,13 +426,29 @@
           <default>false</default>
           <control type="toggle" />
         </setting>
-        <setting id="userAgent" type="string" label="30068" help="30686">
+      </group>
+      <group id="3" label="30071">
+        <setting id="defaultUserAgent" type="string" label="30068" help="30686">
           <level>3</level>
           <constraints>
             <allowempty>true</allowempty>
           </constraints>
           <control type="edit" format="string" />
-          </setting>
+        </setting>
+        <setting id="defaultInputstream" type="string" label="30069" help="30687">
+          <level>3</level>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string" />
+        </setting>
+        <setting id="defaultMimeType" type="string" label="30070" help="30688">
+          <level>3</level>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string" />
+        </setting>
       </group>
     </category>
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -32,11 +32,6 @@ Channel m_currentChannel;
 Settings& settings = Settings::GetInstance();
 CatchupController* m_catchupController = nullptr;
 
-/* User adjustable settings are saved here.
- * Default values are defined inside client.h
- * and exported to the other source files.
- */
-
 CHelper_libXBMC_addon* XBMC = nullptr;
 CHelper_libXBMC_pvr* PVR = nullptr;
 
@@ -248,6 +243,7 @@ PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL* channel, PVR_NAMED_VALUE
 
     // We always call the catchup controller regardless so it can cleanup state
     // whether or not it supports catchup in case there is any houskeeping to do
+    // This also allows us to check if this is a catchup stream or not when we try to get the URL.
     std::map<std::string, std::string> catchupProperties;
     m_catchupController->ProcessChannelForPlayback(m_currentChannel, catchupProperties);
 

--- a/src/iptvsimple/CatchupController.cpp
+++ b/src/iptvsimple/CatchupController.cpp
@@ -191,7 +191,7 @@ void CatchupController::SetCatchupInputStreamProperties(bool playbackAsLive, con
   catchupProperties.insert({"inputstream.ffmpegdirect.catchup_buffer_start_time", std::to_string(m_catchupStartTime)});
   catchupProperties.insert({"inputstream.ffmpegdirect.catchup_buffer_end_time", std::to_string(m_catchupEndTime)});
   catchupProperties.insert({"inputstream.ffmpegdirect.catchup_buffer_offset", std::to_string(m_timeshiftBufferOffset)});
-  catchupProperties.insert({"inputstream.ffmpegdirect.timezone_shift", std::to_string(m_epg.GetEPGTimezoneShiftSecs(channel))});
+  catchupProperties.insert({"inputstream.ffmpegdirect.timezone_shift", std::to_string(m_epg.GetEPGTimezoneShiftSecs(channel) + channel.GetCatchupCorrectionSecs())});
   if (!m_programmeCatchupId.empty())
     catchupProperties.insert({"inputstream.ffmpegdirect.programme_catchup_id", m_programmeCatchupId});
   catchupProperties.insert({"inputstream.ffmpegdirect.catchup_terminates", channel.CatchupSourceTerminates() ? "true" : "false"});
@@ -210,7 +210,7 @@ void CatchupController::SetCatchupInputStreamProperties(bool playbackAsLive, con
   Logger::Log(LEVEL_DEBUG, "catchup_buffer_start_time - %s", std::to_string(m_catchupStartTime).c_str());
   Logger::Log(LEVEL_DEBUG, "catchup_buffer_end_time - %s", std::to_string(m_catchupEndTime).c_str());
   Logger::Log(LEVEL_DEBUG, "catchup_buffer_offset - %s", std::to_string(m_timeshiftBufferOffset).c_str());
-  Logger::Log(LEVEL_DEBUG, "timezone_shift - %s", std::to_string(m_epg.GetEPGTimezoneShiftSecs(channel)).c_str());
+  Logger::Log(LEVEL_DEBUG, "timezone_shift - %s", std::to_string(m_epg.GetEPGTimezoneShiftSecs(channel) + channel.GetCatchupCorrectionSecs()).c_str());
   Logger::Log(LEVEL_DEBUG, "programme_catchup_id - '%s'", m_programmeCatchupId.c_str());
   Logger::Log(LEVEL_DEBUG, "catchup_terminates - %s", channel.CatchupSourceTerminates() ? "true" : "false");
   Logger::Log(LEVEL_DEBUG, "catchup_granularity - %s", std::to_string(channel.GetCatchupGranularitySeconds()).c_str());
@@ -355,14 +355,14 @@ std::string AppendQueryStringAndPreserveOptions(const std::string &url, const st
   return urlFormatString;
 }
 
-std::string BuildEpgTagUrl(time_t startTime, time_t duration, const Channel& channel, long long timeOffset, const std::string& programmeCatchupId, int epgTimezoneShiftSecs)
+std::string BuildEpgTagUrl(time_t startTime, time_t duration, const Channel& channel, long long timeOffset, const std::string& programmeCatchupId, int timezoneShiftSecs)
 {
   std::string startTimeUrl;
   time_t timeNow = std::time(nullptr);
   time_t offset = startTime + timeOffset;
 
   if (startTime > 0 && offset < (timeNow - 5))
-    startTimeUrl = FormatDateTime(offset - epgTimezoneShiftSecs, duration, channel.GetCatchupSource());
+    startTimeUrl = FormatDateTime(offset - timezoneShiftSecs, duration, channel.GetCatchupSource());
   else
     startTimeUrl = channel.GetStreamURL();
 
@@ -405,7 +405,7 @@ std::string CatchupController::GetCatchupUrl(const Channel& channel) const
         duration = timeNow - m_programmeStartTime;
     }
 
-    return BuildEpgTagUrl(m_catchupStartTime, duration, channel, m_timeshiftBufferOffset, m_programmeCatchupId, m_epg.GetEPGTimezoneShiftSecs(channel));
+    return BuildEpgTagUrl(m_catchupStartTime, duration, channel, m_timeshiftBufferOffset, m_programmeCatchupId, m_epg.GetEPGTimezoneShiftSecs(channel) + channel.GetCatchupCorrectionSecs());
   }
 
   return "";
@@ -415,7 +415,7 @@ std::string CatchupController::GetStreamTestUrl(const Channel& channel, bool fro
 {
  if (m_catchupStartTime > 0 || fromEpg)
     // Test URL from 2 hours ago for 1 hour duration.
-    return BuildEpgTagUrl(std::time(nullptr) - (2 * 60 * 60), 60 * 60, channel, 0, m_programmeCatchupId, m_epg.GetEPGTimezoneShiftSecs(channel));
+    return BuildEpgTagUrl(std::time(nullptr) - (2 * 60 * 60), 60 * 60, channel, 0, m_programmeCatchupId, m_epg.GetEPGTimezoneShiftSecs(channel) + channel.GetCatchupCorrectionSecs());
   else
     return channel.GetStreamURL();
 }

--- a/src/iptvsimple/CatchupController.cpp
+++ b/src/iptvsimple/CatchupController.cpp
@@ -197,10 +197,6 @@ void CatchupController::SetCatchupInputStreamProperties(bool playbackAsLive, con
   catchupProperties.insert({"inputstream.ffmpegdirect.catchup_terminates", channel.CatchupSourceTerminates() ? "true" : "false"});
   catchupProperties.insert({"inputstream.ffmpegdirect.catchup_granularity", std::to_string(channel.GetCatchupGranularitySeconds())});
 
-  const std::string mimeType = channel.GetProperty("mimetype");
-  if (!mimeType.empty() && channel.GetProperty("inputstream.ffmpegdirect.mime_type").empty())
-    catchupProperties.insert({"inputstream.ffmpegdirect.mime_type", mimeType});
-
   // TODO: Should also send programme start and duration potentially
   // When doing this don't forget to add Settings::GetInstance().GetCatchupWatchEpgBeginBufferSecs() + Settings::GetInstance().GetCatchupWatchEpgEndBufferSecs();
   // if in video playback mode from epg, i.e. if (!Settings::GetInstance().CatchupPlayEpgAsLive() && m_playbackIsVideo)s
@@ -215,7 +211,7 @@ void CatchupController::SetCatchupInputStreamProperties(bool playbackAsLive, con
   Logger::Log(LEVEL_DEBUG, "programme_catchup_id - '%s'", m_programmeCatchupId.c_str());
   Logger::Log(LEVEL_DEBUG, "catchup_terminates - %s", channel.CatchupSourceTerminates() ? "true" : "false");
   Logger::Log(LEVEL_DEBUG, "catchup_granularity - %s", std::to_string(channel.GetCatchupGranularitySeconds()).c_str());
-  Logger::Log(LEVEL_DEBUG, "mime_type - '%s'", mimeType.c_str());
+  Logger::Log(LEVEL_DEBUG, "mime_type - '%s'", channel.GetProperty("mimetype").c_str());
 }
 
 void CatchupController::TestAndStoreStreamType(Channel& channel, bool fromEpg /* false */)

--- a/src/iptvsimple/CatchupController.h
+++ b/src/iptvsimple/CatchupController.h
@@ -13,6 +13,7 @@
 #include "data/Channel.h"
 #include "data/EpgEntry.h"
 #include "utilities/StreamUtils.h"
+#include "StreamManager.h"
 
 #include <mutex>
 
@@ -27,9 +28,9 @@ namespace iptvsimple
   public:
     CatchupController(iptvsimple::Epg& epg, std::mutex* mutex);
 
-    void ProcessChannelForPlayback(data::Channel& channel, std::map<std::string, std::string>& catchupProperties); //should be const channel
-    void ProcessEPGTagForTimeshiftedPlayback(const EPG_TAG& epgTag, data::Channel& channel, std::map<std::string, std::string>& catchupProperties); //should be const channel
-    void ProcessEPGTagForVideoPlayback(const EPG_TAG& epgTag, data::Channel& channel, std::map<std::string, std::string>& catchupProperties); //should be const channel
+    void ProcessChannelForPlayback(const data::Channel& channel, std::map<std::string, std::string>& catchupProperties);
+    void ProcessEPGTagForTimeshiftedPlayback(const EPG_TAG& epgTag, const data::Channel& channel, std::map<std::string, std::string>& catchupProperties);
+    void ProcessEPGTagForVideoPlayback(const EPG_TAG& epgTag, const data::Channel& channel, std::map<std::string, std::string>& catchupProperties);
 
     std::string GetCatchupUrlFormatString(const data::Channel& channel) const;
     std::string GetCatchupUrl(const data::Channel& channel) const;
@@ -40,9 +41,10 @@ namespace iptvsimple
   private:
     data::EpgEntry* GetLiveEPGEntry(const iptvsimple::data::Channel& myChannel);
     data::EpgEntry* GetEPGEntry(const iptvsimple::data::Channel& myChannel, time_t lookupTime);
-    void SetCatchupInputStreamProperties(bool playbackAsLive, const iptvsimple::data::Channel& channel, std::map<std::string, std::string>& catchupProperties);
-    void TestAndStoreStreamType(data::Channel& channel, bool fromEpg = false);
+    void SetCatchupInputStreamProperties(bool playbackAsLive, const iptvsimple::data::Channel& channel, std::map<std::string, std::string>& catchupProperties, const StreamType& streamType);
+    StreamType StreamTypeLookup(const data::Channel& channel, bool fromEpg = false);
     std::string GetStreamTestUrl(const data::Channel& channel, bool fromEpg) const;
+    std::string GetStreamKey(const data::Channel& channel, bool fromEpg) const;
 
     // Programme helpers
     void UpdateProgrammeFrom(const EPG_TAG& epgTag, int tvgShift);
@@ -69,5 +71,7 @@ namespace iptvsimple
     bool m_controlsLiveStream = false;
     iptvsimple::Epg& m_epg;
     std::mutex* m_mutex = nullptr;
+
+    StreamManager m_streamManager;
   };
 } //namespace iptvsimple

--- a/src/iptvsimple/Epg.cpp
+++ b/src/iptvsimple/Epg.cpp
@@ -318,7 +318,7 @@ PVR_ERROR Epg::GetEPGForChannel(ADDON_HANDLE handle, int iChannelUid, time_t sta
     if (!channelEpg || channelEpg->GetEpgEntries().size() == 0)
       return PVR_ERROR_NO_ERROR;
 
-    int shift = m_tsOverride ? m_epgTimeShift : myChannel.GetTvgShift() + m_epgTimeShift;
+    int shift = GetEPGTimezoneShiftSecs(myChannel);
 
     for (auto& epgEntryPair : channelEpg->GetEpgEntries())
     {
@@ -481,7 +481,7 @@ EpgEntry* Epg::GetEPGEntry(const Channel& myChannel, time_t lookupTime) const
   if (!channelEpg || channelEpg->GetEpgEntries().size() == 0)
     return nullptr;
 
-  int shift = m_tsOverride ? m_epgTimeShift : myChannel.GetTvgShift() + m_epgTimeShift;
+  int shift = GetEPGTimezoneShiftSecs(myChannel);
 
   for (auto& epgEntryPair : channelEpg->GetEpgEntries())
   {
@@ -495,4 +495,9 @@ EpgEntry* Epg::GetEPGEntry(const Channel& myChannel, time_t lookupTime) const
   }
 
   return nullptr;
+}
+
+int Epg::GetEPGTimezoneShiftSecs(const Channel& myChannel) const
+{
+  return m_tsOverride ? m_epgTimeShift : myChannel.GetTvgShift() + m_epgTimeShift;
 }

--- a/src/iptvsimple/Epg.h
+++ b/src/iptvsimple/Epg.h
@@ -43,6 +43,7 @@ namespace iptvsimple
 
     data::EpgEntry* GetLiveEPGEntry(const data::Channel& myChannel) const;
     data::EpgEntry* GetEPGEntry(const data::Channel& myChannel, time_t lookupTime) const;
+    int GetEPGTimezoneShiftSecs(const data::Channel& myChannel) const;
 
   private:
     static const XmltvFileFormat GetXMLTVFileFormat(const char* buffer);

--- a/src/iptvsimple/PlaylistLoader.h
+++ b/src/iptvsimple/PlaylistLoader.h
@@ -32,6 +32,7 @@ namespace iptvsimple
   static const std::string CATCHUP_DAYS            = "catchup-days=";
   static const std::string CATCHUP_SOURCE          = "catchup-source=";
   static const std::string CATCHUP_SIPTV           = "timeshift=";
+  static const std::string CATCHUP_CORRECTION      = "catchup-correction=";
   static const std::string KODIPROP_MARKER         = "#KODIPROP:";
   static const std::string EXTVLCOPT_MARKER        = "#EXTVLCOPT:";
   static const std::string EXTVLCOPT_DASH_MARKER   = "#EXTVLCOPT--";
@@ -50,7 +51,7 @@ namespace iptvsimple
     static std::string ReadMarkerValue(const std::string& line, const std::string& markerName);
     static void ParseSinglePropertyIntoChannel(const std::string& line, iptvsimple::data::Channel& channel, const std::string& markerName);
 
-    std::string ParseIntoChannel(const std::string& line, iptvsimple::data::Channel& channel, std::vector<int>& groupIdList, int epgTimeShift);
+    std::string ParseIntoChannel(const std::string& line, iptvsimple::data::Channel& channel, std::vector<int>& groupIdList, int epgTimeShift, int catchupCorrectionSecs);
     void ParseAndAddChannelGroups(const std::string& groupNamesListString, std::vector<int>& groupIdList, bool isRadio);
 
     std::string m_m3uLocation;

--- a/src/iptvsimple/Settings.cpp
+++ b/src/iptvsimple/Settings.cpp
@@ -108,8 +108,12 @@ void Settings::ReadFromAddon(const std::string& userPath, const std::string clie
     m_useFFmpegReconnect = false;
   if (!XBMC->GetSetting("useInputstreamAdaptiveforHls", &m_useInputstreamAdaptiveforHls))
     m_useInputstreamAdaptiveforHls = false;
-  if (XBMC->GetSetting("userAgent", &buffer))
-    m_userAgent = buffer;
+  if (XBMC->GetSetting("defaultUserAgent", &buffer))
+    m_defaultUserAgent = buffer;
+  if (XBMC->GetSetting("defaultInputstream", &buffer))
+    m_defaultInputstream = buffer;
+  if (XBMC->GetSetting("defaultMimeType", &buffer))
+    m_defaultMimeType = buffer;
 }
 
 ADDON_STATUS Settings::SetValue(const std::string& settingName, const void* settingValue)
@@ -202,8 +206,12 @@ ADDON_STATUS Settings::SetValue(const std::string& settingName, const void* sett
     return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_useFFmpegReconnect, ADDON_STATUS_OK, ADDON_STATUS_OK);
   else if (settingName == "useInputstreamAdaptiveforHls")
     return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_useInputstreamAdaptiveforHls, ADDON_STATUS_OK, ADDON_STATUS_OK);
-  else if (settingName == "userAgent")
-    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_userAgent, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  if (settingName == "defaultUserAgent")
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_defaultUserAgent, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  if (settingName == "defaultInputstream")
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_defaultInputstream, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  if (settingName == "defaultMimeType")
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_defaultMimeType, ADDON_STATUS_OK, ADDON_STATUS_OK);
 
   return ADDON_STATUS_OK;
 }

--- a/src/iptvsimple/Settings.h
+++ b/src/iptvsimple/Settings.h
@@ -118,7 +118,9 @@ namespace iptvsimple
     int GetUdpxyPort() const { return m_udpxyPort; }
     bool UseFFmpegReconnect() const { return m_useFFmpegReconnect; }
     bool UseInputstreamAdaptiveforHls() const { return m_useInputstreamAdaptiveforHls; }
-    const std::string& GetUserAgent() const { return m_userAgent; }
+    const std::string& GetDefaultUserAgent() const { return m_defaultUserAgent; }
+    const std::string& GetDefaultInputstream() const { return m_defaultInputstream; }
+    const std::string& GetDefaultMimeType() const { return m_defaultMimeType; }
 
     const std::string& GetTvgUrl() const { return m_tvgUrl; }
     void SetTvgUrl(const std::string& tvgUrl) { m_tvgUrl = tvgUrl; }
@@ -211,7 +213,9 @@ namespace iptvsimple
     int m_udpxyPort = DEFAULT_UDPXY_MULTICAST_RELAY_PORT;
     bool m_useFFmpegReconnect = true;
     bool m_useInputstreamAdaptiveforHls = false;
-    std::string m_userAgent;
+    std::string m_defaultUserAgent;
+    std::string m_defaultInputstream;
+    std::string m_defaultMimeType;
 
     std::string m_tvgUrl;
   };

--- a/src/iptvsimple/StreamManager.cpp
+++ b/src/iptvsimple/StreamManager.cpp
@@ -1,0 +1,91 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#include "StreamManager.h"
+
+#include "utilities/Logger.h"
+#include "utilities/StreamUtils.h"
+
+using namespace iptvsimple;
+using namespace iptvsimple::data;
+using namespace iptvsimple::utilities;
+
+StreamManager::StreamManager() {}
+
+void StreamManager::Clear()
+{
+  m_streamEntryCache.clear();
+}
+
+void StreamManager::AddUpdateStreamEntry(const std::string& streamKey, const StreamType& streamType, const std::string& mimeType)
+{
+  std::shared_ptr<StreamEntry> foundStreamEntry = GetStreamEntry(streamKey);
+
+  if (!foundStreamEntry)
+  {
+    std::shared_ptr<StreamEntry> newStreamEntry = std::make_shared<StreamEntry>();
+    newStreamEntry->SetStreamKey(streamKey);
+    newStreamEntry->SetStreamType(streamType);
+    newStreamEntry->SetMimeType(mimeType);
+    newStreamEntry->SetLastAccessTime(std::time(nullptr));
+
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_streamEntryCache.insert({streamKey, newStreamEntry});
+  }
+  else
+  {
+    foundStreamEntry->SetStreamType(streamType);
+    foundStreamEntry->SetLastAccessTime(std::time(nullptr));
+  }
+}
+
+bool StreamManager::HasStreamEntry(const std::string& streamKey) const
+{
+  return GetStreamEntry(streamKey) != nullptr;
+}
+
+std::shared_ptr<StreamEntry> StreamManager::GetStreamEntry(const std::string streamKey) const
+{
+  std::lock_guard<std::mutex> lock(m_mutex);
+
+  auto streamEntryPair = m_streamEntryCache.find(streamKey);
+  if (streamEntryPair != m_streamEntryCache.end())
+    return streamEntryPair->second;
+
+  return {};
+}
+
+StreamType StreamManager::StreamTypeLookup(const Channel& channel, const std::string& streamTestUrl, const std::string& streamKey)
+{
+  return StreamEntryLookup(channel, streamTestUrl, streamKey).GetStreamType();
+}
+
+StreamEntry StreamManager::StreamEntryLookup(const Channel& channel, const std::string& streamTestUrl, const std::string& streamKey)
+{
+  std::shared_ptr<StreamEntry> streamEntry = GetStreamEntry(streamKey);
+
+  if (!streamEntry)
+  {
+    StreamType streamType = StreamUtils::GetStreamType(streamTestUrl, channel);
+    if (streamType == StreamType::OTHER_TYPE)
+      streamType = StreamUtils::InspectStreamType(streamTestUrl, channel);
+
+    streamEntry = std::make_shared<StreamEntry>();
+    streamEntry->SetStreamKey(streamKey);
+    streamEntry->SetStreamType(streamType);
+    streamEntry->SetMimeType(StreamUtils::GetMimeType(streamType));
+  }
+
+  // If a channel has a MIME Type we always override with that
+  if (channel.HasMimeType())
+    streamEntry->SetMimeType(channel.GetMimeType());  
+  
+  AddUpdateStreamEntry(streamEntry->GetStreamKey(), streamEntry->GetStreamType(), streamEntry->GetMimeType());
+
+  return *streamEntry;
+}

--- a/src/iptvsimple/StreamManager.h
+++ b/src/iptvsimple/StreamManager.h
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#pragma once
+
+#include "data/Channel.h"
+#include "data/StreamEntry.h"
+
+#include <map>
+#include <mutex>
+#include <string>
+
+namespace iptvsimple
+{
+  class StreamManager
+  {
+  public:
+    StreamManager();
+    
+    StreamType StreamTypeLookup(const data::Channel& channel, const std::string& streamTestUrl, const std::string& streamKey);
+    void Clear();
+
+  private:
+    void AddUpdateStreamEntry(const std::string& streamKey, const StreamType& streamType, const std::string& mimeType);
+    bool HasStreamEntry(const std::string& streamKey) const;
+    std::shared_ptr<data::StreamEntry> GetStreamEntry(const std::string streamKey) const;
+    data::StreamEntry StreamEntryLookup(const data::Channel& channel, const std::string& streamTestUrl, const std::string& streamKey);
+
+    mutable std::mutex m_mutex;
+
+    std::map<std::string, std::shared_ptr<data::StreamEntry>> m_streamEntryCache;
+  };
+} //namespace iptvsimple

--- a/src/iptvsimple/data/Channel.cpp
+++ b/src/iptvsimple/data/Channel.cpp
@@ -143,8 +143,8 @@ void Channel::SetStreamURL(const std::string& url)
 
   if (StringUtils::StartsWith(url, HTTP_PREFIX) || StringUtils::StartsWith(url, HTTPS_PREFIX))
   {
-    if (!Settings::GetInstance().GetUserAgent().empty() && GetProperty("http-user-agent").empty())
-      AddProperty("http-user-agent", Settings::GetInstance().GetUserAgent());
+    if (!Settings::GetInstance().GetDefaultUserAgent().empty() && GetProperty("http-user-agent").empty())
+      AddProperty("http-user-agent", Settings::GetInstance().GetDefaultUserAgent());
 
     TryToAddPropertyAsHeader("http-user-agent", "user-agent");
     TryToAddPropertyAsHeader("http-referrer", "referer"); // spelling differences are correct
@@ -158,6 +158,12 @@ void Channel::SetStreamURL(const std::string& url)
     m_streamURL = "http://" + Settings::GetInstance().GetUdpxyHost() + ":" + std::to_string(Settings::GetInstance().GetUdpxyPort()) + typePath + url.substr(UDP_MULTICAST_PREFIX.length());
     Logger::Log(LEVEL_DEBUG, "%s - Transformed multicast stream URL to local relay url: %s", __FUNCTION__, m_streamURL.c_str());
   }
+
+  if (!Settings::GetInstance().GetDefaultInputstream().empty() && GetProperty(PVR_STREAM_PROPERTY_INPUTSTREAM).empty())
+    AddProperty(PVR_STREAM_PROPERTY_INPUTSTREAM, Settings::GetInstance().GetDefaultInputstream());
+
+  if (!Settings::GetInstance().GetDefaultMimeType().empty() && GetProperty(PVR_STREAM_PROPERTY_MIMETYPE).empty())
+    AddProperty(PVR_STREAM_PROPERTY_MIMETYPE, Settings::GetInstance().GetDefaultMimeType());
 
   m_inputStreamName = GetProperty(PVR_STREAM_PROPERTY_INPUTSTREAM);
 }

--- a/src/iptvsimple/data/Channel.cpp
+++ b/src/iptvsimple/data/Channel.cpp
@@ -63,6 +63,7 @@ void Channel::UpdateTo(Channel& left) const
   left.m_catchupSupportsTimeshifting = m_catchupSupportsTimeshifting;
   left.m_catchupSourceTerminates = m_catchupSourceTerminates;
   left.m_catchupGranularitySeconds = m_catchupGranularitySeconds;
+  left.m_catchupCorrectionSecs = m_catchupCorrectionSecs;
   left.m_tvgId            = m_tvgId;
   left.m_tvgName          = m_tvgName;
   left.m_properties       = m_properties;
@@ -99,6 +100,7 @@ void Channel::Reset()
   m_catchupSourceTerminates = false;
   m_catchupGranularitySeconds = 1;
   m_isCatchupTSStream = false;
+  m_catchupCorrectionSecs = 0;
   m_tvgId.clear();
   m_tvgName.clear();
   m_properties.clear();

--- a/src/iptvsimple/data/Channel.h
+++ b/src/iptvsimple/data/Channel.h
@@ -44,7 +44,7 @@ namespace iptvsimple
         m_catchupDays(c.GetCatchupDays()), m_catchupSource(c.GetCatchupSource()),
         m_isCatchupTSStream(c.IsCatchupTSStream()), m_catchupSupportsTimeshifting(c.CatchupSupportsTimeshifting()),
         m_catchupSourceTerminates(c.CatchupSourceTerminates()), m_catchupGranularitySeconds(c.GetCatchupGranularitySeconds()),
-        m_tvgId(c.GetTvgId()), m_tvgName(c.GetTvgName()),
+        m_catchupCorrectionSecs(c.GetCatchupCorrectionSecs()), m_tvgId(c.GetTvgId()), m_tvgName(c.GetTvgName()),
         m_properties(c.GetProperties()), m_inputStreamName(c.GetInputStreamName()) {};
       ~Channel() = default;
 
@@ -97,6 +97,9 @@ namespace iptvsimple
       int GetCatchupGranularitySeconds() const { return m_catchupGranularitySeconds; }
       void SetCatchupGranularitySeconds(int value) { m_catchupGranularitySeconds = value; }
 
+      int GetCatchupCorrectionSecs() const { return m_catchupCorrectionSecs; }
+      void SetCatchupCorrectionSecs(int value) { m_catchupCorrectionSecs = value; }
+
       const std::string& GetTvgId() const { return m_tvgId; }
       void SetTvgId(const std::string& value) { m_tvgId = value; }
 
@@ -144,6 +147,7 @@ namespace iptvsimple
       bool m_catchupSupportsTimeshifting = false;
       bool m_catchupSourceTerminates = false;
       int m_catchupGranularitySeconds = 1;
+      int m_catchupCorrectionSecs = 0;
       std::string m_tvgId = "";
       std::string m_tvgName = "";
       std::map<std::string, std::string> m_properties;

--- a/src/iptvsimple/data/Channel.h
+++ b/src/iptvsimple/data/Channel.h
@@ -107,6 +107,8 @@ namespace iptvsimple
       void SetProperties(std::map<std::string, std::string>& value) { m_properties = value; }
       void AddProperty(const std::string& prop, const std::string& value) { m_properties.insert({prop, value}); }
       std::string GetProperty(const std::string& propName) const;
+      bool HasMimeType() const { return !GetProperty(PVR_STREAM_PROPERTY_MIMETYPE).empty(); }
+      std::string GetMimeType() const { return GetProperty(PVR_STREAM_PROPERTY_MIMETYPE); }
 
       const std::string& GetInputStreamName() const { return m_inputStreamName; };
       void SetInputStreamName(const std::string& value) { m_inputStreamName = value; }

--- a/src/iptvsimple/data/StreamEntry.h
+++ b/src/iptvsimple/data/StreamEntry.h
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace iptvsimple
+{
+  enum class StreamType
+    : int // same type as addon settings
+  {
+    HLS = 0,
+    DASH,
+    SMOOTH_STREAMING,
+    TS,
+    PLUGIN,
+    MIME_TYPE_UNRECOGNISED,
+    OTHER_TYPE
+  };
+
+  namespace data
+  {
+    class StreamEntry
+    {
+    public:
+      const std::string& GetStreamKey() const { return m_streamKey; }
+      void SetStreamKey(const std::string& value) { m_streamKey = value; }
+
+      const StreamType& GetStreamType() const { return m_streamType; }
+      void SetStreamType(const StreamType& value) { m_streamType = value; }      
+
+      const std::string& GetMimeType() const { return m_mimeType; }
+      void SetMimeType(const std::string& value) { m_mimeType = value; }
+
+      time_t GetLastAccessTime() const { return m_lastAcessTime; }
+      void SetLastAccessTime(time_t value) { m_lastAcessTime = value; }
+
+    private:
+      std::string m_streamKey; // URL or catchup source
+      StreamType m_streamType;
+      std::string m_mimeType;
+      time_t m_lastAcessTime;
+    };
+  } //namespace data
+} //namespace iptvsimple

--- a/src/iptvsimple/utilities/StreamUtils.cpp
+++ b/src/iptvsimple/utilities/StreamUtils.cpp
@@ -143,8 +143,6 @@ const StreamType StreamUtils::GetStreamType(const std::string& url, const Channe
     return StreamType::PLUGIN;
 
   std::string mimeType = channel.GetProperty(PVR_STREAM_PROPERTY_MIMETYPE);
-  if (mimeType.empty())
-    mimeType = channel.GetProperty("inputstream.ffmpegdirect.mime_type");
 
   if (url.find(".m3u8") != std::string::npos ||
       mimeType == "application/x-mpegURL" ||

--- a/src/iptvsimple/utilities/StreamUtils.cpp
+++ b/src/iptvsimple/utilities/StreamUtils.cpp
@@ -159,6 +159,10 @@ const StreamType StreamUtils::GetStreamType(const std::string& url, const Channe
   if (mimeType == "video/mp2t" || channel.IsCatchupTSStream())
     return StreamType::TS;
 
+  // it has a MIME type but not one we recognise
+  if (!mimeType.empty())
+    return StreamType::MIME_TYPE_UNRECOGNISED;
+
   return StreamType::OTHER_TYPE;
 }
 
@@ -218,6 +222,11 @@ const std::string StreamUtils::GetMimeType(const StreamType& streamType)
     default:
       return "";
   }
+}
+
+bool StreamUtils::HasMimeType(const StreamType& streamType)
+{
+  return streamType != StreamType::OTHER_TYPE && streamType != StreamType::SMOOTH_STREAMING;
 }
 
 std::string StreamUtils::GetURLWithFFmpegReconnectOptions(const std::string& streamUrl, const StreamType& streamType, const iptvsimple::data::Channel& channel)

--- a/src/iptvsimple/utilities/StreamUtils.h
+++ b/src/iptvsimple/utilities/StreamUtils.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "../data/Channel.h"
+#include "../data/StreamEntry.h"
 
 #include <map>
 #include <string>
@@ -19,17 +20,6 @@ namespace iptvsimple
 {
   namespace utilities
   {
-    enum class StreamType
-      : int // same type as addon settings
-    {
-      HLS = 0,
-      DASH,
-      SMOOTH_STREAMING,
-      TS,
-      PLUGIN,
-      OTHER_TYPE
-    };
-
     static const std::string CATCHUP_INPUTSTREAM_NAME = "inputstream.ffmpegdirect";
 
     class StreamUtils
@@ -41,6 +31,7 @@ namespace iptvsimple
       static const StreamType InspectStreamType(const std::string& url, const iptvsimple::data::Channel& channel);
       static const std::string GetManifestType(const StreamType& streamType);
       static const std::string GetMimeType(const StreamType& streamType);
+      static bool HasMimeType(const StreamType& streamType);
       static std::string GetURLWithFFmpegReconnectOptions(const std::string& streamUrl, const StreamType& streamType, const iptvsimple::data::Channel& channel);
       static std::string AddHeader(const std::string& headerTarget, const std::string& headerName, const std::string& headerValue, bool encodeHeaderValue);
       static std::string AddHeaderToStreamUrl(const std::string& streamUrl, const std::string& headerName, const std::string& headerValue);


### PR DESCRIPTION
v4.14.0
- Added: Stream Manager for runtime caching of stream/mime types for speeding up channel switches
- Added: Deprecate use of inputstream.ffmpegdirect.mime_type and use mimetype property instead
- Added: Support advanced setting to set a default inputstream and/or MIME type for channels without them
- Fixed: Fix full timeshift calc not being applied to catchup streams
- Added: Suppport catchup-correction value in M3U file for catchup streams geo mismatched to wrong time