### PR TITLE
Send manifest type property to ffmpegdirect so it can recognise Smooth Streaming

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="4.14.0"
+  version="4.14.1"
   name="PVR IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@
@@ -169,6 +169,9 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v4.14.1
+- Fixed: Send manifest type property to ffmpegdirect so it can recognise Smooth Streaming
+
 v4.14.0
 - Added: Stream Manager for runtime caching of stream/mime types for speeding up channel switches
 - Added: Deprecate use of inputstream.ffmpegdirect.mime_type and use mimetype property instead

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v4.14.1
+- Fixed: Send manifest type property to ffmpegdirect so it can recognise Smooth Streaming
+
 v4.14.0
 - Added: Stream Manager for runtime caching of stream/mime types for speeding up channel switches
 - Added: Deprecate use of inputstream.ffmpegdirect.mime_type and use mimetype property instead

--- a/src/iptvsimple/CatchupController.cpp
+++ b/src/iptvsimple/CatchupController.cpp
@@ -200,6 +200,12 @@ void CatchupController::SetCatchupInputStreamProperties(bool playbackAsLive, con
   if (!channel.HasMimeType() && StreamUtils::HasMimeType(streamType))
     catchupProperties.insert({PVR_STREAM_PROPERTY_MIMETYPE, StreamUtils::GetMimeType(streamType)});
 
+  std::string manifestType = channel.GetProperty("inputstream.ffmpegdirect.manifest_type");
+  if (manifestType.empty())
+     manifestType = StreamUtils::GetManifestType(streamType);
+  if (!manifestType.empty())
+    catchupProperties.insert({"inputstream.ffmpegdirect.manifest_type", manifestType});
+
   // TODO: Should also send programme start and duration potentially
   // When doing this don't forget to add Settings::GetInstance().GetCatchupWatchEpgBeginBufferSecs() + Settings::GetInstance().GetCatchupWatchEpgEndBufferSecs();
   // if in video playback mode from epg, i.e. if (!Settings::GetInstance().CatchupPlayEpgAsLive() && m_playbackIsVideo)s
@@ -215,6 +221,7 @@ void CatchupController::SetCatchupInputStreamProperties(bool playbackAsLive, con
   Logger::Log(LEVEL_DEBUG, "catchup_terminates - %s", channel.CatchupSourceTerminates() ? "true" : "false");
   Logger::Log(LEVEL_DEBUG, "catchup_granularity - %s", std::to_string(channel.GetCatchupGranularitySeconds()).c_str());
   Logger::Log(LEVEL_DEBUG, "mimetype - '%s'", channel.HasMimeType() ? channel.GetProperty("mimetype").c_str() : StreamUtils::GetMimeType(streamType).c_str());
+  Logger::Log(LEVEL_DEBUG, "manifest_type - '%s'", manifestType.c_str());
 }
 
 StreamType CatchupController::StreamTypeLookup(const Channel& channel, bool fromEpg /* false */)


### PR DESCRIPTION
v4.14.1
- Fixed: Send manifest type property to ffmpegdirect so it can recognise Smooth Streaming