### PR TITLE
Catchup fixes

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="4.14.1"
+  version="4.14.2"
   name="PVR IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@
@@ -169,6 +169,10 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v4.14.2
+- Check to make sure catchup streams support timeshifting before letting them do so
+- Fix catchup streams for fs, xc and shift being passed URL with possible protocol options
+
 v4.14.1
 - Fixed: Send manifest type property to ffmpegdirect so it can recognise Smooth Streaming
 

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,7 @@
+v4.14.2
+- Check to make sure catchup streams support timeshifting before letting them do so
+- Fix catchup streams for fs, xc and shift being passed URL with possible protocol options
+
 v4.14.1
 - Fixed: Send manifest type property to ffmpegdirect so it can recognise Smooth Streaming
 

--- a/src/iptvsimple/CatchupController.cpp
+++ b/src/iptvsimple/CatchupController.cpp
@@ -228,7 +228,7 @@ StreamType CatchupController::StreamTypeLookup(const Channel& channel, bool from
 {
   StreamType streamType = m_streamManager.StreamTypeLookup(channel, GetStreamTestUrl(channel, fromEpg), GetStreamKey(channel, fromEpg));
 
-  m_controlsLiveStream = StreamUtils::GetEffectiveInputStreamName(streamType, channel) == "inputstream.ffmpegdirect";
+  m_controlsLiveStream = StreamUtils::GetEffectiveInputStreamName(streamType, channel) == "inputstream.ffmpegdirect" && channel.CatchupSupportsTimeshifting();
 
   return streamType;
 }

--- a/src/iptvsimple/data/Channel.cpp
+++ b/src/iptvsimple/data/Channel.cpp
@@ -359,7 +359,7 @@ bool Channel::GenerateAppendCatchupSource(const std::string& url)
 
 void Channel::GenerateShiftCatchupSource(const std::string& url)
 {
-  if (m_streamURL.find('?') != std::string::npos)
+  if (url.find('?') != std::string::npos)
     m_catchupSource = url + "&utc={utc}&lutc={lutc}";
   else
     m_catchupSource = url + "?utc={utc}&lutc={lutc}";
@@ -378,7 +378,7 @@ bool Channel::GenerateFlussonicCatchupSource(const std::string& url)
   static std::regex fsRegex("^(http[s]?://[^/]+)/([^/]+)/([^/]*)(mpegts|\\.m3u8)(\\?.+=.+)?$");
   std::smatch matches;
 
-  if (std::regex_match(m_streamURL, matches, fsRegex))
+  if (std::regex_match(url, matches, fsRegex))
   {
     if (matches.size() == 6)
     {
@@ -419,7 +419,7 @@ bool Channel::GenerateXtreamCodesCatchupSource(const std::string& url)
   static std::regex xcRegex("^(http[s]?://[^/]+)/(?:live/)?([^/]+)/([^/]+)/([^/\\.]+)(\\.m3u[8]?)?$");
   std::smatch matches;
 
-  if (std::regex_match(m_streamURL, matches, xcRegex))
+  if (std::regex_match(url, matches, xcRegex))
   {
     if (matches.size() == 6)
     {


### PR DESCRIPTION
v4.14.2
- Check to make sure catchup streams support timeshifting before letting them do so
- Fix catchup streams for fs, xc and shift being passed URL with possible protocol options