### PR TITLE
Use kodi's built in inputstreams for plugin:// urls

### DIFF
--- a/src/iptvsimple/utilities/StreamUtils.cpp
+++ b/src/iptvsimple/utilities/StreamUtils.cpp
@@ -317,7 +317,7 @@ std::string StreamUtils::AddHeader(const std::string& headerTarget, const std::s
 
 bool StreamUtils::UseKodiInputstreams(const StreamType& streamType)
 {
-  return streamType == StreamType::OTHER_TYPE || streamType == StreamType::TS ||
+  return streamType == StreamType::OTHER_TYPE || streamType == StreamType::TS || streamType == StreamType::PLUGIN ||
         (streamType == StreamType::HLS && !Settings::GetInstance().UseInputstreamAdaptiveforHls());
 }
 


### PR DESCRIPTION
This prevents that InputStream Adaptive is forced when using `plugin://` urls.