### PR TITLE
Catchup fixups, plugin URLs and VOD catchup mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,26 @@ Settings related to Channel Logos.
     - `Prefer M3U` - Use the channel logo from the M3U if available otherwise use the XMLTV logo.
     - `Prefer XMLTV` - Use the channel logo from the XMLTV file if available otherwise use the M3U logo.
 
+### Timeshift
+Timeshift settings for pausing/rewinding and fast-forwarding live streams.
+
+Note that if your stream does is not using a supported protocol you can still enable timeshift by adding some `KODIPROP`'s to the M3U file. The following three properties can be added before each channel/stream you wish to enable it for.
+
+```
+#KODIPROP:inputstream=inputstream.ffmpegdirect
+#KODIPROP:inputstream.ffmpegdirect.stream_mode=timeshift
+#KODIPROP:inputstream.ffmpegdirect.is_realtime_stream=true
+```
+
+For any TS stream an additional property should be added to every M3U entry using timeshift. This will speed up initial load time:
+
+```
+#KODIPROP:mimetype=video/mp2t
+```
+
+* **Enable timeshift**: Enable the timeshift feature.
+* **Enable timeshift for HTTP based streams**: Enable the timeshift feature for HTTP based streams. Will only apply to streams that do not select a specific inputstream addon for playback. The `inputstream.ffmpegdirect` addon will be used for tiemshift."
+
 ### Catchup
 Catchup settings for viewing archived live programmes. Allows the option of 'Play programme' when viewing EPG entry info. Only works if your provider supports catchup.
 

--- a/README.md
+++ b/README.md
@@ -215,6 +215,10 @@ http://list.tv:8888/325/mono.m3u8?token=secret
 http://list.tv:8080/my@account.xc/my_password/1477
 #EXTINF:-1 catchup="fs",Channel I
 http://list.tv:8080/live/my@account.xc/my_password/1477.m3u8
+#EXTINF:-1 catchup="vod" catchup-source="http://path-to-stream/live/catchup-j.ts&cutv={Y}-{m}-{d}T{H}:{M}:{S}" catchup-days="3",Channel J
+http://path-to-stream/live/channel-j.ts
+#EXTINF:-1 catchup="vod",Channel K
+plugin://plugin.video.my-vod-addon/play/catalog/channels/d8659669-b964-414c-aa9c-e31d8d15696b
 ```
 
 *Explanation for Catchup entries*
@@ -227,6 +231,8 @@ http://list.tv:8080/live/my@account.xc/my_password/1477.m3u8
 - For `Channel G` this is an example of a flussonic style entry which auto generates the catchup-source.
 - For `Channel H` this is an example of a xtream codes style entry which auto generates the catchup-source for `ts` streams.
 - For `Channel I` this is an example of a xtream codes style entry which auto generates the catchup-source for `m3u8` streams.
+- For `Channel J` this is an example of an VOD style entry which will only populated and play the `catchup-source` using a value of 3 `catchup-days`.
+- For `Channel K` this is an example of an VOD style entry which use a default `catchup-source` of `{catchup-id}` and will allow playback of any EPG entry with a `catchup-id` past, present or future via a Kodi plugin URL.
 
 Note: The minimum required for a channel/stream is an `#EXTINF` line with a channel name and the `URL` line. E.g. a minimal version of the exmaple file above would be:
 

--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -5,7 +5,7 @@
   name="PVR IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@
-    <import addon="inputstream.ffmpegdirect" minversion="1.9.2" optional="true"/>
+    <import addon="inputstream.ffmpegdirect" minversion="1.12.0" optional="true"/>
     <import addon="inputstream.adaptive" minversion="2.5.5" optional="true"/>
     <import addon="inputstream.rtmp" minversion="3.0.3" optional="true"/>
   </requires>

--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="5.1.0"
+  version="5.2.0"
   name="PVR IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@
@@ -169,6 +169,14 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v5.2.0
+- Added: Enable timeshift feature from inputstream.ffmpegdirect
+- Added: Support VOD catchup streams including those via plugin URLs
+- Added: Access to ffmpegdirect settings and inputstream checks (C++ API)
+- Fixed: Fix flussonic ts detected as wrong type
+- Fixed: Use kodis built in inputstreams for plugin urls
+- Fixed: Fix incorrect catchup granularity for flussonic stream
+
 v5.1.0
 - Added: Support catchup-type M3U property
 - Added: Set MIME type and manifest on stream types if required

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,11 @@
+v5.2.0
+- Added: Enable timeshift feature from inputstream.ffmpegdirect
+- Added: Support VOD catchup streams including those via plugin URLs
+- Added: Access to ffmpegdirect settings and inputstream checks (C++ API)
+- Fixed: Fix flussonic ts detected as wrong type
+- Fixed: Use kodis built in inputstreams for plugin urls
+- Fixed: Fix incorrect catchup granularity for flussonic stream
+
 v5.1.0
 - Added: Support catchup-type M3U property
 - Added: Set MIME type and manifest on stream types if required

--- a/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
@@ -362,7 +362,25 @@ msgctxt "#30115"
 msgid "Xtream codes"
 msgstr ""
 
-#empty strings from id 30116 to 30599
+#empty strings from id 30116 to 30119
+
+#. label-category: timeshift
+#. label-group: Timeshift - Timeshift
+msgctxt "#30120"
+msgid "Timeshift"
+msgstr ""
+
+#. label: Timeshift - timeshiftEnabled
+msgctxt "#30121"
+msgid "Enable timeshift"
+msgstr ""
+
+#. label: Timeshift - timeshiftHttp
+msgctxt "#30122"
+msgid "Enable timeshift for HTTP based streams"
+msgstr ""
+
+#empty strings from id 30123 to 30599
 
 #. ############
 #. help info #
@@ -613,4 +631,23 @@ msgstr ""
 #. help: Catchup - catchupOnlyOnFinishedProgrammes
 msgctxt "#30708"
 msgid "When selected from the EPG the current live programme cannot be watched as catchup until finished."
+msgstr ""
+
+#empty strings from id 30709 to 307199
+
+#. help info - Timeshift
+
+#. help-category: Timeshift
+msgctxt "#30720"
+msgid "Timeshift settings for pausing/rewinding and fast-forwarding live streams."
+msgstr ""
+
+#. help: Timeshift - timeshiftEnabled
+msgctxt "#30721"
+msgid "Enable the timeshift feature."
+msgstr ""
+
+#. help: Timeshift - timeshiftHttp
+msgctxt "#30722"
+msgid "Enable the timeshift feature for HTTP based streams. Will only apply to streams that do not select a specific inputstream addon for playback. . The `inputstream.ffmpegdirect` addon will be used for tiemshift."
 msgstr ""

--- a/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
@@ -380,7 +380,29 @@ msgctxt "#30122"
 msgid "Enable timeshift for HTTP based streams"
 msgstr ""
 
-#empty strings from id 30123 to 30599
+#. label: Timeshift - timeshiftFFmpegdirectSettings
+msgctxt "#30123"
+msgid "- Modify inputstream.ffmpegdirect settings..."
+msgstr ""
+
+#empty strings from id 30123 to 30499
+
+#. notification: Inputstreams
+msgctxt "#30500"
+msgid "Inputstream error"
+msgstr ""
+
+#. notification: Inputstreams
+msgctxt "#30501"
+msgid "The %s addon is not installed."
+msgstr ""
+
+#. notification: Inputstreams
+msgctxt "#30502"
+msgid "The %s addon is not enabled."
+msgstr ""
+
+#empty strings from id 30503 to 30599
 
 #. ############
 #. help info #
@@ -650,4 +672,9 @@ msgstr ""
 #. help: Timeshift - timeshiftHttp
 msgctxt "#30722"
 msgid "Enable the timeshift feature for HTTP based streams. Will only apply to streams that do not select a specific inputstream addon for playback. . The `inputstream.ffmpegdirect` addon will be used for tiemshift."
+msgstr ""
+
+#. help: Timeshift - timeshiftFFmpegdirectSettings
+msgctxt "#30723"
+msgid "Open settings dialog for inputstream.ffmpegdirect for modification of timeshift and other settings."
 msgstr ""

--- a/pvr.iptvsimple/resources/settings.xml
+++ b/pvr.iptvsimple/resources/settings.xml
@@ -294,6 +294,16 @@
           </dependencies>
           <control type="toggle" />
         </setting>
+        <setting id="test123" type="action" label="30123" help="30723">
+          <level>0</level>
+          <data>Addon.OpenSettings(inputstream.ffmpegdirect)</data>
+          <dependencies>
+            <dependency type="enable" setting="timeshiftEnabled" operator="is">true</dependency>
+          </dependencies>
+          <control type="button" format="action">
+            <close>true</close>
+          </control>
+        </setting>
       </group>
     </category>
 

--- a/pvr.iptvsimple/resources/settings.xml
+++ b/pvr.iptvsimple/resources/settings.xml
@@ -278,6 +278,25 @@
       </group>
     </category>
 
+    <!-- Timeshift -->
+    <category id="timeshift" label="30120" help="30720">
+      <group id="1" label="30120">
+        <setting id="timeshiftEnabled" type="boolean" label="30121" help="30721">
+          <level>0</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="timeshiftEnabledHttp" type="boolean"  parent="timeshiftEnabled" label="30122" help="30722">
+          <level>0</level>
+          <default>true</default>
+          <dependencies>
+            <dependency type="enable" setting="timeshiftEnabled" operator="is">true</dependency>
+          </dependencies>
+          <control type="toggle" />
+        </setting>
+      </group>
+    </category>
+
     <!-- Catchup -->
     <category id="catchup" label="30100" help="30700">
       <group id="1" label="30100">

--- a/src/iptvsimple/CatchupController.cpp
+++ b/src/iptvsimple/CatchupController.cpp
@@ -360,7 +360,7 @@ std::string BuildEpgTagUrl(time_t startTime, time_t duration, const Channel& cha
   time_t timeNow = std::time(nullptr);
   time_t offset = startTime + timeOffset;
 
-  if (startTime > 0 && offset < (timeNow - 5))
+  if ((startTime > 0 && offset < (timeNow - 5)) || (channel.IgnoreCatchupDays() && !programmeCatchupId.empty()))
     startTimeUrl = FormatDateTime(offset - timezoneShiftSecs, duration, channel.GetCatchupSource());
   else
     startTimeUrl = channel.GetStreamURL();

--- a/src/iptvsimple/CatchupController.h
+++ b/src/iptvsimple/CatchupController.h
@@ -37,10 +37,10 @@ namespace iptvsimple
 
     bool ControlsLiveStream() const { return m_controlsLiveStream; }
     void ResetCatchupState() { m_resetCatchupState = true; }
+    data::EpgEntry* GetEPGEntry(const iptvsimple::data::Channel& myChannel, time_t lookupTime);
 
   private:
     data::EpgEntry* GetLiveEPGEntry(const iptvsimple::data::Channel& myChannel);
-    data::EpgEntry* GetEPGEntry(const iptvsimple::data::Channel& myChannel, time_t lookupTime);
     void SetCatchupInputStreamProperties(bool playbackAsLive, const iptvsimple::data::Channel& channel, std::map<std::string, std::string>& catchupProperties, const StreamType& streamType);
     StreamType StreamTypeLookup(const data::Channel& channel, bool fromEpg = false);
     std::string GetStreamTestUrl(const data::Channel& channel, bool fromEpg) const;

--- a/src/iptvsimple/PlaylistLoader.cpp
+++ b/src/iptvsimple/PlaylistLoader.cpp
@@ -226,20 +226,10 @@ std::string PlaylistLoader::ParseIntoChannel(const std::string& line, Channel& c
     if (strCatchupCorrection.empty())
       channel.SetCatchupCorrectionSecs(catchupCorrectionSecs);
 
-    int siptvTimeshiftDays = 0;
-    if (!strCatchupSiptv.empty())
-      siptvTimeshiftDays = atoi(strCatchupSiptv.c_str());
-    if (!strCatchupDays.empty())
-      channel.SetCatchupDays(atoi(strCatchupDays.c_str()));
-    else if (siptvTimeshiftDays > 0)
-      channel.SetCatchupDays(siptvTimeshiftDays);
-    else
-      channel.SetCatchupDays(Settings::GetInstance().GetCatchupDays());
-
     if (StringUtils::EqualsNoCase(strCatchup, "default") || StringUtils::EqualsNoCase(strCatchup, "append") ||
         StringUtils::EqualsNoCase(strCatchup, "shift") || StringUtils::EqualsNoCase(strCatchup, "flussonic") ||
         StringUtils::EqualsNoCase(strCatchup, "flussonic-ts") || StringUtils::EqualsNoCase(strCatchup, "fs") ||
-        StringUtils::EqualsNoCase(strCatchup, "xc"))
+        StringUtils::EqualsNoCase(strCatchup, "xc") || StringUtils::EqualsNoCase(strCatchup, "vod"))
       channel.SetHasCatchup(true);
 
     if (StringUtils::EqualsNoCase(strCatchup, "default"))
@@ -252,6 +242,20 @@ std::string PlaylistLoader::ParseIntoChannel(const std::string& line, Channel& c
       channel.SetCatchupMode(CatchupMode::FLUSSONIC);
     else if (StringUtils::EqualsNoCase(strCatchup, "xc"))
       channel.SetCatchupMode(CatchupMode::XTREAM_CODES);
+    else if (StringUtils::EqualsNoCase(strCatchup, "vod"))
+      channel.SetCatchupMode(CatchupMode::VOD);
+
+    int siptvTimeshiftDays = 0;
+    if (!strCatchupSiptv.empty())
+      siptvTimeshiftDays = atoi(strCatchupSiptv.c_str());
+    if (!strCatchupDays.empty())
+      channel.SetCatchupDays(atoi(strCatchupDays.c_str()));
+    else if (channel.GetCatchupMode() == CatchupMode::VOD)
+      channel.SetCatchupDays(IGNORE_CATCHUP_DAYS);
+    else if (siptvTimeshiftDays > 0)
+      channel.SetCatchupDays(siptvTimeshiftDays);
+    else
+      channel.SetCatchupDays(Settings::GetInstance().GetCatchupDays());
 
     // We also need to support the timeshift="days" tag from siptv
     // this was used before the catchup tags were introduced

--- a/src/iptvsimple/PlaylistLoader.cpp
+++ b/src/iptvsimple/PlaylistLoader.cpp
@@ -238,7 +238,8 @@ std::string PlaylistLoader::ParseIntoChannel(const std::string& line, Channel& c
 
     if (StringUtils::EqualsNoCase(strCatchup, "default") || StringUtils::EqualsNoCase(strCatchup, "append") ||
         StringUtils::EqualsNoCase(strCatchup, "shift") || StringUtils::EqualsNoCase(strCatchup, "flussonic") ||
-        StringUtils::EqualsNoCase(strCatchup, "fs") || StringUtils::EqualsNoCase(strCatchup, "xc"))
+        StringUtils::EqualsNoCase(strCatchup, "flussonic-ts") || StringUtils::EqualsNoCase(strCatchup, "fs") ||
+        StringUtils::EqualsNoCase(strCatchup, "xc"))
       channel.SetHasCatchup(true);
 
     if (StringUtils::EqualsNoCase(strCatchup, "default"))

--- a/src/iptvsimple/Settings.cpp
+++ b/src/iptvsimple/Settings.cpp
@@ -79,6 +79,12 @@ void Settings::ReadFromAddon(const std::string& userPath, const std::string clie
   if (!XBMC->GetSetting("logoFromEpg", &m_epgLogosMode))
     m_epgLogosMode = EpgLogosMode::IGNORE_XMLTV;
 
+  // Timeshift
+  if (!XBMC->GetSetting("timeshiftEnabled", &m_timeshiftEnabled))
+    m_timeshiftEnabled = false;
+  if (!XBMC->GetSetting("timeshiftEnabledHttp", &m_timeshiftEnabledHttp))
+    m_timeshiftEnabledHttp = false;
+
   // Catchup
   if (!XBMC->GetSetting("catchupEnabled", &m_catchupEnabled))
     m_catchupEnabled = false;
@@ -178,6 +184,11 @@ ADDON_STATUS Settings::SetValue(const std::string& settingName, const void* sett
     return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_logoBaseUrl, ADDON_STATUS_OK, ADDON_STATUS_OK);
   else if (settingName == "logoFromEpg")
     return SetSetting<EpgLogosMode, ADDON_STATUS>(settingName, settingValue, m_epgLogosMode, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  // Timeshift
+  else if (settingName == "timeshiftEnabled")
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_timeshiftEnabled, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  else if (settingName == "timeshiftEnabledHttp")
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_timeshiftEnabledHttp, ADDON_STATUS_OK, ADDON_STATUS_OK);
   // Catchup
   else if (settingName == "catchupEnabled")
     return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_catchupEnabled, ADDON_STATUS_OK, ADDON_STATUS_OK);

--- a/src/iptvsimple/Settings.h
+++ b/src/iptvsimple/Settings.h
@@ -101,6 +101,9 @@ namespace iptvsimple
     const std::string& GetLogoBaseUrl() const { return m_logoBaseUrl; }
     const EpgLogosMode& GetEpgLogosMode() const { return m_epgLogosMode; }
 
+    bool IsTimeshiftEnabled() const { return m_timeshiftEnabled; }
+    bool IsTimeshiftEnabledHttp() const { return m_timeshiftEnabledHttp; }
+
     bool IsCatchupEnabled() const { return m_catchupEnabled; }
     const std::string& GetCatchupQueryFormat() const { return m_catchupQueryFormat; }
     int GetCatchupDays() const { return m_catchupDays; }
@@ -196,6 +199,10 @@ namespace iptvsimple
     std::string m_logoPath;
     std::string m_logoBaseUrl;
     EpgLogosMode m_epgLogosMode = EpgLogosMode::IGNORE_XMLTV;
+
+    // Timeshift
+    bool m_timeshiftEnabled = false;
+    bool m_timeshiftEnabledHttp = false;
 
     // Catchup
     bool m_catchupEnabled = false;

--- a/src/iptvsimple/data/Channel.cpp
+++ b/src/iptvsimple/data/Channel.cpp
@@ -211,6 +211,12 @@ bool Channel::IsCatchupSupported() const
   return Settings::GetInstance().IsCatchupEnabled() && m_hasCatchup && !m_catchupSource.empty();
 }
 
+bool Channel::SupportsLiveStreamTimeshifting() const
+{
+  return Settings::GetInstance().IsTimeshiftEnabled() && Settings::GetInstance().IsTimeshiftEnabledHttp() &&
+         GetProperty(PVR_STREAM_PROPERTY_ISREALTIMESTREAM) == "true" && StringUtils::StartsWith(m_streamURL, "http");
+}
+
 namespace
 {
 bool IsValidTimeshiftingCatchupSource(const std::string& formatString, const CatchupMode& catchupMode)

--- a/src/iptvsimple/data/Channel.cpp
+++ b/src/iptvsimple/data/Channel.cpp
@@ -248,10 +248,11 @@ bool IsTerminatingCatchupSource(const std::string& formatString)
 
 int FindCatchupSourceGranularitySeconds(const std::string& formatString)
 {
-  // A catchup stream terminates if it has an end time specifier
+  // A catchup stream has one second granularity if it supports these specifiers
   if (formatString.find("{utc}") != std::string::npos ||
       formatString.find("${start}") != std::string::npos ||
-      formatString.find("{S}") != std::string::npos)
+      formatString.find("{S}") != std::string::npos ||
+      formatString.find("{offset:1}") != std::string::npos)
     return 1;
 
   return 60;
@@ -330,7 +331,7 @@ void Channel::ConfigureCatchupMode()
     m_catchupSupportsTimeshifting = IsValidTimeshiftingCatchupSource(m_catchupSource);
     m_catchupSourceTerminates = IsTerminatingCatchupSource(m_catchupSource);
     m_catchupGranularitySeconds = FindCatchupSourceGranularitySeconds(m_catchupSource);
-    Logger::Log(LEVEL_DEBUG, "Channel Catchup Format string properties: %s, valid timeshifting source: %s, terminating source: %s, granularity secs: %d", 
+    Logger::Log(LEVEL_DEBUG, "Channel Catchup Format string properties: %s, valid timeshifting source: %s, terminating source: %s, granularity secs: %d",
                 m_channelName.c_str(), m_catchupSupportsTimeshifting ? "true" : "false", m_catchupSourceTerminates ? "true" : "false", m_catchupGranularitySeconds);
   }
 

--- a/src/iptvsimple/data/Channel.h
+++ b/src/iptvsimple/data/Channel.h
@@ -110,6 +110,8 @@ namespace iptvsimple
       const std::string& GetTvgName() const { return m_tvgName; }
       void SetTvgName(const std::string& value) { m_tvgName = value; }
 
+      bool SupportsLiveStreamTimeshifting() const;
+
       const std::map<std::string, std::string>& GetProperties() const { return m_properties; }
       void SetProperties(std::map<std::string, std::string>& value) { m_properties = value; }
       void AddProperty(const std::string& prop, const std::string& value) { m_properties.insert({prop, value}); }

--- a/src/iptvsimple/data/Channel.h
+++ b/src/iptvsimple/data/Channel.h
@@ -24,8 +24,11 @@ namespace iptvsimple
     SHIFT,
     FLUSSONIC,
     XTREAM_CODES,
-    TIMESHIFT // Obsolete but still used by some providers, predates SHIFT
+    TIMESHIFT, // Obsolete but still used by some providers, predates SHIFT
+    VOD
   };
+
+  constexpr int IGNORE_CATCHUP_DAYS = -1;
 
   namespace data
   {
@@ -79,6 +82,7 @@ namespace iptvsimple
       void SetCatchupMode(const CatchupMode& value) { m_catchupMode = value; }
 
       int GetCatchupDays() const { return m_catchupDays; }
+      bool IgnoreCatchupDays() const { return m_catchupDays == IGNORE_CATCHUP_DAYS; }
       void SetCatchupDays(int catchupDays);
       int GetCatchupDaysInSeconds() const { return m_catchupDays * 24 * 60 * 60; }
 

--- a/src/iptvsimple/utilities/StreamUtils.cpp
+++ b/src/iptvsimple/utilities/StreamUtils.cpp
@@ -58,14 +58,20 @@ void StreamUtils::SetAllStreamProperties(PVR_NAMED_VALUE* properties, unsigned i
       if (!channel.HasMimeType() && StreamUtils::HasMimeType(streamType))
         StreamUtils::SetStreamProperty(properties, propertiesCount, propertiesMax, PVR_STREAM_PROPERTY_MIMETYPE, StreamUtils::GetMimeType(streamType));
 
-      if (streamType == StreamType::HLS || streamType == StreamType::TS)
+      if (streamType == StreamType::HLS || streamType == StreamType::TS || streamType == StreamType::OTHER_TYPE)
       {
         if (channel.IsCatchupSupported())
         {
           StreamUtils::SetStreamProperty(properties, propertiesCount, propertiesMax, PVR_STREAM_PROPERTY_INPUTSTREAM, CATCHUP_INPUTSTREAM_NAME);
           SetFFmpegDirectManifestTypeStreamProperty(properties, propertiesCount, propertiesMax, channel, streamURL, streamType);
         }
-        else
+        else if (channel.SupportsLiveStreamTimeshifting())
+        {
+          StreamUtils::SetStreamProperty(properties, propertiesCount, propertiesMax, PVR_STREAM_PROPERTY_INPUTSTREAM, INPUTSTREAM_FFMPEGDIRECT);
+          StreamUtils::SetStreamProperty(properties, propertiesCount, propertiesMax, "inputstream.ffmpegdirect.stream_mode", "timeshift");
+          StreamUtils::SetStreamProperty(properties, propertiesCount, propertiesMax, "inputstream.ffmpegdirect.is_realtime_stream", "true");
+        }
+        else if (streamType == StreamType::HLS || streamType == StreamType::TS)
         {
           StreamUtils::SetStreamProperty(properties, propertiesCount, propertiesMax, PVR_STREAM_PROPERTY_INPUTSTREAM, PVR_STREAM_PROPERTY_VALUE_INPUTSTREAMFFMPEG);
         }

--- a/src/iptvsimple/utilities/StreamUtils.cpp
+++ b/src/iptvsimple/utilities/StreamUtils.cpp
@@ -13,6 +13,8 @@
 #include "Logger.h"
 #include "WebUtils.h"
 
+// TODO: inlcude when C++ API happens
+// #include <kodi/General.h>
 #include <p8-platform/util/StringUtils.h>
 
 using namespace iptvsimple;
@@ -60,12 +62,12 @@ void StreamUtils::SetAllStreamProperties(PVR_NAMED_VALUE* properties, unsigned i
 
       if (streamType == StreamType::HLS || streamType == StreamType::TS || streamType == StreamType::OTHER_TYPE)
       {
-        if (channel.IsCatchupSupported())
+        if (channel.IsCatchupSupported() && CheckInputstreamInstalledAndEnabled(CATCHUP_INPUTSTREAM_NAME))
         {
           StreamUtils::SetStreamProperty(properties, propertiesCount, propertiesMax, PVR_STREAM_PROPERTY_INPUTSTREAM, CATCHUP_INPUTSTREAM_NAME);
           SetFFmpegDirectManifestTypeStreamProperty(properties, propertiesCount, propertiesMax, channel, streamURL, streamType);
         }
-        else if (channel.SupportsLiveStreamTimeshifting())
+        else if (channel.SupportsLiveStreamTimeshifting() && CheckInputstreamInstalledAndEnabled(INPUTSTREAM_FFMPEGDIRECT))
         {
           StreamUtils::SetStreamProperty(properties, propertiesCount, propertiesMax, PVR_STREAM_PROPERTY_INPUTSTREAM, INPUTSTREAM_FFMPEGDIRECT);
           StreamUtils::SetStreamProperty(properties, propertiesCount, propertiesMax, "inputstream.ffmpegdirect.stream_mode", "timeshift");
@@ -79,6 +81,8 @@ void StreamUtils::SetAllStreamProperties(PVR_NAMED_VALUE* properties, unsigned i
     }
     else // inputstream.adaptive
     {
+      CheckInputstreamInstalledAndEnabled(INPUTSTREAM_ADAPTIVE);
+
       bool streamUrlSet = false;
 
       // If no media headers are explicitly set for inputstream.adaptive,
@@ -106,7 +110,7 @@ void StreamUtils::SetAllStreamProperties(PVR_NAMED_VALUE* properties, unsigned i
       if (!streamUrlSet)
         StreamUtils::SetStreamProperty(properties, propertiesCount, propertiesMax, PVR_STREAM_PROPERTY_STREAMURL, streamURL);
 
-      StreamUtils::SetStreamProperty(properties, propertiesCount, propertiesMax, PVR_STREAM_PROPERTY_INPUTSTREAM, "inputstream.adaptive");
+      StreamUtils::SetStreamProperty(properties, propertiesCount, propertiesMax, PVR_STREAM_PROPERTY_INPUTSTREAM, INPUTSTREAM_ADAPTIVE);
       StreamUtils::SetStreamProperty(properties, propertiesCount, propertiesMax, "inputstream.adaptive.manifest_type", StreamUtils::GetManifestType(streamType));
       if (streamType == StreamType::HLS || streamType == StreamType::DASH)
         StreamUtils::SetStreamProperty(properties, propertiesCount, propertiesMax, PVR_STREAM_PROPERTY_MIMETYPE, StreamUtils::GetMimeType(streamType));
@@ -126,6 +130,29 @@ void StreamUtils::SetAllStreamProperties(PVR_NAMED_VALUE* properties, unsigned i
     for (auto& prop : catchupProperties)
       StreamUtils::SetStreamProperty(properties, propertiesCount, propertiesMax, prop.first, prop.second);
   }
+}
+bool StreamUtils::CheckInputstreamInstalledAndEnabled(const std::string& inputstreamName)
+{
+  // TODO: uncomment when C++ API happens
+
+  // std::string version;
+  // bool enabled;
+
+  // if (kodi::IsAddonAvailable(inputstreamName, version, enabled))
+  // {
+  //   if (!enabled)
+  //   {
+  //     std::string message = StringUtils::Format(kodi::LocalizedString(30502).c_str(), inputstreamName.c_str());
+  //     kodi::QueueNotification(QueueMsg::QUEUE_ERROR, kodi::LocalizedString(30500), message);
+  //   }
+  // }
+  // else // Not installed
+  // {
+  //   std::string message = StringUtils::Format(kodi::LocalizedString(30501).c_str(), inputstreamName.c_str());
+  //   kodi::QueueNotification(QueueMsg::QUEUE_ERROR, kodi::LocalizedString(30500), message);
+  // }
+
+  return true;
 }
 
 void StreamUtils::InspectAndSetFFmpegDirectStreamProperties(PVR_NAMED_VALUE* properties, unsigned int* propertiesCount, unsigned int propertiesMax, const iptvsimple::data::Channel& channel, const std::string& streamURL)

--- a/src/iptvsimple/utilities/StreamUtils.h
+++ b/src/iptvsimple/utilities/StreamUtils.h
@@ -20,6 +20,7 @@ namespace iptvsimple
 {
   namespace utilities
   {
+    static const std::string INPUTSTREAM_ADAPTIVE = "inputstream.adaptive";
     static const std::string INPUTSTREAM_FFMPEGDIRECT = "inputstream.ffmpegdirect";
     static const std::string CATCHUP_INPUTSTREAM_NAME = INPUTSTREAM_FFMPEGDIRECT;
 
@@ -45,6 +46,7 @@ namespace iptvsimple
       static bool SupportsFFmpegReconnect(const StreamType& streamType, const iptvsimple::data::Channel& channel);
       static void InspectAndSetFFmpegDirectStreamProperties(PVR_NAMED_VALUE* properties, unsigned int* propertiesCount, unsigned int propertiesMax, const iptvsimple::data::Channel& channel, const std::string& streamUrl);
       static void SetFFmpegDirectManifestTypeStreamProperty(PVR_NAMED_VALUE* properties, unsigned int* propertiesCount, unsigned int propertiesMax, const iptvsimple::data::Channel& channel, const std::string& streamURL, const StreamType& streamType);
+      static bool CheckInputstreamInstalledAndEnabled(const std::string& inputstreamName);
 
     };
   } // namespace utilities


### PR DESCRIPTION
v5.2.0
- Added: Enable timeshift feature from inputstream.ffmpegdirect
- Added: Support VOD catchup streams including those via plugin URLs
- Added: Access to ffmpegdirect settings and inputstream checks (C++ API)
- Fixed: Fix flussonic ts detected as wrong type
- Fixed: Use kodis built in inputstreams for plugin urls
- Fixed: Fix incorrect catchup granularity for flussonic stream