### PR TITLE
Inputstream check

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="6.0.1"
+  version="6.1.0"
   name="PVR IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@
@@ -169,6 +169,9 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v6.1.0
+- Added: Check inputstream is installed or enabled if a custom inputstream is provided in M3U
+
 v6.0.1
 - Update PVR API 7.0.1
 

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v6.1.0
+- Added: Check inputstream is installed or enabled if a custom inputstream is provided in M3U
+
 v6.0.1
 - Update PVR API 7.0.1
 

--- a/src/iptvsimple/utilities/StreamUtils.cpp
+++ b/src/iptvsimple/utilities/StreamUtils.cpp
@@ -27,6 +27,9 @@ void StreamUtils::SetAllStreamProperties(std::vector<kodi::addon::PVRStreamPrope
     // Channel has an inputstream class set so we only set the stream URL
     properties.emplace_back(PVR_STREAM_PROPERTY_STREAMURL, streamURL);
 
+    if (channel.GetInputStreamName() != PVR_STREAM_PROPERTY_VALUE_INPUTSTREAMFFMPEG)
+      CheckInputstreamInstalledAndEnabled(channel.GetInputStreamName());
+
     if (channel.GetInputStreamName() == INPUTSTREAM_FFMPEGDIRECT)
       InspectAndSetFFmpegDirectStreamProperties(properties, channel, streamURL);
   }


### PR DESCRIPTION
v6.1.0
- Added: Check inputstream is installed or enabled if a custom inputstream is provided in M3U