### PR TITLE
Vod no timeshift

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="6.2.2"
+  version="6.2.3"
   name="PVR IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@
@@ -169,6 +169,9 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v6.2.3
+- Fixed: Don't allow timeshift mode on catchup VOD stream
+
 v6.2.2
 - Fixed: Correctly pass realtime stream information to inputstream.ffmpegdirect addon
 

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v6.2.3
+- Fixed: Don't allow timeshift mode on catchup VOD stream
+
 v6.2.2
 - Fixed: Correctly pass realtime stream information to inputstream.ffmpegdirect addon
 

--- a/src/iptvsimple/utilities/StreamUtils.cpp
+++ b/src/iptvsimple/utilities/StreamUtils.cpp
@@ -56,7 +56,9 @@ void StreamUtils::SetAllStreamProperties(std::vector<kodi::addon::PVRStreamPrope
           properties.emplace_back(PVR_STREAM_PROPERTY_INPUTSTREAM, CATCHUP_INPUTSTREAM_NAME);
           SetFFmpegDirectManifestTypeStreamProperty(properties, channel, streamURL, streamType);
         }
-        else if (channel.SupportsLiveStreamTimeshifting() && CheckInputstreamInstalledAndEnabled(INPUTSTREAM_FFMPEGDIRECT))
+        else if (channel.SupportsLiveStreamTimeshifting() &&
+                 channel.GetCatchupMode() != CatchupMode::VOD &&
+                 CheckInputstreamInstalledAndEnabled(INPUTSTREAM_FFMPEGDIRECT))
         {
           properties.emplace_back(PVR_STREAM_PROPERTY_INPUTSTREAM, INPUTSTREAM_FFMPEGDIRECT);
           SetFFmpegDirectManifestTypeStreamProperty(properties, channel, streamURL, streamType);


### PR DESCRIPTION
v6.2.3
- Fixed: Don't allow timeshift mode on catchup VOD stream