### PR TITLE
Fix no vod timeshift

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ For any TS stream an additional property should be added to every M3U entry usin
 
 * **Enable timeshift**: Enable the timeshift feature.
 * **Enable timeshift for HTTP based streams**: Enable the timeshift feature for HTTP based streams. Will only apply to streams that do not select a specific inputstream addon for playback. The `inputstream.ffmpegdirect` addon will be used for timeshift."
-* **Always enable timeshift stream mode if missing**: If a `stream_mode` property is not specified along with an `inputstream.ffmpegdirect` property always add it for any supported stream types.
+* **Always enable timeshift stream mode if missing**: If a `stream_mode` property is not specified along with an `inputstream.ffmpegdirect` property always add it for any supported stream types. Note that this setting has no effect on catchup VOD streams that are not live.
 * **Modify inputstream.ffmpegdirect settings..**: Open settings dialog for inputstream.ffmpegdirect for modification of timeshift and other settings.
 
 ### Catchup

--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="6.2.3"
+  version="6.2.4"
   name="PVR IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@
@@ -169,6 +169,9 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v6.2.4
+- Fixed: Only allow timeshift on streams that are live
+
 v6.2.3
 - Fixed: Don't allow timeshift mode on catchup VOD stream
 

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v6.2.4
+- Fixed: Only allow timeshift on streams that are live
+
 v6.2.3
 - Fixed: Don't allow timeshift mode on catchup VOD stream
 

--- a/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
@@ -691,5 +691,5 @@ msgstr ""
 
 #. help: Timeshift - timeshiftEnabledCustom
 msgctxt "#30724"
-msgid "If a stream_mode property is not specified along with an inputstream.ffmpegdirect property always add it for any supported stream types."
+msgid "If a stream_mode property is not specified along with an inputstream.ffmpegdirect property always add it for any supported stream types. Note that this setting has no effect on catchup VOD streams that are not live."
 msgstr ""

--- a/src/iptvsimple/utilities/StreamUtils.cpp
+++ b/src/iptvsimple/utilities/StreamUtils.cpp
@@ -57,7 +57,7 @@ void StreamUtils::SetAllStreamProperties(std::vector<kodi::addon::PVRStreamPrope
           SetFFmpegDirectManifestTypeStreamProperty(properties, channel, streamURL, streamType);
         }
         else if (channel.SupportsLiveStreamTimeshifting() &&
-                 channel.GetCatchupMode() != CatchupMode::VOD &&
+                 channel.GetStreamURL() == streamURL &&
                  CheckInputstreamInstalledAndEnabled(INPUTSTREAM_FFMPEGDIRECT))
         {
           properties.emplace_back(PVR_STREAM_PROPERTY_INPUTSTREAM, INPUTSTREAM_FFMPEGDIRECT);
@@ -161,6 +161,7 @@ void StreamUtils::InspectAndSetFFmpegDirectStreamProperties(std::vector<kodi::ad
   }
 
   if (channel.SupportsLiveStreamTimeshifting() &&
+      channel.GetStreamURL() == streamURL &&
       channel.GetProperty("inputstream.ffmpegdirect.stream_mode").empty() &&
       Settings::GetInstance().AlwaysEnableTimeshiftModeIfMissing())
   {


### PR DESCRIPTION
v6.2.4
- Fixed: Don't allow timeshift mode on catchup VOD streams even if enable timeshift on all streams if missing is enabled
