### PR TITLE
Allow max catchup of 15 days and premiere tag from XMLTV

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -121,7 +121,7 @@
     <disclaimer lang="de_DE">Dies ist instabile Software! Die Autoren sind in keiner Weise verantwortlich für fehlgeschlagene Wiedergaben, falsche EPG Zeiten, verschwendete Zeit oder unerwünschte Effekte jeglicher Art.</disclaimer>
     <disclaimer lang="el_GR">Ασταθές πρόγραμμα! Οι δημιουργοί δεν είναι σε καμία περίπτωση υπεύθυνοι για αποτυχημένες εγγραφές, λανθασμένους χρονοδιακόπτες, χαμένες ώρες, ή κάθε είδους ανεπιθύμητα αποτελέσματα.</disclaimer>
     <disclaimer lang="en_AU">This is unstable software! The authors are in no way responsible for failed playings, incorrect EPG times, wasted hours, or any other undesirable effects.</disclaimer>
-    <disclaimer lang="en_GB">This is unstable software! The authors are in no way responsible for failed playings, incorrect EPG times, wasted hours, or any other undesirable effects.</disclaimer>
+    <disclaimer lang="en_GB">The authors are in no way responsible for failed playings, incorrect EPG times, wasted hours, or any other undesirable effects.</disclaimer>
     <disclaimer lang="en_NZ">This is unstable software! The authors are in no way responsible for failed playings, incorrect EPG times, wasted hours, or any other undesirable effects.</disclaimer>
     <disclaimer lang="en_US">This is unstable software! The authors are in no way responsible for failed playings, incorrect EPG times, wasted hours, or any other undesirable effects.</disclaimer>
     <disclaimer lang="es_AR">Este es un software inestable. El autor no se hace responsable por reproducciones fallidas, datos de GEP incorrectos, horas perdidas o cualquier otro efecto indeseable.</disclaimer>

--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="6.2.4"
+  version="6.3.0"
   name="PVR IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@
@@ -169,6 +169,10 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v6.3.0
+- Update: Allow max catchup of 15 days
+- Added: Support premiere and new tag from XMLTV
+
 v6.2.4
 - Fixed: Only allow timeshift on streams that are live
 

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,7 @@
+v6.3.0
+- Update: Allow max catchup of 15 days
+- Added: Support premiere and new tag from XMLTV
+
 v6.2.4
 - Fixed: Only allow timeshift on streams that are live
 

--- a/pvr.iptvsimple/resources/settings.xml
+++ b/pvr.iptvsimple/resources/settings.xml
@@ -341,7 +341,7 @@
           <constraints>
             <minimum>1</minimum>
             <step>1</step>
-            <maximum>7</maximum>
+            <maximum>15</maximum>
           </constraints>
           <default>5</default>
           <dependencies>

--- a/src/iptvsimple/data/EpgEntry.cpp
+++ b/src/iptvsimple/data/EpgEntry.cpp
@@ -236,6 +236,10 @@ bool EpgEntry::UpdateFrom(const xml_node& channelNode, const std::string& id,
   if (starRatingNode)
     m_starRating = ParseStarRating(GetNodeValue(starRatingNode, "value"));
 
+  const auto& newNode = channelNode.child("new");
+  if (newNode)
+    m_new = true;
+
   const auto& premiereNode = channelNode.child("premiere");
   if (premiereNode)
     m_premiere = true;

--- a/src/iptvsimple/data/EpgEntry.cpp
+++ b/src/iptvsimple/data/EpgEntry.cpp
@@ -65,6 +65,8 @@ void EpgEntry::UpdateTo(kodi::addon::PVREPGTag& left, int iChannelUid, int timeS
   int iFlags = EPG_TAG_FLAG_UNDEFINED;
   if (m_new)
     iFlags |= EPG_TAG_FLAG_IS_NEW;
+  if (m_premiere)
+    iFlags |= EPG_TAG_FLAG_IS_PREMIERE;
   left.SetFlags(iFlags);
 }
 
@@ -233,6 +235,10 @@ bool EpgEntry::UpdateFrom(const xml_node& channelNode, const std::string& id,
   const auto& starRatingNode = channelNode.child("star-rating");
   if (starRatingNode)
     m_starRating = ParseStarRating(GetNodeValue(starRatingNode, "value"));
+
+  const auto& premiereNode = channelNode.child("premiere");
+  if (premiereNode)
+    m_premiere = true;
 
   std::vector<std::pair<std::string, std::string>> episodeNumbersList;
   for (const auto& episodeNumNode : channelNode.children("episode-num"))

--- a/src/iptvsimple/data/EpgEntry.h
+++ b/src/iptvsimple/data/EpgEntry.h
@@ -94,6 +94,9 @@ namespace iptvsimple
       bool IsNew() const { return m_new; }
       void SetNew(int value) { m_new = value; }
 
+      bool IsPremiere() const { return m_premiere; }
+      void SetPremiere(int value) { m_premiere = value; }
+
       void UpdateTo(kodi::addon::PVREPGTag& left, int iChannelUid, int timeShift, const std::vector<EpgGenre>& genres);
       bool UpdateFrom(const pugi::xml_node& channelNode, const std::string& id,
                       int start, int end, int minShiftTime, int maxShiftTime);
@@ -127,6 +130,7 @@ namespace iptvsimple
       std::string m_writer;
       std::string m_catchupId;
       bool m_new = false;
+      bool m_premiere = false;
     };
   } //namespace data
 } //namespace iptvsimple


### PR DESCRIPTION
v6.3.0
- Update: Allow max catchup of 15 days
- Added: Support premiere and new tag from XMLTV