### PR TITLE
Allow jenkins to build on any branch for testing, Add appveyor to build. [Thanks]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(version: "Matrix")
+buildPlugin()

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://dev.azure.com/teamkodi/kodi-pvr/_apis/build/status/kodi-pvr.pvr.iptvsimple?branchName=Matrix)](https://dev.azure.com/teamkodi/kodi-pvr/_build/latest?definitionId=57&branchName=Matrix)
 [![Build Status](https://jenkins.kodi.tv/view/Addons/job/kodi-pvr/job/pvr.iptvsimple/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/kodi-pvr%2Fpvr.iptvsimple/branches/)
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/5120/badge.svg)](https://scan.coverity.com/projects/5120)
-[![Build status](https://ci.appveyor.com/api/projects/status/uyf7c799ac864gmg?svg=true)](https://ci.appveyor.com/project/I-Cat/pvr-iptvsimple)
+[![Build status](https://ci.appveyor.com/api/projects/status/uyf7c799ac864gmg/branch/patch-1?svg=true)](https://ci.appveyor.com/project/I-Cat/pvr-iptvsimple/branch/patch-1)
 
 
 # IPTV Simple PVR

--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ For a listing of the supported M3U and XMLTV elements see the appendix [here](#s
 
 In order to build the addon on mac the steps are different to Linux and Windows as the cmake command above will not produce an addon that will run in kodi. Instead using make directly as per the supported build steps for kodi on mac we can build the tools and just the addon on it's own. Following this we copy the addon into kodi. Note that we checkout kodi to a separate directory as this repo will only only be used to build the addon and nothing else.
 
+#### AppVeyour
+Steps
+1. * `cd`
+2. * `git clone --depth=1 https://github.com/xbmc/xbmc.git'
+3. * `cd %app_id%'
+4. * `mkdir build'
+5. * `cd build'
+6. * `mkdir -p definition\%app_id%
+7. * `echo %app_id% %APPVEYOR_BUILD_FOLDER% %APPVEYOR_REPO_COMMIT% > definition\%app_id%\%app_id%.txt'
+8. * `cmake -T host=x64 -G "%GENERATOR%" %WINSTORE% -DADDONS_TO_BUILD=%app_id% -DCMAKE_BUILD_TYPE=%CONFIG% -DADDONS_DEFINITION_DIR=%APPVEYOR_BUILD_FOLDER%/build/definition -           DADDON_SRC_PREFIX=../.. -DCMAKE_INSTALL_PREFIX=../../xbmc/addons -DPACKAGE_ZIP=1 ../../xbmc/cmake/addons`
+
 #### Build tools and initial addon build
 
 1. Get the repos

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Build Status](https://dev.azure.com/teamkodi/kodi-pvr/_apis/build/status/kodi-pvr.pvr.iptvsimple?branchName=Matrix)](https://dev.azure.com/teamkodi/kodi-pvr/_build/latest?definitionId=57&branchName=Matrix)
 [![Build Status](https://jenkins.kodi.tv/view/Addons/job/kodi-pvr/job/pvr.iptvsimple/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/kodi-pvr%2Fpvr.iptvsimple/branches/)
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/5120/badge.svg)](https://scan.coverity.com/projects/5120)
+[![Build status](https://ci.appveyor.com/api/projects/status/uyf7c799ac864gmg?svg=true)](https://ci.appveyor.com/project/I-Cat/pvr-iptvsimple)
+
 
 # IPTV Simple PVR
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,33 @@
+version: BuildNr.{build}
+
+image: Visual Studio 2015
+
+shallow_clone: true
+
+clone_folder: c:\projects\pvr.iptvsimple
+
+environment:
+  app_id: pvr.iptvsimple
+
+  matrix:
+    - GENERATOR: "Visual Studio 14"
+      CONFIG: Release
+    - GENERATOR: "Visual Studio 14 Win64"
+      CONFIG: Release
+    - GENERATOR: "Visual Studio 14 Win64"
+      CONFIG: Release
+      WINSTORE: -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION="10.0.16299.0"
+    - GENERATOR: "Visual Studio 14 ARM"
+      CONFIG: Release
+      WINSTORE: -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION="10.0.16299.0"
+
+build_script:
+  - cd ..
+  - git clone --depth=1 https://github.com/xbmc/xbmc.git
+  - cd %app_id%
+  - mkdir build
+  - cd build
+  - mkdir -p definition\%app_id%
+  - echo %app_id% %APPVEYOR_BUILD_FOLDER% %APPVEYOR_REPO_COMMIT% > definition\%app_id%\%app_id%.txt
+  - cmake -T host=x64 -G "%GENERATOR%" %WINSTORE% -DADDONS_TO_BUILD=%app_id% -DCMAKE_BUILD_TYPE=%CONFIG% -DADDONS_DEFINITION_DIR=%APPVEYOR_BUILD_FOLDER%/build/definition -DADDON_SRC_PREFIX=../.. -DCMAKE_INSTALL_PREFIX=../../xbmc/addons -DPACKAGE_ZIP=1 ../../xbmc/cmake/addons
+  - cmake --build . --config %CONFIG% --target %app_id%


### PR DESCRIPTION
Allow jenkins to build on any branch for testing, Add appveyor to be a builder.
For Me I cannot log in to [https://dev.azure.com/teamkodi/kodi-pvr/_apis/build/status/kodi-pvr.pvr.iptvsimple?branchName="branch"]. By being a ristricted access I & others won't beable to see the azure/Windows biuld flow.
Also can You please update the "Readme.md" to include the azure/Windows build flow please. Thank you.