### PR TITLE
Append TV/Radio to group name if the same group name is used for both channel types

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="6.3.0"
+  version="6.3.1"
   name="PVR IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@
@@ -169,6 +169,9 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v6.3.1
+- Fixed: Append TV/Radio to group name if the same group name is used for both channel types
+
 v6.3.0
 - Update: Allow max catchup of 15 days
 - Added: Support premiere and new tag from XMLTV

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v6.3.1
+- Fixed: Append TV/Radio to group name if the same group name is used for both channel types
+
 v6.3.0
 - Update: Allow max catchup of 15 days
 - Added: Support premiere and new tag from XMLTV

--- a/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
@@ -395,7 +395,19 @@ msgctxt "#30125"
 msgid "Always enable timeshift stream mode if missing"
 msgstr ""
 
-#empty strings from id 30126 to 30499
+#empty strings from id 30126 to 30449
+
+#. label: TV
+msgctxt "#30450"
+msgid "TV"
+msgstr ""
+
+#. label: Radio
+msgctxt "#30451"
+msgid "Radio"
+msgstr ""
+
+#empty strings from id 30452 to 30499
 
 #. notification: Inputstreams
 msgctxt "#30500"

--- a/src/iptvsimple/ChannelGroups.cpp
+++ b/src/iptvsimple/ChannelGroups.cpp
@@ -10,6 +10,8 @@
 
 #include "utilities/Logger.h"
 
+#include <kodi/General.h>
+
 using namespace iptvsimple;
 using namespace iptvsimple::data;
 using namespace iptvsimple::utilities;
@@ -87,6 +89,19 @@ PVR_ERROR ChannelGroups::GetChannelGroupMembers(const kodi::addon::PVRChannelGro
 int ChannelGroups::AddChannelGroup(iptvsimple::data::ChannelGroup& channelGroup)
 {
   const ChannelGroup* existingChannelGroup = FindChannelGroup(channelGroup.GetGroupName());
+
+  if (existingChannelGroup && channelGroup.IsRadio() != existingChannelGroup->IsRadio())
+  {
+    // Ok, we have the same channel group name for both TV and Radio which is not allowed
+    // so let's add ' (Radio)' or ' (TV)' depending on which group was added first.
+
+    if (existingChannelGroup->IsRadio())
+      channelGroup.SetGroupName(channelGroup.GetGroupName() + " (" + kodi::GetLocalizedString(30450) + ")"); // ' (TV)';
+    else
+      channelGroup.SetGroupName(channelGroup.GetGroupName() + " (" + kodi::GetLocalizedString(30451) + ")"); // ' (Radio)';
+
+    existingChannelGroup = FindChannelGroup(channelGroup.GetGroupName());
+  }
 
   if (!existingChannelGroup)
   {


### PR DESCRIPTION
v6.3.1
- Fixed: Append TV/Radio to group name if the same group name is used for both channel types