### PR TITLE
Remove p8 from debian control file - v6.4.1

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: kodi-pvr-iptvsimple
 Priority: extra
 Maintainer: Ross Nicholson <phunkyfish@gmail.com>
-Build-Depends: debhelper (>= 9.0.0), cmake, libp8-platform-dev,
+Build-Depends: debhelper (>= 9.0.0), cmake,
                kodi-addon-dev, zlib1g-dev, libpugixml-dev
 Standards-Version: 4.1.2
 Section: libs

--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="6.4.0"
+  version="6.4.1"
   name="PVR IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v6.4.1
+- Update: Remove p8 from debian control file
+
 v6.4.0
 - Added: Add options to support both UDP and all stream types when using timeshift feature
 - Fixed: README spelling corrections


### PR DESCRIPTION
v6.4.1
- Update: Remove p8 from debian control file