### PR TITLE
Set API stable inputstream versions for Matrix

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="7.0.0"
+  version="7.1.0"
   name="PVR IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@
@@ -168,7 +168,11 @@
     <assets>
       <icon>icon.png</icon>
     </assets>
-    <news>v7.0.0
+    <news>
+v7.1.0
+- Added: Set minimum inputstream ffmpegdirect, rtmp and adaptive versions to API stable version for Matrix
+
+v7.0.0
 - Update: PVR API 7.0.2
 
 v6.4.1

--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -5,9 +5,9 @@
   name="PVR IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@
-    <import addon="inputstream.ffmpegdirect" minversion="1.12.0" optional="true"/>
-    <import addon="inputstream.adaptive" minversion="2.5.5" optional="true"/>
-    <import addon="inputstream.rtmp" minversion="3.0.3" optional="true"/>
+    <import addon="inputstream.ffmpegdirect" minversion="1.18.0" optional="true"/>
+    <import addon="inputstream.adaptive" minversion="2.6.4" optional="true"/>
+    <import addon="inputstream.rtmp" minversion="3.4.0" optional="true"/>
   </requires>
   <extension
     point="kodi.pvrclient"

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v7.1.0
+- Added: Set minimum inputstream ffmpegdirect, rtmp and adaptive versions to API stable version for Matrix
+
 v7.0.0
 - Update: PVR API 7.0.2
 


### PR DESCRIPTION
v7.1.0
- Added: Set minimum inputstream ffmpegdirect, rtmp and adaptive versions to API stable version for Matrix