### PR TITLE
 Set latest API stable inputstream version for Matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,12 @@ Note that the steps in the following section need to be performed before the add
 
 If you would prefer to run the rebuild steps manually instead of using the above helper script check the appendix [here](#manual-steps-to-rebuild-the-addon-on-macosx)
 
-##### Useful links
+## Useful links
 
 * [Kodi's PVR user support](https://forum.kodi.tv/forumdisplay.php?fid=167)
 * [Kodi's PVR development support](https://forum.kodi.tv/forumdisplay.php?fid=136)
+
+## Configuring the addon
 
 ### Settings Levels
 In Kodi 18.2 the level of settings shown will correspond to the level set in the main Kodi settings UI: `Basic`, `Standard`, `Advanced` and `Expert`. From Kodi 19 it will be possible to change the settings level from within the addon settings itself.

--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -5,9 +5,9 @@
   name="PVR IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@
-    <import addon="inputstream.ffmpegdirect" minversion="1.12.0" optional="true"/>
-    <import addon="inputstream.adaptive" minversion="2.5.5" optional="true"/>
-    <import addon="inputstream.rtmp" minversion="3.0.3" optional="true"/>
+    <import addon="inputstream.ffmpegdirect" minversion="1.18.1" optional="true"/>
+    <import addon="inputstream.adaptive" minversion="2.6.6" optional="true"/>
+    <import addon="inputstream.rtmp" minversion="3.4.0" optional="true"/>
   </requires>
   <extension
     point="kodi.pvrclient"

--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="7.0.0"
+  version="7.1.0"
   name="PVR IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@
@@ -168,7 +168,13 @@
     <assets>
       <icon>icon.png</icon>
     </assets>
-    <news>v7.0.0
+    <news>
+v7.1.0
+- Added: Set minimum inputstream ffmpegdirect, rtmp and adaptive versions to API stable version for Matrix
+- Added: Redact URLs when logged
+- Update: Replace square brackets with bold text in addon settings help text
+
+v7.0.0
 - Update: PVR API 7.0.2
 
 v6.4.1

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,8 @@
+v7.1.0
+- Added: Set minimum inputstream ffmpegdirect, rtmp and adaptive versions to API stable version for Matrix
+- Added: Redact URLs when logged
+- Update: Replace square brackets with bold text in addon settings help text
+
 v7.0.0
 - Update: PVR API 7.0.2
 

--- a/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
@@ -449,27 +449,27 @@ msgstr ""
 
 #. help: General - m3uPathType
 msgctxt "#30601"
-msgid "Select where to find the M3U resource. The options are: [Local path] - A path to an M3U file whether it be on the device or the local network; [Remote path] - A URL specifying the location of the M3U file."
+msgid "Select where to find the M3U resource. The options are: [B]Local path[/B] - A path to an M3U file whether it be on the device or the local network; [B]Remote path[/B] - A URL specifying the location of the M3U file."
 msgstr ""
 
 #. help: General - m3uPath
 msgctxt "#30602"
-msgid "If location is [Local path] this setting must contain a valid path for the addon to function."
+msgid "If location is [B]Local path[/B] this setting must contain a valid path for the addon to function."
 msgstr ""
 
 #. help: General - m3uUrl
 msgctxt "#30603"
-msgid "If location is [Remote path] this setting must contain a valid URL for the addon to function."
+msgid "If location is [B]Remote path[/B] this setting must contain a valid URL for the addon to function."
 msgstr ""
 
 #. help: General - m3uCache
 msgctxt "#30604"
-msgid "If location is [Remote path] select whether or not the the M3U file should be cached locally."
+msgid "If location is [B]Remote path[/B] select whether or not the the M3U file should be cached locally."
 msgstr ""
 
 #. help: General - startNum
 msgctxt "#30605"
-msgid "The number to start numbering channels from. Only used when [Use backend channel numbers] from PVR settings is enabled and a channel number is not supplied in the M3U file."
+msgid "The number to start numbering channels from. Only used when [B]Use backend channel numbers[/B] from PVR settings is enabled and a channel number is not supplied in the M3U file."
 msgstr ""
 
 #. help: General - numberByOrder
@@ -479,17 +479,17 @@ msgstr ""
 
 #. help: General - m3uRefreshMode
 msgctxt "#30607"
-msgid "Select the auto refresh mode for the M3U/XMLTV files. Note that caching is disabled if auto refresh is used. The options are: [Disabled] - Don't auto refresh the files; [Repeated refresh] - Refresh the files on a minute based interval; [Once per day] - Refresh the files once per day."
+msgid "Select the auto refresh mode for the M3U/XMLTV files. Note that caching is disabled if auto refresh is used. The options are: [B]Disabled[/B] - Don't auto refresh the files; [B]Repeated refresh[/B] - Refresh the files on a minute based interval; [B]Once per day[/B] - Refresh the files once per day."
 msgstr ""
 
 #. help: General - m3uRefreshIntervalMins
 msgctxt "#30608"
-msgid "If M3U auto refresh mode is [Repeated refresh] refresh the files every time this number of minutes passes. Max 120 minutes."
+msgid "If M3U auto refresh mode is [B]Repeated refresh[/B] refresh the files every time this number of minutes passes. Max 120 minutes."
 msgstr ""
 
 #. help: General - m3uRefreshHour
 msgctxt "#30609"
-msgid "If auto refresh mode is [Once per day] refresh the files every time this hour of the day is reached"
+msgid "If auto refresh mode is [B]Once per day[/B] refresh the files every time this hour of the day is reached"
 msgstr ""
 
 #empty strings from id 30610 to 30619
@@ -503,22 +503,22 @@ msgstr ""
 
 #. help: EPG Settings - epgPathType
 msgctxt "#30621"
-msgid "Select where to find the XMLTV resource. The options are: [Local path] - A path to an XMLTV file whether it be on the device or the local network; [Remote path] - A URL specifying the location of the XMLTV file."
+msgid "Select where to find the XMLTV resource. The options are: [B]Local path[/B] - A path to an XMLTV file whether it be on the device or the local network; [B]Remote path[/B] - A URL specifying the location of the XMLTV file."
 msgstr ""
 
 #. help: EPG Settings - epgPath
 msgctxt "#30622"
-msgid "If location is [Local Path] this setting should contain a valid path."
+msgid "If location is [B]Local Path[/B] this setting should contain a valid path."
 msgstr ""
 
 #. help: EPG Settings - epgUrl
 msgctxt "#30623"
-msgid "If location is [Remote Path] this setting should contain a valid URL."
+msgid "If location is [B]Remote Path[/B] this setting should contain a valid URL."
 msgstr ""
 
 #. help: EPG Settings - epgCache
 msgctxt "#30624"
-msgid "If location is [Remote path] select whether or not the the XMLTV file should be cached locally."
+msgid "If location is [B]Remote path[/B] select whether or not the the XMLTV file should be cached locally."
 msgstr ""
 
 #. help: EPG Settings - epgTimeShift
@@ -542,22 +542,22 @@ msgstr ""
 
 #. help: Channel Logos - logoPathType
 msgctxt "#30641"
-msgid "Select where to find the channel logos. The options are: [Local path] - A path to a folder whether it be on the device or the local network; [Remote path] - A base URL specifying the location of the logos."
+msgid "Select where to find the channel logos. The options are: [B]Local path[/B] - A path to a folder whether it be on the device or the local network; [B]Remote path[/B] - A base URL specifying the location of the logos."
 msgstr ""
 
 #. help: Channel Logos - logo Path
 msgctxt "#30642"
-msgid "If location is [Local Path] this setting should contain a valid folder."
+msgid "If location is [B]Local Path[/B] this setting should contain a valid folder."
 msgstr ""
 
 #. help: Channel Logos - logoBaseUrl
 msgctxt "#30643"
-msgid "If location is [Remote Path] this setting should contain a valid base URL."
+msgid "If location is [B]Remote Path[/B] this setting should contain a valid base URL."
 msgstr ""
 
 #. help: Channel Logos - logoFromEpg
 msgctxt "#30644"
-msgid "Preference on how to handle channel logos. The options are: [Ignore] - Don't use channel logos from an XMLTV file; [Prefer M3U] - Use the channel logo from the M3U if available otherwise use the XMLTV logo; [Prefer XMLTV] - Use the channel logo from the XMLTV file if available otherwise use the M3U logo."
+msgid "Preference on how to handle channel logos. The options are: [B]Ignore[/B] - Don't use channel logos from an XMLTV file; [B]Prefer M3U[/B] - Use the channel logo from the M3U if available otherwise use the XMLTV logo; [B]Prefer XMLTV[/B] - Use the channel logo from the XMLTV file if available otherwise use the M3U logo."
 msgstr ""
 
 #empty strings from id 30645 to 30659
@@ -576,17 +576,17 @@ msgstr ""
 
 #. help: Genres - genresPathType
 msgctxt "#30662"
-msgid "Select where to find the genres XML resource. The options are: [Local path] - A path to a genres XML file whether it be on the device or the local network; [Remote path] - A URL specifying the location of the genres XML file."
+msgid "Select where to find the genres XML resource. The options are: [B]Local path[/B] - A path to a genres XML file whether it be on the device or the local network; [B]Remote path[/B] - A URL specifying the location of the genres XML file."
 msgstr ""
 
 #. help: Genres - genresPath
 msgctxt "#30663"
-msgid "If location is [Local Path] this setting should contain a valid path."
+msgid "If location is [B]Local Path[/B] this setting should contain a valid path."
 msgstr ""
 
 #. help: Genres - genresUrl
 msgctxt "#30664"
-msgid "If location is [Remote Path] this setting should contain a valid URL."
+msgid "If location is [B]Remote Path[/B] this setting should contain a valid URL."
 msgstr ""
 
 #empty strings from id 30665 to 30679
@@ -664,7 +664,7 @@ msgstr ""
 
 #. help: Catchup - allChannelsCatchupMode
 msgctxt "#30704"
-msgid "If enabled it is assumed that all channels support catchup using the selected mode if they do not have catchup tags. In this case the 'Query format string' and 'Catchup window' number of days will come from the addon settings if needed. If this option is disabled then an M3U entry must have at least a 'catchup=' tag to enable catchup. The options for how to build the catch URL are: [Disabled] - Do not assume all channel support catchup; [Default] - Use catchup source as the full catchup URL, if there is no catchup source use Append mode; [Append] - Append the catchup source to the channel URL, if there is no catchup source using the 'Query format string'; [Shift (SIPTV)] - Append the standard SIPTV catchup string to the channel URL; [Flussonic] - Build a flussonic URL from the channel URL; [Xtream codes] - Build an Xtream codes URL from the channel URL."
+msgid "If enabled it is assumed that all channels support catchup using the selected mode if they do not have catchup tags. In this case the 'Query format string' and 'Catchup window' number of days will come from the addon settings if needed. If this option is disabled then an M3U entry must have at least a 'catchup=' tag to enable catchup. The options for how to build the catch URL are: [B]Disabled[/B] - Do not assume all channel support catchup; [B]Default[/B] - Use catchup source as the full catchup URL, if there is no catchup source use Append mode; [B]Append[/B] - Append the catchup source to the channel URL, if there is no catchup source using the 'Query format string'; [B]Shift (SIPTV)[/B] - Append the standard SIPTV catchup string to the channel URL; [B]Flussonic[/B] - Build a flussonic URL from the channel URL; [B]Xtream codes[/B] - Build an Xtream codes URL from the channel URL."
 msgstr ""
 
 #. help: Catchup - catchupPlayEpgAsLive

--- a/src/PVRIptvData.cpp
+++ b/src/PVRIptvData.cpp
@@ -10,6 +10,7 @@
 
 #include "iptvsimple/Settings.h"
 #include "iptvsimple/utilities/Logger.h"
+#include "iptvsimple/utilities/WebUtils.h"
 
 #include <ctime>
 #include <chrono>
@@ -190,7 +191,7 @@ PVR_ERROR PVRIptvData::GetChannelStreamProperties(const kodi::addon::PVRChannel&
 
     StreamUtils::SetAllStreamProperties(properties, m_currentChannel, streamURL, catchupProperties);
 
-    Logger::Log(LogLevel::LEVEL_INFO, "%s - Live %s URL: %s", __FUNCTION__, catchupUrl.empty() ? "Stream" : "Catchup", streamURL.c_str());
+    Logger::Log(LogLevel::LEVEL_INFO, "%s - Live %s URL: %s", __FUNCTION__, catchupUrl.empty() ? "Stream" : "Catchup", WebUtils::RedactUrl(streamURL).c_str());
 
     return PVR_ERROR_NO_ERROR;
   }
@@ -264,7 +265,7 @@ PVR_ERROR PVRIptvData::GetEPGTagStreamProperties(const kodi::addon::PVREPGTag& t
     {
       StreamUtils::SetAllStreamProperties(properties, m_currentChannel, catchupUrl, catchupProperties);
 
-      Logger::Log(LEVEL_INFO, "%s - EPG Catchup URL: %s", __FUNCTION__, catchupUrl.c_str());
+      Logger::Log(LEVEL_INFO, "%s - EPG Catchup URL: %s", __FUNCTION__, WebUtils::RedactUrl(catchupUrl).c_str());
       return PVR_ERROR_NO_ERROR;
     }
   }

--- a/src/iptvsimple/CatchupController.cpp
+++ b/src/iptvsimple/CatchupController.cpp
@@ -13,6 +13,7 @@
 #include "Settings.h"
 #include "data/Channel.h"
 #include "utilities/Logger.h"
+#include "utilities/WebUtils.h"
 
 #include <regex>
 
@@ -202,7 +203,7 @@ void CatchupController::SetCatchupInputStreamProperties(bool playbackAsLive, con
   // When doing this don't forget to add Settings::GetInstance().GetCatchupWatchEpgBeginBufferSecs() + Settings::GetInstance().GetCatchupWatchEpgEndBufferSecs();
   // if in video playback mode from epg, i.e. if (!Settings::GetInstance().CatchupPlayEpgAsLive() && m_playbackIsVideo)s
 
-  Logger::Log(LEVEL_DEBUG, "default_url - %s", channel.GetStreamURL().c_str());
+  Logger::Log(LEVEL_DEBUG, "default_url - %s", WebUtils::RedactUrl(channel.GetStreamURL()).c_str());
   Logger::Log(LEVEL_DEBUG, "playback_as_live - %s", playbackAsLive ? "true" : "false");
   Logger::Log(LEVEL_DEBUG, "catchup_url_format_string - %s", GetCatchupUrlFormatString(channel).c_str());
   Logger::Log(LEVEL_DEBUG, "catchup_buffer_start_time - %s", std::to_string(m_catchupStartTime).c_str());
@@ -330,7 +331,7 @@ std::string FormatDateTime(time_t dateTimeEpg, time_t duration, const std::strin
   FormatUtc("${offset}", dateTimeNow - dateTimeEpg, formattedUrl);
   FormatUnits(dateTimeNow - dateTimeEpg, "offset", formattedUrl);
 
-  Logger::Log(LEVEL_DEBUG, "%s - \"%s\"", __FUNCTION__, formattedUrl.c_str());
+  Logger::Log(LEVEL_DEBUG, "%s - \"%s\"", __FUNCTION__, WebUtils::RedactUrl(formattedUrl).c_str());
 
   return formattedUrl;
 }
@@ -370,7 +371,7 @@ std::string BuildEpgTagUrl(time_t startTime, time_t duration, const Channel& cha
   if (!programmeCatchupId.empty())
     startTimeUrl = std::regex_replace(startTimeUrl, CATCHUP_ID_REGEX, programmeCatchupId);
 
-  Logger::Log(LEVEL_DEBUG, "%s - %s", __FUNCTION__, startTimeUrl.c_str());
+  Logger::Log(LEVEL_DEBUG, "%s - %s", __FUNCTION__, WebUtils::RedactUrl(startTimeUrl).c_str());
 
   return startTimeUrl;
 }

--- a/src/iptvsimple/utilities/StreamUtils.cpp
+++ b/src/iptvsimple/utilities/StreamUtils.cpp
@@ -311,7 +311,7 @@ std::string StreamUtils::GetURLWithFFmpegReconnectOptions(const std::string& str
     newStreamUrl = AddHeaderToStreamUrl(newStreamUrl, "reconnect_streamed", "1");
     newStreamUrl = AddHeaderToStreamUrl(newStreamUrl, "reconnect_delay_max", "4294");
 
-    Logger::Log(LogLevel::LEVEL_DEBUG, "%s - FFmpeg Reconnect Stream URL: %s", __FUNCTION__, newStreamUrl.c_str());
+    Logger::Log(LogLevel::LEVEL_DEBUG, "%s - FFmpeg Reconnect Stream URL: %s", __FUNCTION__, WebUtils::RedactUrl(newStreamUrl).c_str());
   }
 
   return newStreamUrl;

--- a/src/iptvsimple/utilities/WebUtils.cpp
+++ b/src/iptvsimple/utilities/WebUtils.cpp
@@ -67,3 +67,18 @@ bool WebUtils::IsHttpUrl(const std::string& url)
 {
   return StringUtils::StartsWith(url, HTTP_PREFIX) || StringUtils::StartsWith(url, HTTPS_PREFIX);
 }
+
+std::string WebUtils::RedactUrl(const std::string& url)
+{
+  std::string redactedUrl = url;
+  static const std::regex regex("^(http:|https:)//[^@/]+:[^@/]+@.*$");
+  if (std::regex_match(url, regex))
+  {
+    std::string protocol = url.substr(0, url.find_first_of(":"));
+    std::string fullPrefix = url.substr(url.find_first_of("@") + 1);
+
+    redactedUrl = protocol + "://USERNAME:PASSWORD@" + fullPrefix;
+  }
+
+  return redactedUrl;
+}

--- a/src/iptvsimple/utilities/WebUtils.h
+++ b/src/iptvsimple/utilities/WebUtils.h
@@ -25,6 +25,7 @@ namespace iptvsimple
       static const std::string UrlEncode(const std::string& value);
       static std::string ReadFileContentsStartOnly(const std::string& url, int* httpCode);
       static bool IsHttpUrl(const std::string& url);
+      static std::string RedactUrl(const std::string& url);
     };
   } // namespace utilities
 } // namespace iptvsimple


### PR DESCRIPTION
v7.1.0
- Added: Set minimum inputstream ffmpegdirect, rtmp and adaptive versions to API stable version for Matrix
- Added: Redact URLs when logged
- Update: Replace square brackets with bold text in addon settings help text