### PR TITLE
some providers use 'tvg-rec' instead of 'catchup-days'

### DIFF
--- a/src/iptvsimple/PlaylistLoader.cpp
+++ b/src/iptvsimple/PlaylistLoader.cpp
@@ -196,6 +196,7 @@ std::string PlaylistLoader::ParseIntoChannel(const std::string& line, Channel& c
     std::string strTvgShift   = ReadMarkerValue(infoLine, TVG_INFO_SHIFT_MARKER);
     std::string strCatchup       = ReadMarkerValue(infoLine, CATCHUP);
     std::string strCatchupDays   = ReadMarkerValue(infoLine, CATCHUP_DAYS);
+    std::string strTvgRec        = ReadMarkerValue(infoLine, TVG_INFO_REC);
     std::string strCatchupSource = ReadMarkerValue(infoLine, CATCHUP_SOURCE);
     std::string strCatchupSiptv = ReadMarkerValue(infoLine, CATCHUP_SIPTV);
     std::string strCatchupCorrection = ReadMarkerValue(infoLine, CATCHUP_CORRECTION);
@@ -261,6 +262,8 @@ std::string PlaylistLoader::ParseIntoChannel(const std::string& line, Channel& c
       siptvTimeshiftDays = atoi(strCatchupSiptv.c_str());
     if (!strCatchupDays.empty())
       channel.SetCatchupDays(atoi(strCatchupDays.c_str()));
+    else if (!strTvgRec.empty())
+      channel.SetCatchupDays(atoi(strTvgRec.c_str()));
     else if (channel.GetCatchupMode() == CatchupMode::VOD)
       channel.SetCatchupDays(IGNORE_CATCHUP_DAYS);
     else if (siptvTimeshiftDays > 0)

--- a/src/iptvsimple/PlaylistLoader.h
+++ b/src/iptvsimple/PlaylistLoader.h
@@ -27,6 +27,7 @@ namespace iptvsimple
   static const std::string TVG_INFO_LOGO_MARKER    = "tvg-logo=";
   static const std::string TVG_INFO_SHIFT_MARKER   = "tvg-shift=";
   static const std::string TVG_INFO_CHNO_MARKER    = "tvg-chno=";
+  static const std::string TVG_INFO_REC            = "tvg-rec="; // some providers use 'tvg-rec' instead of 'catchup-days'
   static const std::string GROUP_NAME_MARKER       = "group-title=";
   static const std::string CATCHUP                 = "catchup=";
   static const std::string CATCHUP_TYPE            = "catchup-type=";


### PR DESCRIPTION
I just found that some providers use `tvg-rec` to indicate the timeshift buffer in their archive functionality, instead of `catchup-days`
This PR uses `tvg-rec` as a fallback if `catchup-days` is not available.