### PR TITLE
PVR API 7.1.0 - support past and future max epg days and always load EPG data on start

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="7.2.0"
+  version="7.3.0"
   name="PVR IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@
@@ -169,6 +169,10 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v7.3.0
+- Update: PVR API 7.1.0
+- Added: support past and future max epg days and always load EPG data on start
+
 v7.2.0
 - Added: Safe localtime and format strings for timestamps in catchup
 - Added: Allow now/current time format specifiers in live stream URLs

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,7 @@
+v7.3.0
+- Update: PVR API 7.1.0
+- Added: support past and future max epg days and always load EPG data on start
+
 v7.2.0
 - Added: Safe localtime and format strings for timestamps in catchup
 - Added: Allow now/current time format specifiers in live stream URLs

--- a/src/PVRIptvData.cpp
+++ b/src/PVRIptvData.cpp
@@ -65,9 +65,9 @@ ADDON_STATUS PVRIptvData::Create()
   Settings::GetInstance().ReadFromAddon(kodi::GetBaseUserPath(), kodi::GetAddonPath());
 
   m_channels.Init();
-  m_epg.Init();
   m_playlistLoader.Init();
   m_playlistLoader.LoadPlayList();
+  m_epg.Init(EpgMaxPastDays(), EpgMaxFutureDays());
 
   kodi::Log(ADDON_LOG_INFO, "%s Starting separate client update thread...", __FUNCTION__);
 
@@ -306,6 +306,18 @@ PVR_ERROR PVRIptvData::IsEPGTagPlayable(const kodi::addon::PVREPGTag& tag, bool&
                   (!Settings::GetInstance().CatchupOnlyOnFinishedProgrammes() || tag.GetEndTime() < now);
   }
 
+  return PVR_ERROR_NO_ERROR;
+}
+
+PVR_ERROR PVRIptvData::SetEPGMaxPastDays(int epgMaxPastDays)
+{
+  m_epg.SetEPGMaxPastDays(epgMaxPastDays);
+  return PVR_ERROR_NO_ERROR;
+}
+
+PVR_ERROR PVRIptvData::SetEPGMaxFutureDays(int epgMaxFutureDays)
+{
+  m_epg.SetEPGMaxFutureDays(epgMaxFutureDays);
   return PVR_ERROR_NO_ERROR;
 }
 

--- a/src/PVRIptvData.h
+++ b/src/PVRIptvData.h
@@ -50,6 +50,8 @@ public:
   PVR_ERROR GetEPGForChannel(int channelUid, time_t start, time_t end, kodi::addon::PVREPGTagsResultSet& results) override;
   PVR_ERROR GetEPGTagStreamProperties(const kodi::addon::PVREPGTag& tag, std::vector<kodi::addon::PVRStreamProperty>& properties) override;
   PVR_ERROR IsEPGTagPlayable(const kodi::addon::PVREPGTag& tag, bool& bIsPlayable) override;
+  PVR_ERROR SetEPGMaxPastDays(int epgMaxPastDays) override;
+  PVR_ERROR SetEPGMaxFutureDays(int epgMaxFutureDays) override;
 
   PVR_ERROR GetChannelsAmount(int& amount) override;
   PVR_ERROR GetChannels(bool radio, kodi::addon::PVRChannelsResultSet& results) override;

--- a/src/iptvsimple/Epg.cpp
+++ b/src/iptvsimple/Epg.cpp
@@ -37,11 +37,18 @@ Epg::Epg(kodi::addon::CInstancePVRClient* client, Channels& channels)
   }
 }
 
-bool Epg::Init()
+bool Epg::Init(int epgMaxPastDays, int epgMaxFutureDays)
 {
   m_xmltvLocation = Settings::GetInstance().GetEpgLocation();
   m_epgTimeShift = Settings::GetInstance().GetEpgTimeshiftSecs();
   m_tsOverride = Settings::GetInstance().GetTsOverride();
+
+  SetEPGMaxPastDays(epgMaxPastDays);
+  SetEPGMaxFutureDays(epgMaxFutureDays);
+
+  time_t now = std::time(nullptr);
+  LoadEPG(now - m_epgMaxPastDaysSeconds, now + m_epgMaxFutureDaysSeconds);
+
   return true;
 }
 
@@ -49,6 +56,26 @@ void Epg::Clear()
 {
   m_channelEpgs.clear();
   m_genreMappings.clear();
+}
+
+void Epg::SetEPGMaxPastDays(int epgMaxPastDays)
+{
+  m_epgMaxPastDays = epgMaxPastDays;
+
+  if (m_epgMaxPastDays > EPG_TIMEFRAME_UNLIMITED)
+    m_epgMaxPastDaysSeconds = m_epgMaxPastDays * 24 * 60 * 60;
+  else
+    m_epgMaxPastDaysSeconds = DEFAULT_EPG_MAX_DAYS * 24 * 60 * 60;
+}
+
+void Epg::SetEPGMaxFutureDays(int epgMaxFutureDays)
+{
+  m_epgMaxFutureDays = epgMaxFutureDays;
+
+  if (m_epgMaxFutureDays > EPG_TIMEFRAME_UNLIMITED)
+    m_epgMaxFutureDaysSeconds = m_epgMaxFutureDays * 24 * 60 * 60;
+  else
+    m_epgMaxFutureDaysSeconds = DEFAULT_EPG_MAX_DAYS * 24 * 60 * 60;
 }
 
 bool Epg::LoadEPG(time_t start, time_t end)

--- a/src/iptvsimple/Epg.h
+++ b/src/iptvsimple/Epg.h
@@ -24,6 +24,7 @@ namespace iptvsimple
   static const std::string GENRES_MAP_FILENAME = "genres.xml";
   static const std::string GENRE_DIR = "/genres";
   static const std::string GENRE_ADDON_DATA_BASE_DIR = ADDON_DATA_BASE_DIR + GENRE_DIR;
+  static const int DEFAULT_EPG_MAX_DAYS = 3;
 
   enum class XmltvFileFormat
   {
@@ -37,9 +38,11 @@ namespace iptvsimple
   public:
     Epg(kodi::addon::CInstancePVRClient* client, iptvsimple::Channels& channels);
 
-    bool Init();
+    bool Init(int epgMaxPastDays, int epgMaxFutureDays);
 
     PVR_ERROR GetEPGForChannel(int channelUid, time_t start, time_t end, kodi::addon::PVREPGTagsResultSet& results);
+    void SetEPGMaxPastDays(int epgMaxPastDays);
+    void SetEPGMaxFutureDays(int epgMaxFutureDays);
     void Clear();
     void ReloadEPG();
 
@@ -67,6 +70,10 @@ namespace iptvsimple
     bool m_tsOverride;
     int m_lastStart;
     int m_lastEnd;
+    int m_epgMaxPastDays;
+    int m_epgMaxFutureDays;
+    long m_epgMaxPastDaysSeconds;
+    long m_epgMaxFutureDaysSeconds;
 
     iptvsimple::Channels& m_channels;
     std::vector<data::ChannelEpg> m_channelEpgs;


### PR DESCRIPTION
v7.3.0
- Update: PVR API 7.1.0
- Added: support past and future max epg days and always load EPG data on start

Not to be merged until xbmc/xbmc#19035 is merged.