### PR TITLE
Epg load speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,29 @@ General settings required for the addon to function.
 * **M3U play list URL**: If location is `Remote path` this setting must contain a valid URL for the addon to function.
 * **Cache M3U at local storage**: If location is `Remote path` select whether or not the the M3U file should be cached locally.
 * **Start channel number**: The number to start numbering channels from. Only used when `Use backend channel numbers` from PVR settings is enabled and a channel number is not supplied in the M3U file.
-* **Only number by channel order in M3U**: Ignore any 'tvg-chno' tags and only number channels by the order in the M3U starting at 'Start channel number'.
+* **Only number by channel order in M3U**: Ignore any `tvg-chno` tags and only number channels by the order in the M3U starting at `Start channel number`.
 * **Auto refresh mode**: Select the auto refresh mode for the M3U/XMLTV files. Note that caching is disabled if auto refresh is used. The options are:
     - `Disabled` - Don't auto refresh the files.
     - `Repeated refresh` - Refresh the files on a minute based interval.
     - `Once per day` - Refresh the files once per day.
 * **Refresh interval**: If auto refresh mode is `Repeated refresh` refresh the files every time this number of minutes passes. Max 120 minutes.
 * **Refresh hour (24h)**: If auto refresh mode is `Once per day` refresh the files every time this hour of the day is reached.
+* **Only load TV channels in groups**: Only TV channels that belong to groups (i.e. have a `group-title` attribute) will be loaded from the M3U file.
+* **TV group mode**: Choose from one of the following three modes:
+    - `All groups` - Load all TV groups from the M3U file.
+    - `Some groups` - Only load the group specified in the next options
+    - `Custom groups` - Fetch a set of groups from the M3U file whose names are loaded from an XML file.
+* **Number of TV groups**: The number of TV groups to load when `Some groups` is the selected mode. Up to 5 can be chosen. If more than 5 are required the `Custom groups` mode should be used instead.
+* **TV group 1-5**: If the previous option has been has been set to `Some groups` you need to specify a TV group to be loaded from the M3U file. Please not that this is the group-title attribute (i.e. "UK (TV)"). This setting is case-sensitive.
+* **Custom TV Groups file**: The file used to load the custom TV groups (groups). The default file is `customTVGroups-example.xml`. Details on how to customise can be found in the next section of the README.
+* **Only load Radio channels in groups**: Only Radio channels that belong to groups (i.e. have a `group-title` attribute) will be loaded from the M3U file.
+* **Radio group fetch mode**: Choose from one of the following three modes:
+    - `All groups` - Load all Radio groups from the set-top box.
+    - `Some groups` - Only load the group specified in the next options
+    - `Custom groups` - Fetch a set of groups from the M3U file whose names are loaded from an XML file.
+* **Number of radio groups**: The number of Radio groups to load when `Some groups` is the selected mode. Up to 5 can be chosen. If more than 5 are required the `Custom groups` mode should be used instead.
+* **Radio group 1-5**: If the previous option has been has been set to `Some groups` you need to specify a Radio group to be loaded from the M3U file. Please not that this is the group-title attribute (i.e. "UK (Radio)"). This setting is case-sensitive.
+* **Custom Radio Groups file**: The file used to load the custom Radio groups (groups). The default file is `customRadioGroups-example.xml`. Details on how to customise can be found in the next section of the README.
 
 ### EPG
 Settings related to the EPG.
@@ -456,6 +472,17 @@ Note: Once mapped to genre IDs the text displayed can either be the DVB standard
 
 - The `type` attribute can contain a values ranging from 16 to 240 in multiples of 16 (would be 0x10 to 0xF0 if in hex) and the `subtype` attributes can contain a value from 0 to 15 (would be 0x00 to 0x0F if in hex). `subtype` is optional.
 
+### Custom Channel Groups (Channels)
+
+Config files are located in the `userdata/addon_data/pvr.vuplus/channelGroups` folder.
+
+The following files are currently available with the addon:
+    - `customTVGroups-example.xml`
+    - `customRadioGroups-example.xml`
+
+Note that both these files are provided as examples and are overwritten each time the addon starts. Therefore you should make copies and use those for your custom config.
+
+The format is quite simple, containing a number of channel group/bouquet names.
 
 ### HTTP header fields supported by Kodi
 

--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="7.3.0"
+  version="7.4.0"
   name="PVR IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@
@@ -169,6 +169,13 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v7.4.0
+- Fixed: An xmltv channel cannot have an empty id field
+- Fixed: Fix slow epg load due to display name checks when finding a channel
+- Fixed: Only force load EPG data on startup if catchup is enabled
+- Added: Support custom channel group filters
+- Added: Reload settings before reloading playlist and EPG data
+
 v7.3.0
 - Update: PVR API 7.1.0
 - Added: support past and future max epg days and always load EPG data on start

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,10 @@
+v7.4.0
+- Fixed: An xmltv channel cannot have an empty id field
+- Fixed: Fix slow epg load due to display name checks when finding a channel
+- Fixed: Only force load EPG data on startup if catchup is enabled
+- Added: Support custom channel group filters
+- Added: Reload settings before reloading playlist and EPG data
+
 v7.3.0
 - Update: PVR API 7.1.0
 - Added: support past and future max epg days and always load EPG data on start

--- a/pvr.iptvsimple/resources/data/channelGroups/customRadioGroups-example.xml
+++ b/pvr.iptvsimple/resources/data/channelGroups/customRadioGroups-example.xml
@@ -1,0 +1,17 @@
+<!--
+
+Custom Channel Groups:
+ - Allows users to create a bespoke list of groups to load.
+ - For each name that matches a group/bouquet name from the set top box include it in the channels loaded
+ - If no names match the addon will load last scanned by default.
+ - channelGroupName is the only value to be set
+
+If you are creating your own Custom Channel Groups file make a copy of this file in the same directory so it's not overwritten and start from there.
+
+NOTE: IF YOU MODIFY THIS FILE IT WILL BE OVERWRITTEN NEXT TIME THE ADDON IS STARTED
+-->
+
+<customChannelGroups>
+  <channelGroupName>My 1st Provder - Radio Channels</channelGroupName>
+  <channelGroupName>My 2nd Provider - Radio Channels</channelGroupName>
+</customChannelGroups>

--- a/pvr.iptvsimple/resources/data/channelGroups/customTVGroups-example.xml
+++ b/pvr.iptvsimple/resources/data/channelGroups/customTVGroups-example.xml
@@ -1,0 +1,18 @@
+<!--
+
+Custom Channel Groups:
+ - Allows users to create a bespoke list of groups to load.
+ - For each name that matches a group/bouquet name from the set top box include it in the channels loaded
+ - If no names match the addon will load last scanned by default.
+ - channelGroupName is the only value to be set
+
+If you are creating your own Custom Channel Groups file make a copy of this file in the same directory so it's not overwritten and start from there.
+
+NOTE: IF YOU MODIFY THIS FILE IT WILL BE OVERWRITTEN NEXT TIME THE ADDON IS STARTED
+-->
+
+<customChannelGroups>
+  <channelGroupName>My 1st Provder - Sports</channelGroupName>
+  <channelGroupName>My 2nd Provder - Entertainment</channelGroupName>
+  <channelGroupName>My 3rd Provder - Movies</channelGroupName>
+</customChannelGroups>

--- a/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
@@ -149,7 +149,15 @@ msgctxt "#30027"
 msgid "{0:.1f} hours"
 msgstr ""
 
-#empty strings from id 30028 to 30029
+#. label: General - tvChannelGroupsOnly
+msgctxt "#30028"
+msgid "Only load TV channels in groups"
+msgstr ""
+
+#. label-group: General - TV Groups
+msgctxt "#30029"
+msgid "TV Groups"
+msgstr ""
 
 #. label-category: channellogos
 #. label-group: Channel Logos - Channel Logos
@@ -167,7 +175,43 @@ msgctxt "#30032"
 msgid "Channel logos base URL"
 msgstr ""
 
-#empty strings from id 30033 to 30039
+#. label-group: General - Radio Groups
+msgctxt "#30033"
+msgid "Radio Groups"
+msgstr ""
+
+#. label: General - tvGroupMoade
+msgctxt "#30034"
+msgid "TV group mode"
+msgstr ""
+
+#. label: General - radioGroupMoade
+msgctxt "#30035"
+msgid "Radio group mode"
+msgstr ""
+
+#. label-option: Channels - tvGroupmode
+#. label-option: Channels - radioGroupGode
+msgctxt "#30036"
+msgid "All groups"
+msgstr ""
+
+#. label-option: Channels - tvGroupMode
+#. label-option: Channels - radioGroupGode
+msgctxt "#30037"
+msgid "Some groups"
+msgstr ""
+
+#. label-option: General - tvGroupMode
+#. label-option: General - radioGroupGode
+msgctxt "#30038"
+msgid "Custom groups"
+msgstr ""
+
+#. label: Channels - numTvGroups
+msgctxt "#30039"
+msgid "Number of TV groups"
+msgstr ""
 
 #. label-group: Channel Logos - XMLTV Logos Options
 msgctxt "#30040"
@@ -194,7 +238,30 @@ msgctxt "#30044"
 msgid "Prefer XMLTV"
 msgstr ""
 
-#empty strings from id 30045 to 30049
+#. label: General - oneTvGroup
+msgctxt "#30045"
+msgid "TV group 1"
+msgstr ""
+
+#. label: General - twoTvGroup
+msgctxt "#30046"
+msgid "TV group 2"
+msgstr ""
+
+#. label: General - threeTvGroup
+msgctxt "#30047"
+msgid "TV group 3"
+msgstr ""
+
+#. label: General - fourTvGroup
+msgctxt "#30048"
+msgid "TV group 4"
+msgstr ""
+
+#. label: General - fiveTvGroup
+msgctxt "#30049"
+msgid "TV group 5"
+msgstr ""
 
 #. label-category: genres
 #. label-group: Genres - Genres
@@ -217,7 +284,35 @@ msgctxt "#30053"
 msgid "Genres URL"
 msgstr ""
 
-#empty strings from id 30054 to 30059
+#. label: Channels - customTvGroupsFile
+msgctxt "#30054"
+msgid "Custom TV groups file"
+msgstr ""
+
+#. label: General - oneRadioGroup
+msgctxt "#30055"
+msgid "Radio group 1"
+msgstr ""
+
+#. label: General - twoRadioGroup
+msgctxt "#30056"
+msgid "Radio group 2"
+msgstr ""
+
+#. label: General - threeRadioGroup
+msgctxt "#30057"
+msgid "Radio group 3"
+msgstr ""
+
+#. label: General - fourRadioGroup
+msgctxt "#30058"
+msgid "Radio group 4"
+msgstr ""
+
+#. label: General - fiveRadioGroup
+msgctxt "#30059"
+msgid "Radio group 5"
+msgstr ""
 
 #. label-category: advanced
 msgctxt "#30060"
@@ -279,7 +374,22 @@ msgctxt "#30071"
 msgid "Channel defaults"
 msgstr ""
 
-#empty strings from id 30072 to 30099
+#. label: General - numRadioGroups
+msgctxt "#30072"
+msgid "Number of Radio groups"
+msgstr ""
+
+#. label: Channels - customRadioGroupsFile
+msgctxt "#30073"
+msgid "Custom Radio groups file"
+msgstr ""
+
+#. label: General - radioChannelGroupsOnly
+msgctxt "#30074"
+msgid "Only load Radio channels in groups"
+msgstr ""
+
+#empty strings from id 30075 to 30099
 
 #. label-category: catchup
 #. label-group: Catchup - Catchup
@@ -489,10 +599,66 @@ msgstr ""
 
 #. help: General - m3uRefreshHour
 msgctxt "#30609"
-msgid "If auto refresh mode is [B]Once per day[/B] refresh the files every time this hour of the day is reached"
+msgid "If auto refresh mode is [B]Once per day[/B] refresh the files every time this hour of the day is reached."
 msgstr ""
 
-#empty strings from id 30610 to 30619
+#. help: General - tvChannelGroupsOnly
+msgctxt "#30610"
+msgid "Only TV channels that belong to groups (i.e. have a [B]group-title[/B] attribute) will be loaded from the M3U file."
+msgstr ""
+
+#. help: Channels - tvGroupMode
+msgctxt "#30611"
+msgid "Choose from one of the following three modes: [B]All groups[/B] Load all TV groups from the M3U file; [B]Some groups[/B] Only load the groups specified in the next options; [B]Custom groups[/B] Load a set of groups from the M3U file whose names are loaded from an XML file."
+msgstr ""
+
+#. help: Channels - oneTvGroup
+#. help: Channels - twoTvGroup
+#. help: Channels - threeTvGroup
+#. help: Channels - fourTvGroup
+#. help: Channels - fiveTvGroup
+msgctxt "#30612"
+msgid "If the previous option has been has been set to 'Some groups' you need to specify a TV group to be loaded from the M3U file. Please note that this is the group name as shown in the group-title attribute (i.e. 'UK (TV)'). This setting is case-sensitive."
+msgstr ""
+
+#. help: Channels - radioGroupMode
+msgctxt "#30613"
+msgid "Choose from one of the following three modes: [B]All groups[/B] Load all Radio groups from the M3U file[/B]; [B]Some groups[/B] Only load the groups specified in the next options; [B]Custom groups[/B] Load a set of groups from the M3U file whose names are loaded from an XML file."
+msgstr ""
+
+#. help: Channels - oneRadioGroup
+#. help: Channels - twoRadioGroup
+#. help: Channels - threeRadioGroup
+#. help: Channels - fourRadioGroup
+#. help: Channels - fiveRadioGroup
+msgctxt "#30614"
+msgid "If the previous option has been has been set to 'Some groups' you need to specify a Radio group to be fetched from the M3U file. Please not that this is the group name as shown on the group-title attribute (i.e. 'UK (Radio)'). This setting is case-sensitive."
+msgstr ""
+
+#. help: Channels - customTvGroupsFile
+msgctxt "#30615"
+msgid "The file used to load the custom TV groups. The default file is `customTVGroups-example.xml`."
+msgstr ""
+
+#. help: Channels - customRadioGroupsFile
+msgctxt "#30616"
+msgid "The file used to load the custom Radio groups. The default file is `customRadioGroups-example.xml`."
+msgstr ""
+
+#. help: Channels - numTvGroups
+msgctxt "#30617"
+msgid "The number of TV groups to load when `Some groups` is the selected mode. Up to 5 can be chosen. If more than 5 are required the 'Custom groups' mode should be used instead."
+msgstr ""
+
+#. help: Channels - numRadioGroups
+msgctxt "#30618"
+msgid "The number of Radio groups to load when `Some groups` is the selected mode. Up to 5 can be chosen. If more than 5 are required the 'Custom groups'  mode should be used instead."
+msgstr ""
+
+#. help: General - radioChannelGroupsOnly
+msgctxt "#30619"
+msgid "Only Radio channels that belong to groups (i.e. have a [B]group-title[/B] attribute) will be loaded from the M3U file."
+msgstr ""
 
 #. help info - EPG Settings
 

--- a/pvr.iptvsimple/resources/settings.xml
+++ b/pvr.iptvsimple/resources/settings.xml
@@ -105,6 +105,250 @@
           </control>
         </setting>
       </group>
+
+      <group id="3" label="30029">
+        <setting id="tvGroupMode" type="integer" label="30034" help="30611">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="30036">0</option> <!-- ALL_GROUPS -->
+              <option label="30037">1</option> <!-- SOME_GROUPS -->
+              <option label="30038">2</option> <!-- CUSTOM_GROUPS -->
+            </options>
+          </constraints>
+          <control type="spinner" format="integer" />
+        </setting>
+        <setting id="numTvGroups" type="integer" parent="tvGroupMode" label="30039" help="30617">
+          <level>0</level>
+          <default>1</default>
+          <constraints>
+            <minimum>1</minimum>
+            <step>1</step>
+            <maximum>5</maximum>
+          </constraints>
+          <dependencies>
+            <dependency type="visible" setting="tvGroupMode" operator="is">1</dependency>
+          </dependencies>
+          <control type="spinner" format="integer" />
+        </setting>
+        <setting id="oneTvGroup" type="string" parent="tvGroupMode" label="30045" help="30612">
+          <level>0</level>
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <dependencies>
+            <dependency type="visible" setting="tvGroupMode" operator="is">1</dependency>
+          </dependencies>
+          <control type="edit" format="string" />
+        </setting>
+        <setting id="twoTvGroup" type="string" parent="tvGroupMode" label="30046" help="30612">
+          <level>0</level>
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="tvGroupMode" operator="is">1</condition>
+                <condition setting="numTvGroups" operator="gt">1</condition>
+              </and>
+            </dependency>
+          </dependencies>
+          <control type="edit" format="string" />
+        </setting>
+        <setting id="threeTvGroup" type="string" parent="tvGroupMode" label="30047" help="30612">
+          <level>0</level>
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="tvGroupMode" operator="is">1</condition>
+                <condition setting="numTvGroups" operator="gt">2</condition>
+              </and>
+            </dependency>
+          </dependencies>
+          <control type="edit" format="string" />
+        </setting>
+        <setting id="fourTvGroup" type="string" parent="tvGroupMode" label="30048" help="30612">
+          <level>0</level>
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="tvGroupMode" operator="is">1</condition>
+                <condition setting="numTvGroups" operator="gt">3</condition>
+              </and>
+            </dependency>
+          </dependencies>
+          <control type="edit" format="string" />
+        </setting>
+        <setting id="fiveTvGroup" type="string" parent="tvGroupMode" label="30049" help="30612">
+          <level>0</level>
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="tvGroupMode" operator="is">1</condition>
+                <condition setting="numTvGroups" operator="gt">4</condition>
+              </and>
+            </dependency>
+          </dependencies>
+          <control type="edit" format="string" />
+        </setting>
+        <setting id="customTvGroupsFile" type="path" parent="tvGroupMode" label="30054" help="30615">
+          <level>0</level>
+          <default>special://userdata/addon_data/pvr.iptvsimple/channelGroups/customTVGroups-example.xml</default>
+          <constraints>
+            <allowempty>false</allowempty>
+            <writable>false</writable>
+          </constraints>
+          <dependencies>
+            <dependency type="visible" setting="tvGroupMode" operator="is">2</dependency>
+          </dependencies>
+          <control type="button" format="file">
+            <heading>1033</heading>
+          </control>
+        </setting>
+        <setting id="tvChannelGroupsOnly" type="boolean" label="30028" help="30610">
+          <level>2</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+      </group>
+
+      <group id="4" label="30033">
+        <setting id="radioGroupMode" type="integer" label="30035" help="30647">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="30036">0</option> <!-- ALL_GROUPS -->
+              <option label="30037">1</option> <!-- SOME_GROUPS -->
+              <option label="30038">2</option> <!-- CUSTOM_GROUPS -->
+            </options>
+          </constraints>
+          <control type="spinner" format="integer" />
+        </setting>
+        <setting id="numRadioGroups" type="integer" parent="radioGroupMode" label="30072" help="30618">
+          <level>0</level>
+          <default>1</default>
+          <constraints>
+            <minimum>1</minimum>
+            <step>1</step>
+            <maximum>5</maximum>
+          </constraints>
+          <dependencies>
+            <dependency type="visible" setting="radioGroupMode" operator="is">1</dependency>
+          </dependencies>
+          <control type="spinner" format="integer" />
+        </setting>
+        <setting id="oneRadioGroup" type="string" parent="radioGroupMode" label="30055" help="30614">
+          <level>0</level>
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <dependencies>
+            <dependency type="visible" setting="radioGroupMode" operator="is">1</dependency>
+          </dependencies>
+          <control type="edit" format="string" />
+        </setting>
+        <setting id="twoRadioGroup" type="string" parent="radioGroupMode" label="30056" help="30614">
+          <level>0</level>
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="radioGroupMode" operator="is">1</condition>
+                <condition setting="numRadioGroups" operator="gt">1</condition>
+              </and>
+            </dependency>
+          </dependencies>
+          <control type="edit" format="string" />
+        </setting>
+        <setting id="threeRadioGroup" type="string" parent="radioGroupMode" label="30057" help="30614">
+          <level>0</level>
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="radioGroupMode" operator="is">1</condition>
+                <condition setting="numRadioGroups" operator="gt">2</condition>
+              </and>
+            </dependency>
+          </dependencies>
+          <control type="edit" format="string" />
+        </setting>
+        <setting id="fourRadioGroup" type="string" parent="radioGroupMode" label="30058" help="30614">
+          <level>0</level>
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="radioGroupMode" operator="is">1</condition>
+                <condition setting="numRadioGroups" operator="gt">3</condition>
+              </and>
+            </dependency>
+          </dependencies>
+          <control type="edit" format="string" />
+        </setting>
+        <setting id="fiveRadioGroup" type="string" parent="radioGroupMode" label="30059" help="30614">
+          <level>0</level>
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="radioGroupMode" operator="is">1</condition>
+                <condition setting="numRadioGroups" operator="gt">4</condition>
+              </and>
+            </dependency>
+          </dependencies>
+          <control type="edit" format="string" />
+        </setting>
+        <setting id="customRadioGroupsFile" type="path" parent="radioGroupMode" label="30073" help="30616">
+          <level>0</level>
+          <default>special://userdata/addon_data/pvr.iptvsimple/channelGroups/customRadioGroups-example.xml</default>
+          <constraints>
+            <allowempty>false</allowempty>
+            <writable>false</writable>
+          </constraints>
+          <dependencies>
+            <dependency type="visible" setting="radioGroupMode" operator="is">2</dependency>
+          </dependencies>
+          <control type="button" format="file">
+            <heading>1033</heading>
+          </control>
+        </setting>
+        <setting id="radioChannelGroupsOnly" type="boolean" label="30074" help="30619">
+          <level>2</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+      </group>
     </category>
 
     <!-- EPG -->

--- a/pvr.iptvsimple/resources/settings.xml
+++ b/pvr.iptvsimple/resources/settings.xml
@@ -330,7 +330,7 @@
         </setting>
       </group>
       <group id="2" label="30124">
-        <setting id="test123" type="action" label="30123" help="30723">
+        <setting id="ffmpegdirectSettings" type="action" label="30123" help="30723">
           <level>0</level>
           <data>Addon.OpenSettings(inputstream.ffmpegdirect)</data>
           <dependencies>

--- a/src/PVRIptvData.cpp
+++ b/src/PVRIptvData.cpp
@@ -135,6 +135,7 @@ void PVRIptvData::Process()
     {
       std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 
+      Settings::GetInstance().ReloadAddonSettings();
       m_playlistLoader.ReloadPlayList();
       m_epg.ReloadEPG();
 

--- a/src/iptvsimple/ChannelGroups.cpp
+++ b/src/iptvsimple/ChannelGroups.cpp
@@ -8,6 +8,7 @@
 
 #include "ChannelGroups.h"
 
+#include "Settings.h"
 #include "utilities/Logger.h"
 
 #include <kodi/General.h>
@@ -139,4 +140,32 @@ ChannelGroup* ChannelGroups::FindChannelGroup(const std::string& name)
   }
 
   return nullptr;
+}
+
+bool ChannelGroups::CheckChannelGroupAllowed(iptvsimple::data::ChannelGroup& newChannelGroup)
+{
+  std::vector<std::string> customNameList;
+
+  if (newChannelGroup.IsRadio())
+  {
+    if (Settings::GetInstance().GetRadioChannelGroupMode() == ChannelGroupMode::ALL_GROUPS)
+      return true;
+
+    customNameList = Settings::GetInstance().GetCustomRadioChannelGroupNameList();
+  }
+  else
+  {
+    if (Settings::GetInstance().GetTVChannelGroupMode() == ChannelGroupMode::ALL_GROUPS)
+      return true;
+
+    customNameList = Settings::GetInstance().GetCustomTVChannelGroupNameList();
+  }
+
+  for (const std::string& groupName : customNameList)
+  {
+    if (groupName == newChannelGroup.GetGroupName())
+      return true;
+  }
+
+  return false;
 }

--- a/src/iptvsimple/ChannelGroups.h
+++ b/src/iptvsimple/ChannelGroups.h
@@ -32,6 +32,7 @@ namespace iptvsimple
     iptvsimple::data::ChannelGroup* FindChannelGroup(const std::string& name);
     const std::vector<data::ChannelGroup>& GetChannelGroupsList() const { return m_channelGroups; }
     void Clear();
+    bool CheckChannelGroupAllowed(iptvsimple::data::ChannelGroup& newChannelGroup);
 
   private:
     const iptvsimple::Channels& m_channels;

--- a/src/iptvsimple/Channels.h
+++ b/src/iptvsimple/Channels.h
@@ -36,7 +36,7 @@ namespace iptvsimple
     bool GetChannel(const kodi::addon::PVRChannel& channel, iptvsimple::data::Channel& myChannel) const;
     bool GetChannel(int uniqueId, iptvsimple::data::Channel& myChannel) const;
 
-    void AddChannel(iptvsimple::data::Channel& channel, std::vector<int>& groupIdList, iptvsimple::ChannelGroups& channelGroups);
+    bool AddChannel(iptvsimple::data::Channel& channel, std::vector<int>& groupIdList, iptvsimple::ChannelGroups& channelGroups, bool channelHadGroups);
     iptvsimple::data::Channel* GetChannel(int uniqueId);
     const iptvsimple::data::Channel* FindChannel(const std::string& id, const std::string& displayName) const;
     const std::vector<data::Channel>& GetChannelsList() const { return m_channels; }

--- a/src/iptvsimple/Epg.cpp
+++ b/src/iptvsimple/Epg.cpp
@@ -243,12 +243,12 @@ bool Epg::LoadChannelEpgs(const xml_node& rootElement)
       if (existingChannelEpg)
       {
         if (existingChannelEpg->CombineNamesAndIconPathFrom(channelEpg))
-          Logger::Log(LEVEL_DEBUG, "%s - Combined channel EPG with id '%s' now has display names: '%s'", __FUNCTION__, channelEpg.GetId().c_str(), StringUtils::Join(channelEpg.GetNames(), EPG_STRING_TOKEN_SEPARATOR).c_str());
+          Logger::Log(LEVEL_DEBUG, "%s - Combined channel EPG with id '%s' now has display names: '%s'", __FUNCTION__, channelEpg.GetId().c_str(), channelEpg.GetJoinedDisplayNames().c_str());
 
         continue;
       }
 
-      Logger::Log(LEVEL_DEBUG, "%s - Loaded channel EPG with id '%s' with display names: '%s'", __FUNCTION__, channelEpg.GetId().c_str(), StringUtils::Join(channelEpg.GetNames(), EPG_STRING_TOKEN_SEPARATOR).c_str());
+      Logger::Log(LEVEL_DEBUG, "%s - Loaded channel EPG with id '%s' with display names: '%s'", __FUNCTION__, channelEpg.GetId().c_str(), channelEpg.GetJoinedDisplayNames().c_str());
 
       m_channelEpgs.emplace_back(channelEpg);
     }
@@ -397,20 +397,19 @@ ChannelEpg* Epg::FindEpgForChannel(const Channel& channel) const
 
   for (auto& myChannelEpg : m_channelEpgs)
   {
-    for (const std::string& displayName : myChannelEpg.GetNames())
+    for (const DisplayNamePair& displayNamePair : myChannelEpg.GetDisplayNames())
     {
-      const std::string convertedDisplayName = std::regex_replace(displayName, std::regex(" "), "_");
-      if (StringUtils::EqualsNoCase(convertedDisplayName, channel.GetTvgName()) ||
-          StringUtils::EqualsNoCase(displayName, channel.GetTvgName()))
+      if (StringUtils::EqualsNoCase(displayNamePair.m_displayNameWithUnderscores, channel.GetTvgName()) ||
+          StringUtils::EqualsNoCase(displayNamePair.m_displayName, channel.GetTvgName()))
         return const_cast<ChannelEpg*>(&myChannelEpg);
     }
   }
 
   for (auto& myChannelEpg : m_channelEpgs)
   {
-    for (const std::string& displayName : myChannelEpg.GetNames())
+    for (const DisplayNamePair& displayNamePair : myChannelEpg.GetDisplayNames())
     {
-      if (StringUtils::EqualsNoCase(displayName, channel.GetChannelName()))
+      if (StringUtils::EqualsNoCase(displayNamePair.m_displayName, channel.GetChannelName()))
         return const_cast<ChannelEpg*>(&myChannelEpg);
     }
   }

--- a/src/iptvsimple/Epg.cpp
+++ b/src/iptvsimple/Epg.cpp
@@ -46,8 +46,14 @@ bool Epg::Init(int epgMaxPastDays, int epgMaxFutureDays)
   SetEPGMaxPastDays(epgMaxPastDays);
   SetEPGMaxFutureDays(epgMaxFutureDays);
 
-  time_t now = std::time(nullptr);
-  LoadEPG(now - m_epgMaxPastDaysSeconds, now + m_epgMaxFutureDaysSeconds);
+  if (Settings::GetInstance().IsCatchupEnabled())
+  {
+    // For catchup we need a local store of the EPG data. Kodi may not load the
+    // data on each startup so we need to make sure it's loaded whether or not
+    // kodi considers it necessary.
+    time_t now = std::time(nullptr);
+    LoadEPG(now - m_epgMaxPastDaysSeconds, now + m_epgMaxFutureDaysSeconds);
+  }
 
   return true;
 }

--- a/src/iptvsimple/Settings.cpp
+++ b/src/iptvsimple/Settings.cpp
@@ -140,6 +140,11 @@ void Settings::ReadFromAddon(const std::string& userPath, const std::string& cli
   m_defaultMimeType = kodi::GetSettingString("defaultMimeType");
 }
 
+void Settings::ReloadAddonSettings()
+{
+  ReadFromAddon(m_userPath, m_clientPath);
+}
+
 ADDON_STATUS Settings::SetValue(const std::string& settingName, const kodi::CSettingValue& settingValue)
 {
   // reset cache and restart addon

--- a/src/iptvsimple/Settings.cpp
+++ b/src/iptvsimple/Settings.cpp
@@ -9,15 +9,21 @@
 #include "Settings.h"
 
 #include "utilities/FileUtils.h"
+#include "utilities/XMLUtils.h"
+
+#include <pugixml.hpp>
 
 using namespace iptvsimple;
 using namespace iptvsimple::utilities;
+using namespace pugi;
 
 /***************************************************************************
  * PVR settings
  **************************************************************************/
 void Settings::ReadFromAddon(const std::string& userPath, const std::string& clientPath)
 {
+  FileUtils::CopyDirectory(FileUtils::GetResourceDataPath() + CHANNEL_GROUPS_DIR, CHANNEL_GROUPS_ADDON_DATA_BASE_DIR, true);
+
   m_userPath = userPath;
   m_clientPath = clientPath;
 
@@ -31,6 +37,60 @@ void Settings::ReadFromAddon(const std::string& userPath, const std::string& cli
   m_m3uRefreshMode = kodi::GetSettingEnum<RefreshMode>("m3uRefreshMode", RefreshMode::DISABLED);
   m_m3uRefreshIntervalMins = kodi::GetSettingInt("m3uRefreshIntervalMins", 60);
   m_m3uRefreshHour = kodi::GetSettingInt("m3uRefreshHour", 4);
+
+  m_allowTVChannelGroupsOnly = kodi::GetSettingBoolean("tvChannelGroupsOnly", false);
+  m_tvChannelGroupMode = kodi::GetSettingEnum<ChannelGroupMode>("tvGroupMode", ChannelGroupMode::ALL_GROUPS);
+  m_numTVGroups = kodi::GetSettingInt("numTvGroups", DEFAULT_NUM_GROUPS);
+  m_oneTVGroup = kodi::GetSettingString("oneTvGroup");
+  m_twoTVGroup = kodi::GetSettingString("twoTvGroup");
+  m_threeTVGroup = kodi::GetSettingString("threeTvGroup");
+  m_fourTVGroup = kodi::GetSettingString("fourTvGroup");
+  m_fiveTVGroup = kodi::GetSettingString("fiveTvGroup");
+  if (m_tvChannelGroupMode == ChannelGroupMode::SOME_GROUPS)
+  {
+    m_customTVChannelGroupNameList.clear();
+
+    if (!m_oneTVGroup.empty() && m_numTVGroups >= 1)
+      m_customTVChannelGroupNameList.emplace_back(m_oneTVGroup);
+    if (!m_twoTVGroup.empty() && m_numTVGroups >= 2)
+      m_customTVChannelGroupNameList.emplace_back(m_twoTVGroup);
+    if (!m_threeTVGroup.empty() && m_numTVGroups >= 3)
+      m_customTVChannelGroupNameList.emplace_back(m_threeTVGroup);
+    if (!m_fourTVGroup.empty() && m_numTVGroups >= 4)
+      m_customTVChannelGroupNameList.emplace_back(m_fourTVGroup);
+    if (!m_fiveTVGroup.empty() && m_numTVGroups >= 5)
+      m_customTVChannelGroupNameList.emplace_back(m_fiveTVGroup);
+  }
+  m_customTVGroupsFile = kodi::GetSettingString("customTvGroupsFile", DEFAULT_CUSTOM_TV_GROUPS_FILE);
+  if (m_tvChannelGroupMode == ChannelGroupMode::CUSTOM_GROUPS)
+    LoadCustomChannelGroupFile(m_customTVGroupsFile, m_customTVChannelGroupNameList);
+
+  m_allowRadioChannelGroupsOnly = kodi::GetSettingBoolean("radioChannelGroupsOnly", false);
+  m_radioChannelGroupMode = kodi::GetSettingEnum<ChannelGroupMode>("radioGroupMode", ChannelGroupMode::ALL_GROUPS);
+  m_numRadioGroups = kodi::GetSettingInt("numRadioGroups", DEFAULT_NUM_GROUPS);
+  m_oneRadioGroup = kodi::GetSettingString("oneRadioGroup");
+  m_twoRadioGroup = kodi::GetSettingString("twoRadioGroup");
+  m_threeRadioGroup = kodi::GetSettingString("threeRadioGroup");
+  m_fourRadioGroup = kodi::GetSettingString("fourRadioGroup");
+  m_fiveRadioGroup = kodi::GetSettingString("fiveRadioGroup");
+  if (m_radioChannelGroupMode == ChannelGroupMode::SOME_GROUPS)
+  {
+    m_customRadioChannelGroupNameList.clear();
+
+    if (!m_oneRadioGroup.empty() && m_numRadioGroups >= 1)
+      m_customRadioChannelGroupNameList.emplace_back(m_oneRadioGroup);
+    if (!m_twoRadioGroup.empty() && m_numRadioGroups >= 2)
+      m_customRadioChannelGroupNameList.emplace_back(m_twoRadioGroup);
+    if (!m_threeRadioGroup.empty() && m_numRadioGroups >= 3)
+      m_customRadioChannelGroupNameList.emplace_back(m_threeRadioGroup);
+    if (!m_fourRadioGroup.empty() && m_numRadioGroups >= 4)
+      m_customRadioChannelGroupNameList.emplace_back(m_fourRadioGroup);
+    if (!m_fiveRadioGroup.empty() && m_numRadioGroups >= 5)
+      m_customRadioChannelGroupNameList.emplace_back(m_fiveRadioGroup);
+  }
+  m_customRadioGroupsFile = kodi::GetSettingString("customRadioGroupsFile", DEFAULT_CUSTOM_RADIO_GROUPS_FILE);
+  if (m_radioChannelGroupMode == ChannelGroupMode::CUSTOM_GROUPS)
+    LoadCustomChannelGroupFile(m_customRadioGroupsFile, m_customRadioChannelGroupNameList);
 
   // EPG
   m_epgPathType = kodi::GetSettingEnum<PathType>("epgPathType", PathType::REMOTE_PATH);
@@ -111,6 +171,42 @@ ADDON_STATUS Settings::SetValue(const std::string& settingName, const kodi::CSet
     return SetSetting<int, ADDON_STATUS>(settingName, settingValue, m_m3uRefreshIntervalMins, ADDON_STATUS_OK, ADDON_STATUS_OK);
   else if (settingName == "m3uRefreshHour")
     return SetSetting<int, ADDON_STATUS>(settingName, settingValue, m_m3uRefreshHour, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  else if (settingName == "tvChannelGroupsOnly")
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_allowTVChannelGroupsOnly, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  else if (settingName == "tvGroupMode")
+    return SetEnumSetting<ChannelGroupMode, ADDON_STATUS>(settingName, settingValue, m_tvChannelGroupMode, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  else if (settingName == "numTvGroups")
+    return SetSetting<unsigned int, ADDON_STATUS>(settingName, settingValue, m_numTVGroups, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  else if (settingName == "oneTvGroup")
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_oneTVGroup, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  else if (settingName == "twoTvGroup")
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_twoTVGroup, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  else if (settingName == "threeTvGroup")
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_threeTVGroup, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  else if (settingName == "twoTvGroup")
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_fourTVGroup, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  else if (settingName == "fiveTvGroup")
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_fiveTVGroup, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  else if (settingName == "customTvGroupsFile")
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_customTVGroupsFile, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  else if (settingName == "radioChannelGroupsOnly")
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_allowRadioChannelGroupsOnly, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  else if (settingName == "radioGroupMode")
+    return SetEnumSetting<ChannelGroupMode, ADDON_STATUS>(settingName, settingValue, m_radioChannelGroupMode, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  else if (settingName == "numRadioGroups")
+    return SetSetting<unsigned int, ADDON_STATUS>(settingName, settingValue, m_numRadioGroups, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  else if (settingName == "oneRadioGroup")
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_oneRadioGroup, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  else if (settingName == "twoRadioGroup")
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_twoRadioGroup, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  else if (settingName == "threeRadioGroup")
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_threeRadioGroup, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  else if (settingName == "fourRadioGroup")
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_fourRadioGroup, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  else if (settingName == "fiveRadioGroup")
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_fiveRadioGroup, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  else if (settingName == "customRadioGroupsFile")
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_customRadioGroupsFile, ADDON_STATUS_OK, ADDON_STATUS_OK);
   // EPG
   else if (settingName == "epgPathType")
     return SetEnumSetting<PathType, ADDON_STATUS>(settingName, settingValue, m_epgPathType, ADDON_STATUS_OK, ADDON_STATUS_OK);
@@ -189,4 +285,50 @@ ADDON_STATUS Settings::SetValue(const std::string& settingName, const kodi::CSet
     return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_defaultMimeType, ADDON_STATUS_OK, ADDON_STATUS_OK);
 
   return ADDON_STATUS_OK;
+}
+
+bool Settings::LoadCustomChannelGroupFile(std::string& xmlFile, std::vector<std::string>& channelGroupNameList)
+{
+  channelGroupNameList.clear();
+
+  if (!FileUtils::FileExists(xmlFile.c_str()))
+  {
+    Logger::Log(LEVEL_ERROR, "%s No XML file found: %s", __func__, xmlFile.c_str());
+    return false;
+  }
+
+  Logger::Log(LEVEL_DEBUG, "%s Loading XML File: %s", __func__, xmlFile.c_str());
+
+  std::string data;
+  FileUtils::GetFileContents(xmlFile, data);
+
+  if (data.empty())
+    return false;
+
+  char* buffer = &(data[0]);
+  xml_document xmlDoc;
+  xml_parse_result result = xmlDoc.load_string(buffer);
+
+  if (!result)
+  {
+    std::string errorString;
+    int offset = GetParseErrorString(buffer, result.offset, errorString);
+    Logger::Log(LEVEL_ERROR, "%s - Unable parse CustomChannelGroup XML: %s, offset: %d: \n[ %s \n]", __FUNCTION__, result.description(), offset, errorString.c_str());
+    return false;
+  }
+
+  const auto& rootElement = xmlDoc.child("customChannelGroups");
+  if (!rootElement)
+    return false;
+
+  for (const auto& groupNameNode : rootElement.children("channelGroupName"))
+  {
+    std::string channelGroupName = groupNameNode.child_value();
+    channelGroupNameList.emplace_back(channelGroupName);
+    Logger::Log(LEVEL_DEBUG, "%s Read CustomChannelGroup Name: %s, from file: %s", __func__, channelGroupName.c_str(), xmlFile.c_str());
+  }
+
+  xmlDoc.reset();
+
+  return true;
 }

--- a/src/iptvsimple/Settings.h
+++ b/src/iptvsimple/Settings.h
@@ -24,6 +24,12 @@ namespace iptvsimple
   static const std::string DEFAULT_GENRE_TEXT_MAP_FILE = ADDON_DATA_BASE_DIR + "/genres/genreTextMappings/genres.xml";
   static const int DEFAULT_UDPXY_MULTICAST_RELAY_PORT = 4022;
 
+  static const int DEFAULT_NUM_GROUPS = 1;
+  static const std::string CHANNEL_GROUPS_DIR = "/channelGroups";
+  static const std::string DEFAULT_CUSTOM_TV_GROUPS_FILE = ADDON_DATA_BASE_DIR + "/channelGroups/customTVGroups-example.xml";
+  static const std::string DEFAULT_CUSTOM_RADIO_GROUPS_FILE = ADDON_DATA_BASE_DIR + "/channelGroups/customRadioGroups-example.xml";
+  static const std::string CHANNEL_GROUPS_ADDON_DATA_BASE_DIR = ADDON_DATA_BASE_DIR + CHANNEL_GROUPS_DIR;
+
   enum class PathType
     : int // same type as addon settings
   {
@@ -37,6 +43,14 @@ namespace iptvsimple
     DISABLED = 0,
     REPEATED_REFRESH,
     ONCE_PER_DAY
+  };
+
+  enum class ChannelGroupMode
+    : int // same type as addon settings
+  {
+    ALL_GROUPS = 0,
+    SOME_GROUPS,
+    CUSTOM_GROUPS
   };
 
   enum class EpgLogosMode
@@ -75,6 +89,12 @@ namespace iptvsimple
     const RefreshMode& GetM3URefreshMode() const { return m_m3uRefreshMode; }
     int GetM3URefreshIntervalMins() const { return m_m3uRefreshIntervalMins; }
     int GetM3URefreshHour() const { return m_m3uRefreshHour; }
+    bool AllowTVChannelGroupsOnly() const { return m_allowTVChannelGroupsOnly; }
+    const ChannelGroupMode& GetTVChannelGroupMode() const { return m_tvChannelGroupMode; }
+    const std::string& GetCustomTVGroupsFile() const { return m_customTVGroupsFile; }
+    bool AllowRadioChannelGroupsOnly() const { return m_allowRadioChannelGroupsOnly; }
+    const ChannelGroupMode& GetRadioChannelGroupMode() const { return m_radioChannelGroupMode; }
+    const std::string& GetCustomRadioGroupsFile() const { return m_customRadioGroupsFile; }
 
     const std::string& GetEpgLocation() const
     {
@@ -130,6 +150,9 @@ namespace iptvsimple
 
     const std::string& GetTvgUrl() const { return m_tvgUrl; }
     void SetTvgUrl(const std::string& tvgUrl) { m_tvgUrl = tvgUrl; }
+
+    std::vector<std::string>& GetCustomTVChannelGroupNameList() { return m_customTVChannelGroupNameList; }
+    std::vector<std::string>& GetCustomRadioChannelGroupNameList() { return m_customRadioChannelGroupNameList; }
 
   private:
     Settings() = default;
@@ -192,6 +215,8 @@ namespace iptvsimple
       return defaultReturnValue;
     }
 
+    static bool LoadCustomChannelGroupFile(std::string& file, std::vector<std::string>& channelGroupNameList);
+
     std::string m_userPath;
     std::string m_clientPath;
 
@@ -205,6 +230,24 @@ namespace iptvsimple
     RefreshMode m_m3uRefreshMode = RefreshMode::DISABLED;
     int m_m3uRefreshIntervalMins = 60;
     int m_m3uRefreshHour = 4;
+    bool m_allowTVChannelGroupsOnly = false;
+    ChannelGroupMode m_tvChannelGroupMode = ChannelGroupMode::ALL_GROUPS;
+    unsigned int m_numTVGroups = DEFAULT_NUM_GROUPS;
+    std::string m_oneTVGroup = "";
+    std::string m_twoTVGroup = "";
+    std::string m_threeTVGroup = "";
+    std::string m_fourTVGroup = "";
+    std::string m_fiveTVGroup = "";
+    std::string m_customTVGroupsFile = "";
+    bool m_allowRadioChannelGroupsOnly = false;
+    ChannelGroupMode m_radioChannelGroupMode = ChannelGroupMode::ALL_GROUPS;
+    unsigned int m_numRadioGroups = DEFAULT_NUM_GROUPS;
+    std::string m_oneRadioGroup = "";
+    std::string m_twoRadioGroup = "";
+    std::string m_threeRadioGroup = "";
+    std::string m_fourRadioGroup = "";
+    std::string m_fiveRadioGroup = "";
+    std::string m_customRadioGroupsFile = "";
 
     // EPG
     PathType m_epgPathType = PathType::REMOTE_PATH;
@@ -252,6 +295,9 @@ namespace iptvsimple
     std::string m_defaultUserAgent;
     std::string m_defaultInputstream;
     std::string m_defaultMimeType;
+
+    std::vector<std::string> m_customTVChannelGroupNameList;
+    std::vector<std::string> m_customRadioChannelGroupNameList;
 
     std::string m_tvgUrl;
   };

--- a/src/iptvsimple/Settings.h
+++ b/src/iptvsimple/Settings.h
@@ -74,6 +74,7 @@ namespace iptvsimple
     }
 
     void ReadFromAddon(const std::string& userPath, const std::string& clientPath);
+    void ReloadAddonSettings();
     ADDON_STATUS SetValue(const std::string& settingName, const kodi::CSettingValue& settingValue);
 
     const std::string& GetUserPath() const { return m_userPath; }

--- a/src/iptvsimple/data/Channel.cpp
+++ b/src/iptvsimple/data/Channel.cpp
@@ -199,6 +199,12 @@ void Channel::TryToAddPropertyAsHeader(const std::string& propertyName, const st
   }
 }
 
+bool Channel::ChannelTypeAllowsGroupsOnly() const
+{
+  return ((m_radio && Settings::GetInstance().AllowRadioChannelGroupsOnly()) ||
+          (!m_radio && Settings::GetInstance().AllowTVChannelGroupsOnly()));
+}
+
 void Channel::SetCatchupDays(int catchupDays)
 {
   if (catchupDays > 0 || catchupDays == IGNORE_CATCHUP_DAYS)

--- a/src/iptvsimple/data/Channel.h
+++ b/src/iptvsimple/data/Channel.h
@@ -128,6 +128,8 @@ namespace iptvsimple
       void SetIconPathFromTvgLogo(const std::string& tvgLogo, std::string& channelName);
       void ConfigureCatchupMode();
 
+      bool ChannelTypeAllowsGroupsOnly() const;
+
     private:
       void RemoveProperty(const std::string& propName);
       void TryToAddPropertyAsHeader(const std::string& propertyName, const std::string& headerName);

--- a/src/iptvsimple/data/ChannelEpg.cpp
+++ b/src/iptvsimple/data/ChannelEpg.cpp
@@ -10,6 +10,9 @@
 
 #include "../utilities/XMLUtils.h"
 
+#include <kodi/tools/StringUtils.h>
+
+using namespace kodi::tools;
 using namespace iptvsimple;
 using namespace iptvsimple::data;
 using namespace pugi;
@@ -29,7 +32,7 @@ bool ChannelEpg::UpdateFrom(const xml_node& channelNode, Channels& channels)
     if (channels.FindChannel(m_id, name))
     {
       foundChannel = true;
-      m_names.emplace_back(name);
+      AddDisplayName(name);
     }
   }
 
@@ -55,9 +58,9 @@ bool ChannelEpg::CombineNamesAndIconPathFrom(const ChannelEpg& right)
 {
   bool combined = false;
 
-  for (const std::string& name : right.m_names)
+  for (const DisplayNamePair& namePair : right.m_displayNames)
   {
-    AddName(name);
+    AddDisplayName(namePair.m_displayName);
     combined = true;
   }
 
@@ -68,4 +71,21 @@ bool ChannelEpg::CombineNamesAndIconPathFrom(const ChannelEpg& right)
   }
 
   return combined;
+}
+
+void ChannelEpg::AddDisplayName(const std::string& value)
+{
+  DisplayNamePair pair;
+  pair.m_displayName = value;
+  StringUtils::Replace(pair.m_displayNameWithUnderscores, ' ', '_');
+  m_displayNames.emplace_back(pair);
+}
+
+std::string ChannelEpg::GetJoinedDisplayNames()
+{
+  std::vector<std::string> names;
+  for (auto& displayNamePair : m_displayNames)
+    names.emplace_back(displayNamePair.m_displayName);
+
+  return StringUtils::Join(names, EPG_STRING_TOKEN_SEPARATOR);
 }

--- a/src/iptvsimple/data/ChannelEpg.cpp
+++ b/src/iptvsimple/data/ChannelEpg.cpp
@@ -19,7 +19,7 @@ using namespace pugi;
 
 bool ChannelEpg::UpdateFrom(const xml_node& channelNode, Channels& channels)
 {
-  if (!GetAttributeValue(channelNode, "id", m_id))
+  if (!GetAttributeValue(channelNode, "id", m_id) || m_id.empty())
     return false;
 
   bool foundChannel = false;

--- a/src/iptvsimple/data/ChannelEpg.h
+++ b/src/iptvsimple/data/ChannelEpg.h
@@ -20,14 +20,21 @@ namespace iptvsimple
 {
   namespace data
   {
+    struct DisplayNamePair
+    {
+      std::string m_displayName;
+      std::string m_displayNameWithUnderscores;
+    };
+
     class ChannelEpg
     {
     public:
       const std::string& GetId() const { return m_id; }
       void SetId(const std::string& value) { m_id = value; }
 
-      const std::vector<std::string>& GetNames() const { return m_names; }
-      void AddName(const std::string& value) { m_names.emplace_back(value); }
+      const std::vector<DisplayNamePair>& GetDisplayNames() const { return m_displayNames; }
+      void AddDisplayName(const std::string& value);
+      std::string GetJoinedDisplayNames();
 
       const std::string& GetIconPath() const { return m_iconPath; }
       void SetIconPath(const std::string& value) { m_iconPath = value; }
@@ -40,7 +47,8 @@ namespace iptvsimple
 
     private:
       std::string m_id;
-      std::vector<std::string> m_names;
+      //std::vector<std::string> m_names;
+      std::vector<DisplayNamePair> m_displayNames;
       std::string m_iconPath;
       std::map<time_t, EpgEntry> m_epgEntries;
     };


### PR DESCRIPTION
v7.4.0
- Fixed: An xmltv channel cannot have an empty id field
- Fixed: Fix slow epg load due to display name checks when finding a channel
- Fixed: Only force load EPG data on startup if catchup is enabled
- Added: Support custom channel group filters
- Added: Reload settings before reloading playlist and EPG data
