### PR TITLE
Fix crash after restarting the addon

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="3.10.0"
+  version="3.10.1"
   name="PVR IPTV Simple Client"
   provider-name="nightik">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v3.10.1
+- Fixed: Addon crashes when it is restarted
+
 v3.10.0
 - Added: Support for EXTGRP markers for channel groups
 

--- a/src/PVRIptvData.cpp
+++ b/src/PVRIptvData.cpp
@@ -598,6 +598,7 @@ bool PVRIptvData::LoadPlayList(void)
   bool bFirst = true;
   bool bIsRealTime  = true;
   int iChannelIndex     = 0;
+  int iUniqueGroupId    = 0;
   int iChannelNum       = g_iStartNumber;
   int iEPGTimeShift     = 0;
   bool bRadio           = false;
@@ -728,14 +729,14 @@ bool PVRIptvData::LoadPlayList(void)
         }
 
         iChannelGroupName = strGroupName;
-        ProcessGroupLine(strGroupName, bRadio, iCurrentGroupId);
+        ProcessGroupLine(strGroupName, bRadio, iUniqueGroupId, iCurrentGroupId);
       }
     }
     else if (iChannelGroupName.empty() && StringUtils::Left(strLine, strlen(M3U_GROUP_MARKER)) == M3U_GROUP_MARKER)
     {
       iChannelGroupName = StringUtils::Right(strLine, static_cast<int>(strLine.size()) - strlen(M3U_GROUP_MARKER));
       iChannelGroupName = StringUtils::Trim(iChannelGroupName);
-      ProcessGroupLine(iChannelGroupName, bRadio, iCurrentGroupId);
+      ProcessGroupLine(iChannelGroupName, bRadio, iUniqueGroupId, iCurrentGroupId);
     }
     else if (StringUtils::Left(strLine, strlen(KODIPROP_MARKER)) == KODIPROP_MARKER)
     {
@@ -846,10 +847,8 @@ bool PVRIptvData::LoadPlayList(void)
   return true;
 }
 
-void PVRIptvData::ProcessGroupLine(std::string groupsLine, bool bRadio, std::vector<int>& iCurrentGroupId)
+void PVRIptvData::ProcessGroupLine(std::string groupsLine, bool bRadio, int &uniqueGroupId, std::vector<int>& iCurrentGroupId)
 {
-  static int iUniqueGroupId = 0;
-
   if (!groupsLine.empty())
   {
     std::stringstream streamGroups(groupsLine);
@@ -863,11 +862,11 @@ void PVRIptvData::ProcessGroupLine(std::string groupsLine, bool bRadio, std::vec
       {
         PVRIptvChannelGroup group;
         group.strGroupName = groupsLine;
-        group.iGroupId = ++iUniqueGroupId;
+        group.iGroupId = ++uniqueGroupId;
         group.bRadio = bRadio;
 
         m_groups.push_back(group);
-        iCurrentGroupId.push_back(iUniqueGroupId);
+        iCurrentGroupId.push_back(uniqueGroupId);
       }
       else
       {

--- a/src/PVRIptvData.h
+++ b/src/PVRIptvData.h
@@ -139,7 +139,7 @@ private:
   static bool ParseXmltvNsEpisodeNumberInfo(const std::string& episodeNumberString, PVRIptvEpgEntry& entry);
   static bool ParseOnScreenEpisodeNumberInfo(const std::string& episodeNumberString, PVRIptvEpgEntry& entry);
 
-  virtual void ProcessGroupLine(std::string groupsLine, bool bRadio, std::vector<int>& iCurrentGroupId);
+  virtual void ProcessGroupLine(std::string groupsLine, bool bRadio, int &uniqueGroupId, std::vector<int>& iCurrentGroupId);
 
   bool                              m_bTSOverride;
   int                               m_iEPGTimeShift;


### PR DESCRIPTION
This PR fixes the glaring problem somehow missed in the previous release #460, where the addon crashes after it is restarted (due to settings change, or just after disabling/enabling it in the Kodi menu)
It happens when channel groups exist in the channel playlist.