### PR TITLE
Fix terminating catchup

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -5,9 +5,9 @@
   name="PVR IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@
-    <import addon="inputstream.ffmpegdirect" minversion="1.19.0" optional="true"/>
-    <import addon="inputstream.adaptive" minversion="2.6.6" optional="true"/>
-    <import addon="inputstream.rtmp" minversion="3.4.0" optional="true"/>
+    <import addon="inputstream.ffmpegdirect" minversion="1.19.0"/>
+    <import addon="inputstream.adaptive" minversion="2.6.6"/>
+    <import addon="inputstream.rtmp" minversion="3.4.0"/>
   </requires>
   <extension
     point="kodi.pvrclient"

--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="7.4.2"
+  version="7.4.3"
   name="PVR IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@
@@ -169,6 +169,10 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v7.4.3
+- Fixed: Add support for format specifiers use for detecting terminating catchup and granularity
+- Update: Make inputstream add-ons a required dependency
+
 v7.4.2
 - Fixed: Add missing initialisation of display name with underscores after fixing slow epg
 

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,7 @@
+v7.4.3
+- Fixed: Add support for format specifiers use for detecting terminating catchup and granularity
+- Update: Make inputstream add-ons a required dependency
+
 v7.4.2
 - Fixed: Add missing initialisation of display name with underscores after fixing slow epg
 

--- a/src/iptvsimple/data/Channel.cpp
+++ b/src/iptvsimple/data/Channel.cpp
@@ -257,9 +257,13 @@ bool IsTerminatingCatchupSource(const std::string& formatString)
   if (formatString.find("{duration}") != std::string::npos ||
       formatString.find("{duration:") != std::string::npos ||
       formatString.find("{lutc}") != std::string::npos ||
+      formatString.find("{lutc:") != std::string::npos ||
       formatString.find("${timestamp}") != std::string::npos ||
+      formatString.find("${timestamp:") != std::string::npos ||
       formatString.find("{utcend}") != std::string::npos ||
-      formatString.find("${end}") != std::string::npos)
+      formatString.find("{utcend:") != std::string::npos ||
+      formatString.find("${end}") != std::string::npos ||
+      formatString.find("${end:") != std::string::npos)
     return true;
 
   return false;
@@ -269,7 +273,9 @@ int FindCatchupSourceGranularitySeconds(const std::string& formatString)
 {
   // A catchup stream has one second granularity if it supports these specifiers
   if (formatString.find("{utc}") != std::string::npos ||
+      formatString.find("{utc:") != std::string::npos ||
       formatString.find("${start}") != std::string::npos ||
+      formatString.find("${start:") != std::string::npos ||
       formatString.find("{S}") != std::string::npos ||
       formatString.find("{offset:1}") != std::string::npos)
     return 1;


### PR DESCRIPTION
v7.4.3
- Fixed: Add support for format specifiers use for detecting terminating catchup and granularity
- Update: Make inputstream add-ons a required dependency