### PR TITLE
tvg-rec fix

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="7.5.0"
+  version="7.5.1"
   name="PVR IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@
@@ -169,6 +169,10 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v7.5.1
+- Fixed: Treat 'tvg-rec' catchup tag like the siptv 'timeshift' tag
+- Fixed: Ensure channel's catchup window is used instead of value from settings
+
 v7.5.0
 - Added: Support sub channel numbers
 - Added: Allow setting scope for channels using catchup mode setting to enable overriding

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,7 @@
+v7.5.1
+- Fixed: Treat 'tvg-rec' catchup tag like the siptv 'timeshift' tag
+- Fixed: Ensure channel's catchup window is used instead of value from settings
+
 v7.5.0
 - Added: Support sub channel numbers
 - Added: Allow setting scope for channels using catchup mode setting to enable overriding

--- a/src/iptvsimple/CatchupController.cpp
+++ b/src/iptvsimple/CatchupController.cpp
@@ -65,8 +65,8 @@ void CatchupController::ProcessChannelForPlayback(const Channel& channel, std::m
       m_programmeCatchupId.clear();
       if (channel.IsCatchupSupported())
       {
-        m_timeshiftBufferOffset = Settings::GetInstance().GetCatchupDaysInSeconds(); //offset from now to start of catchup window
-        m_timeshiftBufferStartTime = std::time(nullptr) - Settings::GetInstance().GetCatchupDaysInSeconds(); // now - the window size
+        m_timeshiftBufferOffset = channel.GetCatchupDaysInSeconds(); //offset from now to start of catchup window
+        m_timeshiftBufferStartTime = std::time(nullptr) - channel.GetCatchupDaysInSeconds(); // now - the window size
       }
       else
       {
@@ -107,7 +107,7 @@ void CatchupController::ProcessEPGTagForTimeshiftedPlayback(const kodi::addon::P
 
     time_t timeNow = time(0);
     time_t programmeOffset = timeNow - m_catchupStartTime;
-    time_t timeshiftBufferDuration = std::max(programmeOffset, Settings::GetInstance().GetCatchupDaysInSeconds());
+    time_t timeshiftBufferDuration = std::max(programmeOffset, static_cast<time_t>(channel.GetCatchupDaysInSeconds()));
     m_timeshiftBufferStartTime = timeNow - timeshiftBufferDuration;
     m_catchupStartTime = m_timeshiftBufferStartTime;
     m_catchupEndTime = timeNow;

--- a/src/iptvsimple/PlaylistLoader.cpp
+++ b/src/iptvsimple/PlaylistLoader.cpp
@@ -280,10 +280,12 @@ std::string PlaylistLoader::ParseIntoChannel(const std::string& line, Channel& c
     int siptvTimeshiftDays = 0;
     if (!strCatchupSiptv.empty())
       siptvTimeshiftDays = atoi(strCatchupSiptv.c_str());
+    // treat tvg-rec tag like siptv if siptv has not been used
+    if (!strTvgRec.empty() && siptvTimeshiftDays == 0)
+      siptvTimeshiftDays = atoi(strTvgRec.c_str());
+
     if (!strCatchupDays.empty())
       channel.SetCatchupDays(atoi(strCatchupDays.c_str()));
-    else if (!strTvgRec.empty())
-      channel.SetCatchupDays(atoi(strTvgRec.c_str()));
     else if (channel.GetCatchupMode() == CatchupMode::VOD)
       channel.SetCatchupDays(IGNORE_CATCHUP_DAYS);
     else if (siptvTimeshiftDays > 0)


### PR DESCRIPTION
v7.5.1
- Fixed: Treat 'tvg-rec' catchup tag like the siptv 'timeshift' tag
- Fixed: Ensure channel's catchup window is used instead of value from settings
