### PR TITLE
Allow catchup correction (timezone shift) when live URLs have catchup placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ General settings required for the addon to function.
 * **Custom Radio Groups file**: The file used to load the custom Radio groups (groups). The default file is `customRadioGroups-example.xml`. Details on how to customise can be found in the next section of the README.
 
 ### EPG
-Settings related to the EPG.
+Settings related to the EPG. Note that Kodi will only load the EPG data when it needs to. The add-on will force a load of the EPG data regardless of whether or not Kodi requests it if either catchup is enabled or XMLTV logos are required.
 
 For settings related to genres please see the next section.
 

--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="7.6.1"
+  version="7.6.2"
   name="PVR IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@
@@ -169,6 +169,10 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v7.6.2
+- Fixed: Allow catchup correction (timezone shift) when live URLs have catchup placeholders
+- Fixed: Always load EPG data if we prefer XMLTV logos or catchup is enabled
+
 v7.6.1
 - Fixed: Allow ignoring M3U logos when using local logo path
 

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,7 @@
+v7.6.2
+- Fixed: Allow catchup correction (timezone shift) when live URLs have catchup placeholders
+- Fixed: Always load EPG data if we prefer XMLTV logos or catchup is enabled
+
 v7.6.1
 - Fixed: Allow ignoring M3U logos when using local logo path
 

--- a/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
@@ -692,7 +692,7 @@ msgstr ""
 
 #. help-category: EPG Settings
 msgctxt "#30620"
-msgid "Settings related to the EPG."
+msgid "Settings related to the EPG. Note that Kodi will only load the EPG data when it needs to. The add-on will force a load of the EPG data regardless of whether or not Kodi requests it if either catchup is enabled or XMLTV logos are required."
 msgstr ""
 
 #. help: EPG Settings - epgPathType

--- a/src/PVRIptvData.cpp
+++ b/src/PVRIptvData.cpp
@@ -191,7 +191,7 @@ PVR_ERROR PVRIptvData::GetChannelStreamProperties(const kodi::addon::PVRChannel&
     if (!catchupUrl.empty())
       streamURL = catchupUrl;
     else
-      streamURL = m_catchupController.ProcessStreamUrl(streamURL);
+      streamURL = m_catchupController.ProcessStreamUrl(m_currentChannel);
 
     StreamUtils::SetAllStreamProperties(properties, m_currentChannel, streamURL, catchupUrl.empty(), catchupProperties);
 

--- a/src/iptvsimple/CatchupController.h
+++ b/src/iptvsimple/CatchupController.h
@@ -34,7 +34,7 @@ namespace iptvsimple
 
     std::string GetCatchupUrlFormatString(const data::Channel& channel) const;
     std::string GetCatchupUrl(const data::Channel& channel) const;
-    std::string ProcessStreamUrl(const std::string& streamUrl) const;
+    std::string ProcessStreamUrl(const data::Channel& channel) const;
 
     bool ControlsLiveStream() const { return m_controlsLiveStream; }
     void ResetCatchupState() { m_resetCatchupState = true; }

--- a/src/iptvsimple/Epg.cpp
+++ b/src/iptvsimple/Epg.cpp
@@ -46,11 +46,11 @@ bool Epg::Init(int epgMaxPastDays, int epgMaxFutureDays)
   SetEPGMaxPastDays(epgMaxPastDays);
   SetEPGMaxFutureDays(epgMaxFutureDays);
 
-  if (Settings::GetInstance().IsCatchupEnabled())
+  if (Settings::GetInstance().AlwaysLoadEPGData())
   {
-    // For catchup we need a local store of the EPG data. Kodi may not load the
-    // data on each startup so we need to make sure it's loaded whether or not
-    // kodi considers it necessary.
+    // Kodi may not load the data on each startup so we need to make sure it's loaded whether
+    // or not kodi considers it necessary when either 1) we need the EPG logos or 2) for
+    // catchup we need a local store of the EPG data
     time_t now = std::time(nullptr);
     LoadEPG(now - m_epgMaxPastDaysSeconds, now + m_epgMaxFutureDaysSeconds);
   }

--- a/src/iptvsimple/Settings.h
+++ b/src/iptvsimple/Settings.h
@@ -117,6 +117,7 @@ namespace iptvsimple
     float GetEpgTimeshiftHours() const { return m_epgTimeShiftHours; }
     int GetEpgTimeshiftSecs() const { return static_cast<int>(m_epgTimeShiftHours * 60 * 60); }
     bool GetTsOverride() const { return m_tsOverride; }
+    bool AlwaysLoadEPGData() const { return m_epgLogosMode == EpgLogosMode::PREFER_XMLTV || IsCatchupEnabled(); }
 
     const std::string& GetGenresLocation() const { return m_genresPathType == PathType::REMOTE_PATH ? m_genresUrl : m_genresPath; }
     bool UseEpgGenreTextWhenMapping() const { return m_useEpgGenreTextWhenMapping; }


### PR DESCRIPTION
v7.6.2
- Fixed: Allow catchup correction (timezone shift) when live URLs have catchup placeholders
- Fixed: Always load EPG data if we prefer XMLTV logos or catchup is enabled