### PR TITLE
Fix absolute logo path

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="7.6.2"
+  version="7.6.3"
   name="PVR IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@
@@ -169,6 +169,10 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v7.6.3
+- Fixed: Only use Local logo location if file is relative
+- Fixed: Add string initialisation from macros as some linux fail to compile without it
+
 v7.6.2
 - Fixed: Allow catchup correction (timezone shift) when live URLs have catchup placeholders
 - Fixed: Always load EPG data if we prefer XMLTV logos or catchup is enabled

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,7 @@
+v7.6.3
+- Fixed: Only use Local logo location if file is relative
+- Fixed: Add string initialisation from macros as some linux fail to compile without it
+
 v7.6.2
 - Fixed: Allow catchup correction (timezone shift) when live URLs have catchup placeholders
 - Fixed: Always load EPG data if we prefer XMLTV logos or catchup is enabled

--- a/src/PVRIptvData.cpp
+++ b/src/PVRIptvData.cpp
@@ -98,7 +98,8 @@ PVR_ERROR PVRIptvData::GetBackendName(std::string& name)
 }
 PVR_ERROR PVRIptvData::GetBackendVersion(std::string& version)
 {
-  version = STR(IPTV_VERSION);
+  // Some linux platform require the full string initialisation here to compile. No idea why.
+  version = std::string(STR(IPTV_VERSION));
   return PVR_ERROR_NO_ERROR;
 }
 PVR_ERROR PVRIptvData::GetConnectionString(std::string& connection)

--- a/src/iptvsimple/data/Channel.cpp
+++ b/src/iptvsimple/data/Channel.cpp
@@ -17,6 +17,7 @@
 #include <regex>
 
 #include <kodi/General.h>
+#include <kodi/Filesystem.h>
 #include <kodi/tools/StringUtils.h>
 
 using namespace kodi::tools;
@@ -134,7 +135,8 @@ void Channel::SetIconPathFromTvgLogo(const std::string& tvgLogo, std::string& ch
   if (m_iconPath.find("://") == std::string::npos)
   {
     const std::string& logoLocation = Settings::GetInstance().GetLogoLocation();
-    if (!logoLocation.empty())
+    // If the file does not exist it must be relative
+    if (!logoLocation.empty() && !kodi::vfs::FileExists(m_iconPath))
     {
       // not absolute path, only append .png in this case.
       m_iconPath = utilities::FileUtils::PathCombine(logoLocation, m_iconPath);


### PR DESCRIPTION
v7.6.3
- Fixed: Only use Local logo location if file is relative
- Fixed: Add string initialisation from macros as some linux fail to compile without it