### PR TITLE
changelog and version v7.6.4

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="7.6.3"
+  version="7.6.4"
   name="PVR IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@
@@ -169,9 +169,12 @@
       <icon>icon.png</icon>
     </assets>
     <news>
-v7.6.3
+v7.6.4
 - Fixed: Only use Local logo location if file is relative
 - Fixed: Add string initialisation from macros as some linux fail to compile without it
+
+v7.6.3
+- Skipped
 
 v7.6.2
 - Fixed: Allow catchup correction (timezone shift) when live URLs have catchup placeholders

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,6 +1,9 @@
-v7.6.3
+v7.6.4
 - Fixed: Only use Local logo location if file is relative
 - Fixed: Add string initialisation from macros as some linux fail to compile without it
+
+v7.6.3
+- Skipped
 
 v7.6.2
 - Fixed: Allow catchup correction (timezone shift) when live URLs have catchup placeholders


### PR DESCRIPTION
v7.6.4
- Fixed: Only use Local logo location if file is relative
- Fixed: Add string initialisation from macros as some linux fail to compile without it