### PR TITLE
Fix: Allow embedded commas in channel name in M3U

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="7.6.4"
+  version="7.6.5"
   name="PVR IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@
@@ -169,6 +169,9 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v7.6.5
+- Fixed: Allow embedded commas in channel name in M3U
+
 v7.6.4
 - Fixed: Only use Local logo location if file is relative
 - Fixed: Add string initialisation from macros as some linux fail to compile without it

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v7.6.5
+- Fixed: Allow embedded commas in channel name in M3U
+
 v7.6.4
 - Fixed: Only use Local logo location if file is relative
 - Fixed: Add string initialisation from macros as some linux fail to compile without it

--- a/src/iptvsimple/PlaylistLoader.cpp
+++ b/src/iptvsimple/PlaylistLoader.cpp
@@ -198,9 +198,25 @@ bool PlaylistLoader::LoadPlayList()
 
 std::string PlaylistLoader::ParseIntoChannel(const std::string& line, Channel& channel, std::vector<int>& groupIdList, int epgTimeShift, int catchupCorrectionSecs, bool xeevCatchup)
 {
-  // parse line
   size_t colonIndex = line.find(':');
-  size_t commaIndex = line.rfind(',');
+  size_t commaIndex = line.rfind(','); //default to last comma on line in case we don't find a better match
+
+  size_t lastQuoteIndex = line.rfind('"');
+  if (lastQuoteIndex != std::string::npos)
+  {
+    // This is a better way to find the correct comma in
+    // case there is a comma embedded in the channel name
+    std::string possibleName = line.substr(lastQuoteIndex + 1);
+    std::string commaName = possibleName;
+    StringUtils::Trim(commaName);
+
+    if (StringUtils::StartsWith(commaName, ","))
+    {
+      commaIndex = lastQuoteIndex + possibleName.find(',') + 1;
+      std::string temp = line.substr(commaIndex + 1);
+    }
+  }
+
   if (colonIndex != std::string::npos && commaIndex != std::string::npos && commaIndex > colonIndex)
   {
     // parse name


### PR DESCRIPTION
v7.6.5
- Fixed: Allow embedded commas in channel name in M3U
