### PR TITLE
Fix <date> parsing only year to firstAired

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="7.6.10"
+  version="7.6.11"
   name="PVR IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@
@@ -21,6 +21,9 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v7.6.11
+- Fixed: EPG date entry only parsing year
+
 v7.6.10
 - Fixed: Fix episode number when there is no season
 - Fixed: Return server error if channels or groups could not be loaded due to missing file so they are not cleared in Kodi

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v7.6.11
+- Fixed: EPG date entry only parsing year
+
 v7.6.10
 - Fixed: Fix episode number when there is no season
 - Fixed: Return server error if channels or groups could not be loaded due to missing file so they are not cleared in Kodi

--- a/src/iptvsimple/data/EpgEntry.cpp
+++ b/src/iptvsimple/data/EpgEntry.cpp
@@ -152,7 +152,7 @@ std::string ParseAsW3CDateString(const std::string& strDate)
 
   std::sscanf(strDate.c_str(), "%04d%02d%02d", &year, &mon, &mday);
 
-  return StringUtils::Format("%04d%-02d%-02d", year, mon, mday);
+  return StringUtils::Format("%04d-%02d-%02d", year, mon, mday);
 }
 
 std::string ParseAsW3CDateString(time_t time)


### PR DESCRIPTION
wrong format template causing only the year to be picked up by kodi

This will also be stopping any epg entries being marked as "new"
as this line currently will always be false: https://github.com/kodi-pvr/pvr.iptvsimple/blob/Matrix/src/iptvsimple/data/EpgEntry.cpp#L230

Before:
![screenshot00003](https://user-images.githubusercontent.com/6225961/132900988-00dd390c-1118-4c1c-8d42-004d2516cd97.png)
After:
![screenshot00002](https://user-images.githubusercontent.com/6225961/132900997-71a38755-9f55-48c5-951d-434c3302d61b.png)

(need to PVR > Clear data after updating)