### PR TITLE
Fix new comparision and don't set year for TV shows as it will usually be wrong

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="7.6.11"
+  version="7.6.12"
   name="PVR IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@
@@ -21,6 +21,10 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v7.6.12
+- Fixed: Always compare to the raw start date and not the localised time to detect NEW programmes
+- Fixed: Do not set year if this programme is a TV show
+
 v7.6.11
 - Fixed: EPG date entry only parsing year
 

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v7.6.12
+- Fixed: Always compare to the raw start date and not the localised time to detect NEW programmes
+
 v7.6.11
 - Fixed: EPG date entry only parsing year
 

--- a/src/iptvsimple/data/EpgEntry.cpp
+++ b/src/iptvsimple/data/EpgEntry.cpp
@@ -227,7 +227,8 @@ bool EpgEntry::UpdateFrom(const xml_node& channelNode, const std::string& id,
     if (std::regex_match(dateString, dateRegex))
     {
       m_firstAired = ParseAsW3CDateString(dateString);
-      if (m_firstAired == ParseAsW3CDateString(m_startTime))
+      // Always compare to the raw string date value to avoid timezone issues
+      if (m_firstAired == ParseAsW3CDateString(strStart))
         m_new = true;
     }
 

--- a/src/iptvsimple/data/EpgEntry.cpp
+++ b/src/iptvsimple/data/EpgEntry.cpp
@@ -256,7 +256,14 @@ bool EpgEntry::UpdateFrom(const xml_node& channelNode, const std::string& id,
   }
 
   if (!episodeNumbersList.empty())
+  {
     ParseEpisodeNumberInfo(episodeNumbersList);
+
+    // If we don't have a season or episode number don't set the year as it's a TV show
+    // For TV show year usually represents the year of S01E01 which we don't have
+    if (m_episodeNumber != EPG_TAG_INVALID_SERIES_EPISODE || m_seasonNumber != EPG_TAG_INVALID_SERIES_EPISODE)
+      m_year = 0;
+  }
 
   const auto& creditsNode = channelNode.child("credits");
   if (creditsNode)


### PR DESCRIPTION
v7.6.12
- Fixed: Always compare to the raw start date and not the localised time to detect NEW programmes
- Fixed: Don't set year if this programme is a TV show