### PR TITLE
use tz aware <date> for m_firstAired

### DIFF
--- a/src/iptvsimple/data/EpgEntry.cpp
+++ b/src/iptvsimple/data/EpgEntry.cpp
@@ -226,10 +226,18 @@ bool EpgEntry::UpdateFrom(const xml_node& channelNode, const std::string& id,
     static const std::regex dateRegex("^[1-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]");
     if (std::regex_match(dateString, dateRegex))
     {
-      m_firstAired = ParseAsW3CDateString(dateString);
-      // Always compare to the raw string date value to avoid timezone issues
-      if (m_firstAired == ParseAsW3CDateString(strStart))
-        m_new = true;
+      long long tmpDate = ParseDateTime(dateString.substr(0,8) + strStart.substr(8));
+      // Windows localtime_s does not support negative time_t
+      if (tmpDate < 0)
+      {
+        m_firstAired = ParseAsW3CDateString(dateString);
+        m_new = m_firstAired == ParseAsW3CDateString(strStart);
+      }
+      else
+      {
+        m_firstAired = ParseAsW3CDateString(static_cast<time_t>(tmpDate));
+        m_new = m_firstAired == ParseAsW3CDateString(m_startTime);
+      }
     }
 
     std::sscanf(dateString.c_str(), "%04d", &m_year);


### PR DESCRIPTION
Fixes: https://github.com/kodi-pvr/pvr.iptvsimple/issues/553

Before
![before](https://user-images.githubusercontent.com/6225961/132947337-54febcbb-7d92-4098-843f-675b08f7ba65.png)
After
![after](https://user-images.githubusercontent.com/6225961/132947338-aed0c18b-bdf1-4bc7-b807-d4da83fb9e97.png)
