### PR TITLE
Changelog and version for v7.6.13

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="7.6.12"
+  version="7.6.13"
   name="PVR IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@
@@ -21,6 +21,9 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v7.6.13
+- Fixed: Apply timezone for first aired date if after 1970
+
 v7.6.12
 - Fixed: Always compare to the raw start date and not the localised time to detect NEW programmes
 - Fixed: Do not set year if this programme is a TV show

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v7.6.13
+- Fixed: Apply timezone for first aired date if after 1970
+
 v7.6.12
 - Fixed: Always compare to the raw start date and not the localised time to detect NEW programmes
 - Fixed: Do not set year if this programme is a TV show

--- a/src/iptvsimple/data/EpgEntry.cpp
+++ b/src/iptvsimple/data/EpgEntry.cpp
@@ -226,8 +226,8 @@ bool EpgEntry::UpdateFrom(const xml_node& channelNode, const std::string& id,
     static const std::regex dateRegex("^[1-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]");
     if (std::regex_match(dateString, dateRegex))
     {
-      long long tmpDate = ParseDateTime(dateString.substr(0,8) + strStart.substr(8));
-      // Windows localtime_s does not support negative time_t
+      long long tmpDate = ParseDateTime(dateString.substr(0, DATESTRING_LENGTH) + strStart.substr(DATESTRING_LENGTH));
+      // Protect against negative time_t which can crash on some platforms such as localtime_s on Windows
       if (tmpDate < 0)
       {
         m_firstAired = ParseAsW3CDateString(dateString);

--- a/src/iptvsimple/data/EpgEntry.h
+++ b/src/iptvsimple/data/EpgEntry.h
@@ -21,6 +21,7 @@ namespace iptvsimple
   namespace data
   {
     static const float STAR_RATING_SCALE = 10.0f;
+    constexpr int DATESTRING_LENGTH = 8;
 
     class EpgEntry
     {


### PR DESCRIPTION
v7.6.13
- Fixed: Apply timezone for first aired date if after 1970