### PR TITLE
Default player for ffmpegdirect - matrix

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="19.0.0"
+  version="19.0.1"
   name="PVR IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@
@@ -21,6 +21,9 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v19.0.1
+- Set default player as VideoPlayer for ffmpegdirect so Timeshift works for PVR Radio
+
 v19.0.0
 - Changed: Test builds to 'Kodi 19 Matrix'
 - Increased version to 19.0.0

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v19.0.1
+- Set default player as VideoPlayer for ffmpegdirect so Timeshift works for PVR Radio
+
 v19.0.0
 - Changed: Test builds to 'Kodi 19 Matrix'
 - Increased version to 19.0.0

--- a/src/iptvsimple/utilities/StreamUtils.cpp
+++ b/src/iptvsimple/utilities/StreamUtils.cpp
@@ -54,12 +54,16 @@ void StreamUtils::SetAllStreamProperties(std::vector<kodi::addon::PVRStreamPrope
             CheckInputstreamInstalledAndEnabled(CATCHUP_INPUTSTREAM_NAME))
         {
           properties.emplace_back(PVR_STREAM_PROPERTY_INPUTSTREAM, CATCHUP_INPUTSTREAM_NAME);
+          // this property is required to force VideoPlayer for Radio channels
+          properties.emplace_back("inputstream-player", "videodefaultplayer");
           SetFFmpegDirectManifestTypeStreamProperty(properties, channel, streamURL, streamType);
         }
         else if (channel.SupportsLiveStreamTimeshifting() && isChannelURL &&
                  CheckInputstreamInstalledAndEnabled(INPUTSTREAM_FFMPEGDIRECT))
         {
           properties.emplace_back(PVR_STREAM_PROPERTY_INPUTSTREAM, INPUTSTREAM_FFMPEGDIRECT);
+          // this property is required to force VideoPlayer for Radio channels
+          properties.emplace_back("inputstream-player", "videodefaultplayer");
           SetFFmpegDirectManifestTypeStreamProperty(properties, channel, streamURL, streamType);
           properties.emplace_back("inputstream.ffmpegdirect.stream_mode", "timeshift");
           properties.emplace_back("inputstream.ffmpegdirect.is_realtime_stream", "true");


### PR DESCRIPTION
v19.0.1
- Set default player as VideoPlayer for ffmpegdirect so Timeshift works for PVR Radio