### PR TITLE
Remove redundant PVR from add-on name

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="20.2.0"
-  name="PVR IPTV Simple Client"
+  version="20.2.1"
+  name="IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@
     <import addon="inputstream.ffmpegdirect" minversion="1.19.0"/>

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v20.2.1
+- Remove redundant PVR from addon name
+
 v20.2.0
 - Translation updates by Weblate
 - Kodi main API update to version 2.0.0


### PR DESCRIPTION
v20.2.1
- Remove redundant PVR from addon name

It just makes it hard when scanning the list of PVR clients.