### PR TITLE
Default stream type

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="20.2.1"
+  version="20.3.0"
   name="IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,11 @@
+v20.3.0
+- Choose a suitable default stream type for default and append catchup modes
+- Allow catchup tags in M3U header
+- Update flussonic catchup type strings
+- For flussonic catchup add support for generic stream types (where any dir name is used after channel id)
+- Support alternative tag name for channel number
+- Fix incorrect provider mappings file path
+
 v20.2.1
 - Remove redundant PVR from addon name
 

--- a/pvr.iptvsimple/resources/settings.xml
+++ b/pvr.iptvsimple/resources/settings.xml
@@ -122,7 +122,7 @@
         </setting>
         <setting id="providerMappingFile" type="path" parent="enableProviderMapping" label="30009" help="30472">
           <level>2</level>
-          <default>special://userdata/addon_data/pvr.iptvsimple/providers/providersMappings.xml</default>
+          <default>special://userdata/addon_data/pvr.iptvsimple/providers/providerMappings.xml</default>
           <constraints>
             <allowempty>false</allowempty>
             <writable>false</writable>

--- a/src/iptvsimple/PlaylistLoader.cpp
+++ b/src/iptvsimple/PlaylistLoader.cpp
@@ -306,6 +306,10 @@ std::string PlaylistLoader::ParseIntoChannel(const std::string& line, Channel& c
       strTvgId.append(buff);
     }
 
+    // If don't have a channel number try another format
+    if (strChnlNo.empty())
+      ReadMarkerValue(infoLine, CHANNEL_NUMBER_MARKER);
+
     if (!strChnlNo.empty() && !Settings::GetInstance().NumberChannelsByM3uOrderOnly())
     {
       size_t found = strChnlNo.find('.');

--- a/src/iptvsimple/PlaylistLoader.cpp
+++ b/src/iptvsimple/PlaylistLoader.cpp
@@ -345,8 +345,9 @@ std::string PlaylistLoader::ParseIntoChannel(const std::string& line, Channel& c
 
     if (StringUtils::EqualsNoCase(strCatchup, "default") || StringUtils::EqualsNoCase(strCatchup, "append") ||
         StringUtils::EqualsNoCase(strCatchup, "shift") || StringUtils::EqualsNoCase(strCatchup, "flussonic") ||
-        StringUtils::EqualsNoCase(strCatchup, "flussonic-ts") || StringUtils::EqualsNoCase(strCatchup, "fs") ||
-        StringUtils::EqualsNoCase(strCatchup, "xc") || StringUtils::EqualsNoCase(strCatchup, "vod"))
+        StringUtils::EqualsNoCase(strCatchup, "flussonic-hls") || StringUtils::EqualsNoCase(strCatchup, "flussonic-ts") ||
+        StringUtils::EqualsNoCase(strCatchup, "fs") || StringUtils::EqualsNoCase(strCatchup, "xc") ||
+        StringUtils::EqualsNoCase(strCatchup, "vod"))
       channel.SetHasCatchup(true);
 
     if (StringUtils::EqualsNoCase(strCatchup, "default"))
@@ -355,12 +356,16 @@ std::string PlaylistLoader::ParseIntoChannel(const std::string& line, Channel& c
       channel.SetCatchupMode(CatchupMode::APPEND);
     else if (StringUtils::EqualsNoCase(strCatchup, "shift"))
       channel.SetCatchupMode(CatchupMode::SHIFT);
-    else if (StringUtils::EqualsNoCase(strCatchup, "flussonic") || StringUtils::EqualsNoCase(strCatchup, "flussonic-ts") || StringUtils::EqualsNoCase(strCatchup, "fs"))
+    else if (StringUtils::EqualsNoCase(strCatchup, "flussonic") || StringUtils::EqualsNoCase(strCatchup, "flussonic-hls") ||
+             StringUtils::EqualsNoCase(strCatchup, "flussonic-ts") || StringUtils::EqualsNoCase(strCatchup, "fs"))
       channel.SetCatchupMode(CatchupMode::FLUSSONIC);
     else if (StringUtils::EqualsNoCase(strCatchup, "xc"))
       channel.SetCatchupMode(CatchupMode::XTREAM_CODES);
     else if (StringUtils::EqualsNoCase(strCatchup, "vod"))
       channel.SetCatchupMode(CatchupMode::VOD);
+
+    if (StringUtils::EqualsNoCase(strCatchup, "flussonic-ts") || StringUtils::EqualsNoCase(strCatchup, "fs"))
+      channel.SetCatchupTSStream(true);
 
     if (!channel.HasCatchup() && xeevCatchup && (StringUtils::StartsWith(channelName, "* ") || StringUtils::StartsWith(channelName, "[+] ")))
     {

--- a/src/iptvsimple/PlaylistLoader.h
+++ b/src/iptvsimple/PlaylistLoader.h
@@ -29,6 +29,7 @@ namespace iptvsimple
   static const std::string TVG_INFO_LOGO_MARKER    = "tvg-logo=";
   static const std::string TVG_INFO_SHIFT_MARKER   = "tvg-shift=";
   static const std::string TVG_INFO_CHNO_MARKER    = "tvg-chno=";
+  static const std::string CHANNEL_NUMBER_MARKER   = "ch-number=";
   static const std::string TVG_INFO_REC            = "tvg-rec="; // some providers use 'tvg-rec' instead of 'catchup-days'
   static const std::string GROUP_NAME_MARKER       = "group-title=";
   static const std::string CATCHUP                 = "catchup=";
@@ -58,7 +59,7 @@ namespace iptvsimple
         std::string m_catchup;
         std::string m_catchupDays;
         std::string m_catchupSource;
-    };    
+    };
 
   public:
     PlaylistLoader(kodi::addon::CInstancePVRClient* client, iptvsimple::Channels& channels,

--- a/src/iptvsimple/PlaylistLoader.h
+++ b/src/iptvsimple/PlaylistLoader.h
@@ -53,6 +53,13 @@ namespace iptvsimple
 
   class PlaylistLoader
   {
+    struct M3UHeaderStrings {
+        // members will be public without `private:` keyword
+        std::string m_catchup;
+        std::string m_catchupDays;
+        std::string m_catchupSource;
+    };    
+
   public:
     PlaylistLoader(kodi::addon::CInstancePVRClient* client, iptvsimple::Channels& channels,
                    iptvsimple::ChannelGroups& channelGroups, iptvsimple::Providers& providers,
@@ -78,5 +85,7 @@ namespace iptvsimple
     iptvsimple::Channels& m_channels;
     iptvsimple::Media& m_media;
     kodi::addon::CInstancePVRClient* m_client;
+
+    M3UHeaderStrings m_m3uHeaderStrings;
   };
 } //namespace iptvsimple

--- a/src/iptvsimple/data/Channel.cpp
+++ b/src/iptvsimple/data/Channel.cpp
@@ -435,12 +435,15 @@ bool Channel::GenerateFlussonicCatchupSource(const std::string& url)
   // catchup: http://list.tv:8888/325/timeshift_rel-{offset:1}.m3u8?token=secret
   // stream:  http://list.tv:8888/325/mono.m3u8?token=secret
   // catchup: http://list.tv:8888/325/mono-timeshift_rel-{offset:1}.m3u8?token=secret
+  // stream:  http://list.tv:8888/325/live?token=my_token
+  // catchup: http://list.tv:8888/325/{utc}.ts?token=my_token
 
   static std::regex fsRegex("^(http[s]?://[^/]+)/(.*)/([^/]*)(mpegts|\\.m3u8)(\\?.+=.+)?$");
   std::smatch matches;
 
   if (std::regex_match(url, matches, fsRegex))
   {
+    // This is path for well defined stream naming
     if (matches.size() == 6)
     {
       const std::string fsHost = matches[1].str();
@@ -463,6 +466,31 @@ bool Channel::GenerateFlussonicCatchupSource(const std::string& url)
       }
 
       return true;
+    }
+  }
+  else
+  {
+    // Flussonic servers will return a stream with any directory name after the channel id
+    // so we handle this case separately
+    static std::regex genericRegex("^(http[s]?://[^/]+)/(.*)/([^\\?]*)(\\?.+=.+)?$");
+    std::smatch genericMmatches;
+
+    if (std::regex_match(url, genericMmatches, genericRegex))
+    {
+      if (genericMmatches.size() == 5)
+      {
+        const std::string fsHost = genericMmatches[1].str();
+        const std::string fsChannelId = genericMmatches[2].str();
+        const std::string fsStreamType = genericMmatches[3].str();
+        const std::string fsUrlAppend = genericMmatches[4].str();
+
+        if (m_isCatchupTSStream) // the catchup type was "flussonic-ts" or "fs"
+          m_catchupSource = fsHost + "/" + fsChannelId + "/timeshift_abs-${start}.ts" + fsUrlAppend;
+        else // the catchup type was "flussonic" or "flussonic-hls"
+          m_catchupSource = fsHost + "/" + fsChannelId + "/timeshift_rel-{offset:1}.m3u8" + fsUrlAppend;
+
+        return true;
+      }
     }
   }
 

--- a/src/iptvsimple/utilities/StreamUtils.cpp
+++ b/src/iptvsimple/utilities/StreamUtils.cpp
@@ -256,8 +256,10 @@ const StreamType StreamUtils::InspectStreamType(const std::string& url, const Ch
       return StreamType::SMOOTH_STREAMING;
   }
 
-  // If we can't inspect the stream type the only option left for shift mode is TS
-  if (channel.GetCatchupMode() == CatchupMode::SHIFT ||
+  // If we can't inspect the stream type the only option left for default, append or shift mode is TS
+  if (channel.GetCatchupMode() == CatchupMode::DEFAULT ||
+      channel.GetCatchupMode() == CatchupMode::APPEND ||
+      channel.GetCatchupMode() == CatchupMode::SHIFT ||
       channel.GetCatchupMode() == CatchupMode::TIMESHIFT)
     return StreamType::TS;
 


### PR DESCRIPTION
v20.3.0
- Choose a suitable default stream type for default and append catchup modes
- Allow catchup tags in M3U header
- Update flussonic catchup type strings
- For flussonic catchup add support for generic stream types (where any dir name is used after channel id)
- Support alternative tag name for channel number
