### PR TITLE
Default stream type matrix

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="19.0.3"
+  version="19.1.0"
   name="PVR IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@
@@ -21,6 +21,13 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v19.1.0
+- Choose a suitable default stream type for default and append catchup modes
+- Allow catchup tags in M3U header
+- Update flussonic catchup type strings
+- For flussonic catchup add support for generic stream types (where any dir name is used after channel id)
+- Support alternative tag name for channel number
+
 v19.0.3
 - Translations updates from Weblate
 	- da_dk, es_mx, et_ee, hu_hu, lt_lt, nl_nl, pl_pl, zh_cn, zh_tw

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,10 @@
+v19.1.0
+- Choose a suitable default stream type for default and append catchup modes
+- Allow catchup tags in M3U header
+- Update flussonic catchup type strings
+- For flussonic catchup add support for generic stream types (where any dir name is used after channel id)
+- Support alternative tag name for channel number
+
 v19.0.3
 - Translations updates from Weblate
 	- da_dk, es_mx, et_ee, hu_hu, lt_lt, nl_nl, pl_pl, zh_cn, zh_tw

--- a/src/iptvsimple/PlaylistLoader.cpp
+++ b/src/iptvsimple/PlaylistLoader.cpp
@@ -312,8 +312,9 @@ std::string PlaylistLoader::ParseIntoChannel(const std::string& line, Channel& c
 
     if (StringUtils::EqualsNoCase(strCatchup, "default") || StringUtils::EqualsNoCase(strCatchup, "append") ||
         StringUtils::EqualsNoCase(strCatchup, "shift") || StringUtils::EqualsNoCase(strCatchup, "flussonic") ||
-        StringUtils::EqualsNoCase(strCatchup, "flussonic-ts") || StringUtils::EqualsNoCase(strCatchup, "fs") ||
-        StringUtils::EqualsNoCase(strCatchup, "xc") || StringUtils::EqualsNoCase(strCatchup, "vod"))
+        StringUtils::EqualsNoCase(strCatchup, "flussonic-hls") || StringUtils::EqualsNoCase(strCatchup, "flussonic-ts") ||
+        StringUtils::EqualsNoCase(strCatchup, "fs") || StringUtils::EqualsNoCase(strCatchup, "xc") ||
+        StringUtils::EqualsNoCase(strCatchup, "vod"))
       channel.SetHasCatchup(true);
 
     if (StringUtils::EqualsNoCase(strCatchup, "default"))
@@ -322,12 +323,16 @@ std::string PlaylistLoader::ParseIntoChannel(const std::string& line, Channel& c
       channel.SetCatchupMode(CatchupMode::APPEND);
     else if (StringUtils::EqualsNoCase(strCatchup, "shift"))
       channel.SetCatchupMode(CatchupMode::SHIFT);
-    else if (StringUtils::EqualsNoCase(strCatchup, "flussonic") || StringUtils::EqualsNoCase(strCatchup, "flussonic-ts") || StringUtils::EqualsNoCase(strCatchup, "fs"))
+    else if (StringUtils::EqualsNoCase(strCatchup, "flussonic") || StringUtils::EqualsNoCase(strCatchup, "flussonic-hls") ||
+             StringUtils::EqualsNoCase(strCatchup, "flussonic-ts") || StringUtils::EqualsNoCase(strCatchup, "fs"))
       channel.SetCatchupMode(CatchupMode::FLUSSONIC);
     else if (StringUtils::EqualsNoCase(strCatchup, "xc"))
       channel.SetCatchupMode(CatchupMode::XTREAM_CODES);
     else if (StringUtils::EqualsNoCase(strCatchup, "vod"))
       channel.SetCatchupMode(CatchupMode::VOD);
+
+    if (StringUtils::EqualsNoCase(strCatchup, "flussonic-ts") || StringUtils::EqualsNoCase(strCatchup, "fs"))
+      channel.SetCatchupTSStream(true);
 
     if (!channel.HasCatchup() && xeevCatchup && (StringUtils::StartsWith(channelName, "* ") || StringUtils::StartsWith(channelName, "[+] ")))
     {

--- a/src/iptvsimple/PlaylistLoader.cpp
+++ b/src/iptvsimple/PlaylistLoader.cpp
@@ -273,6 +273,10 @@ std::string PlaylistLoader::ParseIntoChannel(const std::string& line, Channel& c
       strTvgId.append(buff);
     }
 
+    // If don't have a channel number try another format
+    if (strChnlNo.empty())
+      ReadMarkerValue(infoLine, CHANNEL_NUMBER_MARKER);
+
     if (!strChnlNo.empty() && !Settings::GetInstance().NumberChannelsByM3uOrderOnly())
     {
       size_t found = strChnlNo.find('.');

--- a/src/iptvsimple/PlaylistLoader.cpp
+++ b/src/iptvsimple/PlaylistLoader.cpp
@@ -101,10 +101,22 @@ bool PlaylistLoader::LoadPlayList()
           catchupCorrectionSecs = static_cast<int>(catchupCorrectionDecimal * 3600.0);
         }
 
-        std::string strXeevCatchup = ReadMarkerValue(line, CATCHUP);
-        if (strXeevCatchup == "xc")
+        //
+        // If there are catchup values in the M3U header we read them to be used as defaults later on
+        //
+        m_m3uHeaderStrings.m_catchup = ReadMarkerValue(line, CATCHUP);
+        // There is some xeev specific functionality if specificed in the header
+        if (m_m3uHeaderStrings.m_catchup == "xc")
           xeevCatchup = true;
+        // Some providers use a 'catchup-type' tag instead of 'catchup'
+        if (m_m3uHeaderStrings.m_catchup.empty())
+          m_m3uHeaderStrings.m_catchup = ReadMarkerValue(line, CATCHUP_TYPE);
+        m_m3uHeaderStrings.m_catchupDays = ReadMarkerValue(line, CATCHUP_DAYS);
+        m_m3uHeaderStrings.m_catchupSource = ReadMarkerValue(line, CATCHUP_SOURCE);
 
+        //
+        // Read either of the M3U header based EPG xmltv urls
+        //
         std::string tvgUrl = ReadMarkerValue(line, TVG_URL_MARKER);
         if (tvgUrl.empty())
           tvgUrl = ReadMarkerValue(line, TVG_URL_OTHER_MARKER);
@@ -247,6 +259,9 @@ std::string PlaylistLoader::ParseIntoChannel(const std::string& line, Channel& c
     // Some providers use a 'catchup-type' tag instead of 'catchup'
     if (strCatchup.empty())
       strCatchup = ReadMarkerValue(infoLine, CATCHUP_TYPE);
+    // If we still don't have a value use the header supplied value if there is one
+    if (strCatchup.empty() && !m_m3uHeaderStrings.m_catchup.empty())
+      strCatchup = m_m3uHeaderStrings.m_catchup;
 
     if (strTvgId.empty())
       strTvgId = ReadMarkerValue(infoLine, TVG_INFO_ID_MARKER_UC);
@@ -278,6 +293,9 @@ std::string PlaylistLoader::ParseIntoChannel(const std::string& line, Channel& c
     channel.SetTvgId(strTvgId);
     channel.SetTvgName(strTvgName);
     channel.SetCatchupSource(strCatchupSource);
+    // If we still don't have a value use the header supplied value if there is one
+    if (strCatchupSource.empty() && !m_m3uHeaderStrings.m_catchupSource.empty())
+      strCatchupSource = m_m3uHeaderStrings.m_catchupSource;
     channel.SetTvgShift(static_cast<int>(tvgShiftDecimal * 3600.0));
     channel.SetRadio(isRadio);
     if (Settings::GetInstance().GetLogoPathType() == PathType::LOCAL_PATH && Settings::GetInstance().UseLocalLogosOnlyIgnoreM3U())
@@ -326,6 +344,9 @@ std::string PlaylistLoader::ParseIntoChannel(const std::string& line, Channel& c
 
     if (!strCatchupDays.empty())
       channel.SetCatchupDays(atoi(strCatchupDays.c_str()));
+    // If we still don't have a value use the header supplied value if there is one
+    else if (!m_m3uHeaderStrings.m_catchupSource.empty())
+      channel.SetCatchupDays(atoi(m_m3uHeaderStrings.m_catchupDays.c_str()));
     else if (channel.GetCatchupMode() == CatchupMode::VOD)
       channel.SetCatchupDays(IGNORE_CATCHUP_DAYS);
     else if (siptvTimeshiftDays > 0)

--- a/src/iptvsimple/PlaylistLoader.h
+++ b/src/iptvsimple/PlaylistLoader.h
@@ -43,6 +43,13 @@ namespace iptvsimple
 
   class PlaylistLoader
   {
+    struct M3UHeaderStrings {
+        // members will be public without `private:` keyword
+        std::string m_catchup;
+        std::string m_catchupDays;
+        std::string m_catchupSource;
+    };    
+
   public:
     PlaylistLoader(kodi::addon::CInstancePVRClient* client, iptvsimple::Channels& channels, iptvsimple::ChannelGroups& channelGroups);
 
@@ -64,5 +71,7 @@ namespace iptvsimple
     iptvsimple::ChannelGroups& m_channelGroups;
     iptvsimple::Channels& m_channels;
     kodi::addon::CInstancePVRClient* m_client;
+
+    M3UHeaderStrings m_m3uHeaderStrings;
   };
 } //namespace iptvsimple

--- a/src/iptvsimple/PlaylistLoader.h
+++ b/src/iptvsimple/PlaylistLoader.h
@@ -27,6 +27,7 @@ namespace iptvsimple
   static const std::string TVG_INFO_LOGO_MARKER    = "tvg-logo=";
   static const std::string TVG_INFO_SHIFT_MARKER   = "tvg-shift=";
   static const std::string TVG_INFO_CHNO_MARKER    = "tvg-chno=";
+  static const std::string CHANNEL_NUMBER_MARKER   = "ch-number=";
   static const std::string TVG_INFO_REC            = "tvg-rec="; // some providers use 'tvg-rec' instead of 'catchup-days'
   static const std::string GROUP_NAME_MARKER       = "group-title=";
   static const std::string CATCHUP                 = "catchup=";
@@ -48,7 +49,7 @@ namespace iptvsimple
         std::string m_catchup;
         std::string m_catchupDays;
         std::string m_catchupSource;
-    };    
+    };
 
   public:
     PlaylistLoader(kodi::addon::CInstancePVRClient* client, iptvsimple::Channels& channels, iptvsimple::ChannelGroups& channelGroups);

--- a/src/iptvsimple/utilities/StreamUtils.cpp
+++ b/src/iptvsimple/utilities/StreamUtils.cpp
@@ -256,8 +256,10 @@ const StreamType StreamUtils::InspectStreamType(const std::string& url, const Ch
       return StreamType::SMOOTH_STREAMING;
   }
 
-  // If we can't inspect the stream type the only option left for shift mode is TS
-  if (channel.GetCatchupMode() == CatchupMode::SHIFT ||
+  // If we can't inspect the stream type the only option left for default, append or shift mode is TS
+  if (channel.GetCatchupMode() == CatchupMode::DEFAULT ||
+      channel.GetCatchupMode() == CatchupMode::APPEND ||
+      channel.GetCatchupMode() == CatchupMode::SHIFT ||
       channel.GetCatchupMode() == CatchupMode::TIMESHIFT)
     return StreamType::TS;
 


### PR DESCRIPTION
v19.1.0
- Choose a suitable default stream type for default and append catchup modes
- Allow catchup tags in M3U header
- Update flussonic catchup type strings
- For flussonic catchup add support for generic stream types (where any dir name is used after channel id)
- Support alternative tag name for channel number