### PR TITLE
Fix "ch-number" tag being ignored - Nexus

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="20.3.0"
+  version="20.3.1"
   name="IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v20.3.1
+- Fix ch-number tag being ignored
+
 v20.3.0
 - Choose a suitable default stream type for default and append catchup modes
 - Allow catchup tags in M3U header

--- a/src/iptvsimple/PlaylistLoader.cpp
+++ b/src/iptvsimple/PlaylistLoader.cpp
@@ -308,7 +308,7 @@ std::string PlaylistLoader::ParseIntoChannel(const std::string& line, Channel& c
 
     // If don't have a channel number try another format
     if (strChnlNo.empty())
-      ReadMarkerValue(infoLine, CHANNEL_NUMBER_MARKER);
+      strChnlNo = ReadMarkerValue(infoLine, CHANNEL_NUMBER_MARKER);
 
     if (!strChnlNo.empty() && !Settings::GetInstance().NumberChannelsByM3uOrderOnly())
     {


### PR DESCRIPTION
v20.3.1
- Fix ch-number tag being ignored