### PR TITLE
Catchup duration keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ The format specifiers are substitution based and work as follows:
 - `{M}`: The minute (00-59) of the start date\time.
 - `{S}`: The second (00-59) of the start date\time.
 - `{duration}`: The programme duration + any start and end buffer (if set).
+- `${duration}`: Same as `{duration}`.
 - `{duration:X}`: The programme duration (as above) divided by X seconds. Allows conversion to minutes and other time units. The minimum divider is 1, it must be an integer (not 1.5 or 2.25 etc.) and it must be a positive value. E.g. If you have a duration of 7200 seconds and you need 2 hours (2 hours is 7200 seconds), it means your divider is 3600: `{duration:3600}`. If you need minutes for the same duration you could use: `{duration:60}` which would result in a value of 120.
 - `{offset:X}`: The current offset (now - start time) divided by X seconds. Allows conversion to minutes and other time units. The minimum divider is 1, it must be an integer (not 1.5 or 2.25 etc.) and it must be a positive value. E.g. If you need an offset of 720 for a start time of 2 hours ago (2 hours is 7200 seconds), it means your divider is 10: `{offset:10}`. If you need minutes for the same offset you could use: `{offset:60}` which would result in a value of 120.
 - `{catchup-id}`: A programme specific identifier required in the catchup URL, value loaded from XMLTV programme entries.

--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="20.3.1"
+  version="20.4.0"
   name="IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v20.4.0
+- Support ${duration} format specifier
+
 v20.3.1
 - Fix ch-number tag being ignored
 

--- a/src/iptvsimple/CatchupController.cpp
+++ b/src/iptvsimple/CatchupController.cpp
@@ -357,6 +357,7 @@ std::string FormatDateTime(time_t timeStart, time_t duration, const std::string 
   FormatUtc("{lutc}", timeNow, formattedUrl);
   FormatUtc("${now}", timeNow, formattedUrl);
   FormatUtc("${timestamp}", timeNow, formattedUrl);
+  FormatUtc("${duration}", duration, formattedUrl);
   FormatUtc("{duration}", duration, formattedUrl);
   FormatUnits("duration", duration, formattedUrl);
   FormatUtc("${offset}", timeNow - timeStart, formattedUrl);


### PR DESCRIPTION
The catchup string from my itpv provider looks like `http://example.com/channelname/video-${start}-${duration}.m3u8?token=xxxxxx` so I get a wrong address `http://example.com/channelname/video-1658199600-$15600.m3u8?token=xxxxxx` (with a redundant `$`), the proposed change should take into account this situation while not breaking the case in which only the `{duration}` keyword without `$` is used, which, as far as I understand, is a possible case as well.