### PR TITLE
Tvg logo unencoded

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="20.4.0"
+  version="20.5.0"
   name="IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v20.5.0
+- URL encode last part of tvg logo URL as they can be based on channel names and they can contain spaces and non standard characters not allowed in paths
+
 v20.4.0
 - Support ${duration} format specifier
 - Fix azure image to use Windows 2019 and VS 2019

--- a/src/iptvsimple/data/Channel.cpp
+++ b/src/iptvsimple/data/Channel.cpp
@@ -129,10 +129,29 @@ void Channel::SetIconPathFromTvgLogo(const std::string& tvgLogo, std::string& ch
 
   kodi::UnknownToUTF8(m_iconPath, m_iconPath);
 
-  // urlencode channel logo when set from channel name and source is Remote Path
-  // append extension as channel name wouldn't have it
+  // urlencode channel logo when set from channel name and source is Remote Path, append extension as channel wouldn't cover this
   if (logoSetFromChannelName && Settings::GetInstance().GetLogoPathType() == PathType::REMOTE_PATH)
+  {
     m_iconPath = utilities::WebUtils::UrlEncode(m_iconPath);
+  }
+  else if (m_iconPath.find("://") != std::string::npos)
+  {
+    // we also want to check the last part of a URL to ensure it's valid as quite often they are based on channel names
+    // the path should be fine
+
+    size_t pos = m_iconPath.find_last_of("/");
+    if (pos != std::string::npos)
+    {
+      const std::string urlPath = m_iconPath.substr(0, pos + 1);
+      std::string urlFile = m_iconPath.substr(pos + 1);
+      if (!utilities::WebUtils::IsEncoded(urlFile))
+      {
+        urlFile = utilities::WebUtils::UrlEncode(urlFile);
+
+        m_iconPath = urlPath + urlFile;
+      }
+    }
+  }
 
   if (m_iconPath.find("://") == std::string::npos)
   {

--- a/src/iptvsimple/utilities/WebUtils.cpp
+++ b/src/iptvsimple/utilities/WebUtils.cpp
@@ -42,6 +42,53 @@ const std::string WebUtils::UrlEncode(const std::string& value)
   return escaped.str();
 }
 
+namespace
+{
+
+char from_hex(char ch) {
+    return isdigit(ch) ? ch - '0' : tolower(ch) - 'a' + 10;
+}
+
+} // unamed namespace
+
+const std::string WebUtils::UrlDecode(const std::string& value)
+{
+  char h;
+  std::ostringstream escaped;
+  escaped.fill('0');
+
+  for (auto i = value.begin(), n = value.end(); i != n; ++i)
+  {
+    std::string::value_type c = (*i);
+
+    if (c == '%')
+    {
+      if (i[1] && i[2])
+      {
+        h = from_hex(i[1]) << 4 | from_hex(i[2]);
+        escaped << h;
+        i += 2;
+      }
+    }
+    else if (c == '+')
+    {
+      escaped << ' ';
+    }
+    else
+    {
+      escaped << c;
+    }
+  }
+
+  return escaped.str();
+}
+
+bool WebUtils::IsEncoded(const std::string& value)
+{
+  // Note this is not perfect as '+' symbols will mess this up, they should in general be avoided in preference of '%20'
+  return UrlDecode(value) != value;
+}
+
 std::string WebUtils::ReadFileContentsStartOnly(const std::string& url, int* httpCode)
 {
   std::string strContent;

--- a/src/iptvsimple/utilities/WebUtils.h
+++ b/src/iptvsimple/utilities/WebUtils.h
@@ -22,6 +22,8 @@ namespace iptvsimple
     {
     public:
       static const std::string UrlEncode(const std::string& value);
+      static const std::string UrlDecode(const std::string& value);
+      static bool IsEncoded(const std::string& value);
       static std::string ReadFileContentsStartOnly(const std::string& url, int* httpCode);
       static bool IsHttpUrl(const std::string& url);
       static std::string RedactUrl(const std::string& url);


### PR DESCRIPTION
v20.5.0
- URL encode last part of tvg logo URL as they can be based on channel names and they can contain spaces and non standard characters not allowed in paths
