### PR TITLE
Fix: Some icons using url arguments not displaying

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="20.5.1"
+  version="20.5.2"
   name="IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v20.5.2
+- Fixed: Some icons using url arguments not displaying
+
 v20.5.1
 - Support url arguments when encoding file portion of icon URL
 

--- a/src/iptvsimple/data/Channel.cpp
+++ b/src/iptvsimple/data/Channel.cpp
@@ -150,7 +150,7 @@ void Channel::SetIconPathFromTvgLogo(const std::string& tvgLogo, std::string& ch
       if (argumentsPos != std::string::npos && argumentsPos > 0)
       {
         urlArguments = urlFile.substr(argumentsPos);
-        urlFile = urlFile.substr(0, argumentsPos - 1);
+        urlFile = urlFile.substr(0, argumentsPos);
       }
 
       if (!utilities::WebUtils::IsEncoded(urlFile))


### PR DESCRIPTION
in playlist
`https://vmndims.flashnews.com.au/api/v2/img/62f0c4a3e4b0c10070134721?location=menu-item-selected&imwidth=800`
is getting changed to
`https://vmndims.flashnews.com.au/api/v2/img/62f0c4a3e4b0c1007013472?location=menu-item-selected&imwidth=800`
notice the missing 1 before ?