### PR TITLE
Ensure groups are delimited by semi-colon's when supplied by an EXTGRP tag

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="20.6.0"
+  version="20.6.1"
   name="IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,8 @@
+v20.6.1
+- Ensure groups are delimited by semi-colon's when suoplied by an EXTGRP tag
+- Don't break if multiple TVG URLs are supplied, just use the first one
+- Fix warning from using sprintf by switching to snprintf
+
 v20.6.0
 - Kodi inputstream API update to version 3.2.0
 - Kodi PVR API update to version 8.0.2

--- a/src/iptvsimple/PlaylistLoader.cpp
+++ b/src/iptvsimple/PlaylistLoader.cpp
@@ -544,6 +544,13 @@ std::string PlaylistLoader::ReadMarkerValue(const std::string& line, const std::
     markerStart += marker.length();
     if (markerStart < line.length())
     {
+      if (marker == M3U_GROUP_MARKER && line[markerStart] != '"')
+      {
+        //For this case we just want to return the full string without splitting it
+        //This is because groups use semi-colons and not spaces as a delimiter
+        return line.substr(markerStart, line.length());
+      }
+
       char find = ' ';
       if (line[markerStart] == '"')
       {

--- a/src/iptvsimple/PlaylistLoader.cpp
+++ b/src/iptvsimple/PlaylistLoader.cpp
@@ -123,6 +123,11 @@ bool PlaylistLoader::LoadPlayList()
         std::string tvgUrl = ReadMarkerValue(line, TVG_URL_MARKER);
         if (tvgUrl.empty())
           tvgUrl = ReadMarkerValue(line, TVG_URL_OTHER_MARKER);
+        // The tvgUrl might be a comma separated list. If it is just take
+        // the first one as we don't support multiple list but at least it will work.
+        size_t found = tvgUrl.find(',');
+        if (found != std::string::npos)
+          tvgUrl = tvgUrl.substr(0, found);
         Settings::GetInstance().SetTvgUrl(tvgUrl);
 
         continue;

--- a/src/iptvsimple/PlaylistLoader.cpp
+++ b/src/iptvsimple/PlaylistLoader.cpp
@@ -302,7 +302,7 @@ std::string PlaylistLoader::ParseIntoChannel(const std::string& line, Channel& c
     if (strTvgId.empty())
     {
       char buff[255];
-      sprintf(buff, "%d", std::atoi(infoLine.c_str()));
+      snprintf(buff, 255, "%d", std::atoi(infoLine.c_str()));
       strTvgId.append(buff);
     }
 


### PR DESCRIPTION
v20.6.1
- Ensure groups are delimited by semi-colon's when suoplied by an EXTGRP tag
- Fix warning from using sprintf by switching to snprintf