### PR TITLE
Don't URL encode paths using resource:// or special:// protocols - Omega

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="21.2.0"
+  version="21.2.1"
   name="IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v21.2.1
+- Don't URL encode paths using resource:// or special:// protocols
+
 v21.2.0
 - Support async connect
 

--- a/src/iptvsimple/data/Channel.cpp
+++ b/src/iptvsimple/data/Channel.cpp
@@ -116,6 +116,16 @@ void Channel::Reset()
   m_inputStreamName.clear();
 }
 
+namespace
+{
+
+bool IsSpecialOrResourceProtocol(const std::string& path)
+{
+  return StringUtils::StartsWith(path, "special://") || StringUtils::StartsWith(path, "resource://");
+}
+
+}
+
 void Channel::SetIconPathFromTvgLogo(const std::string& tvgLogo, std::string& channelName)
 {
   m_iconPath = tvgLogo;
@@ -134,7 +144,7 @@ void Channel::SetIconPathFromTvgLogo(const std::string& tvgLogo, std::string& ch
   {
     m_iconPath = utilities::WebUtils::UrlEncode(m_iconPath);
   }
-  else if (m_iconPath.find("://") != std::string::npos)
+  else if (m_iconPath.find("://") != std::string::npos && !IsSpecialOrResourceProtocol(m_iconPath))
   {
     // we also want to check the last part of a URL to ensure it's valid as quite often they are based on channel names
     // the path should be fine


### PR DESCRIPTION
v21.2.1
- Don't URL encode paths using resource:// or special:// protocols