### PR TITLE
If media has no season try to extract it from title for folder structure

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="20.11.1"
+  version="20.12.0"
   name="IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,7 @@
+v20.12.0
+- Extract season from medis title for path if not available
+- Set default to include media Group name in path if no dir present
+
 v20.11.1
 - EPG entry selection criteria for timezone shift calculation works for Media as well as channels
 - Fix being able to disable media from settings

--- a/pvr.iptvsimple/resources/instance-settings.xml
+++ b/pvr.iptvsimple/resources/instance-settings.xml
@@ -600,7 +600,7 @@
         </setting>
         <setting id="mediaM3UGroupPath" type="integer" parent="mediaEnabled" label="30156" help="30806">
           <level>0</level>
-          <default>0</default>
+          <default>2</default>
           <constraints>
             <options>
               <option label="30157">0</option> <!-- DONT_USE_GROUP_TITLE -->

--- a/src/iptvsimple/Media.cpp
+++ b/src/iptvsimple/Media.cpp
@@ -116,12 +116,12 @@ MediaEntry Media::GetMediaEntry(const std::string& mediaEntryId) const
 
 bool Media::IsInVirtualMediaEntryFolder(const MediaEntry& mediaEntryToCheck) const
 {
-  const std::string& mediaEntryFolderToCheck = mediaEntryToCheck.GetTitle();
+  const std::string& mediaEntryFolderToCheck = mediaEntryToCheck.GetFolderTitle();
 
   int iMatches = 0;
   for (const auto& mediaEntry : m_media)
   {
-    if (mediaEntryFolderToCheck == mediaEntry.GetTitle())
+    if (mediaEntryFolderToCheck == mediaEntry.GetFolderTitle())
     {
       iMatches++;
       Logger::Log(LEVEL_DEBUG, "%s Found MediaEntry title '%s' in media vector!", __func__, mediaEntryFolderToCheck.c_str());

--- a/src/iptvsimple/data/MediaEntry.cpp
+++ b/src/iptvsimple/data/MediaEntry.cpp
@@ -59,6 +59,23 @@ void MediaEntry::Reset()
   m_tvgShift = 0;
 }
 
+namespace {
+
+std::string ExtractFolderTitle(const std::string& title)
+{
+  std::regex pattern("[sS]\\.?[0-9]+ ?[eE][pP]?\\.?[0-9]+/?[0-9]* *");
+  std::stringstream result;
+  std::regex_replace(std::ostream_iterator<char>(result), title.begin(), title.end(), pattern, "");
+  const std::string folderTitle = result.str();
+
+  if (title != folderTitle)
+    return folderTitle;
+
+  return title;
+}
+
+}
+
 void MediaEntry::UpdateFrom(iptvsimple::data::Channel channel)
 {
   m_radio = channel.IsRadio();
@@ -74,6 +91,8 @@ void MediaEntry::UpdateFrom(iptvsimple::data::Channel channel)
   m_providerUniqueId = channel.GetProviderUniqueId();
   m_properties = channel.GetProperties();
   m_inputStreamName = channel.GetInputStreamName();
+
+  m_folderTitle = ExtractFolderTitle(m_title);
 }
 
 void MediaEntry::UpdateFrom(iptvsimple::data::EpgEntry epgEntry, const std::vector<EpgGenre>& genreMappings)
@@ -119,6 +138,8 @@ void MediaEntry::UpdateFrom(iptvsimple::data::EpgEntry epgEntry, const std::vect
 
   m_new = epgEntry.IsNew();
   m_premiere = epgEntry.IsPremiere();
+
+  m_folderTitle = ExtractFolderTitle(m_title);
 }
 
 bool MediaEntry::SetEpgGenre(const std::vector<EpgGenre> genreMappings)
@@ -270,10 +291,21 @@ void MediaEntry::UpdateTo(kodi::addon::PVRRecording& left, bool isInVirtualMedia
   std::string newDirectory = FixPath(m_directory);
   if (m_settings->GroupMediaByTitle() && isInVirtualMediaEntryFolder)
   {
-    if (m_settings->GroupMediaBySeason() && m_seasonNumber != EPG_TAG_INVALID_SERIES_EPISODE)
-      newDirectory = StringUtils::Format("%s%s/%s/", newDirectory.c_str(), m_title.c_str(), GetSeasonPrefix(m_seasonNumber).c_str());
-    else
-      newDirectory = StringUtils::Format("%s%s/", newDirectory.c_str(), m_title.c_str());
+    if (m_settings->GroupMediaBySeason())
+    {
+      if (m_seasonNumber != EPG_TAG_INVALID_SERIES_EPISODE)
+      {
+        newDirectory = StringUtils::Format("%s%s/%s/", newDirectory.c_str(), m_title.c_str(), GetSeasonPrefix(m_seasonNumber).c_str());
+      }
+      else
+      {
+        static std::regex pattern("^.*([sS]\\.?[0-9]+) ?[^]*$");
+        std::string seasonText = GetMatchTextFromString(m_title, pattern);
+
+        if (!seasonText.empty())
+          newDirectory = StringUtils::Format("%s%s/%s/", newDirectory.c_str(), m_folderTitle.c_str(), seasonText.c_str());
+      }
+    }
   }
 
   left.SetDirectory(newDirectory);

--- a/src/iptvsimple/data/MediaEntry.h
+++ b/src/iptvsimple/data/MediaEntry.h
@@ -12,6 +12,7 @@
 #include "Channel.h"
 #include "EpgEntry.h"
 
+#include <regex>
 #include <string>
 
 #include <kodi/addon-instance/pvr/Recordings.h>
@@ -67,6 +68,9 @@ namespace iptvsimple
       int64_t GetSizeInBytes() const { return m_sizeInBytes; }
       void SetSizeInBytes(int64_t value) { m_sizeInBytes = value; }
 
+      const std::string& GetFolderTitle() const { return m_folderTitle; }
+      void SetFolderTitle(const std::string& value);
+
       const std::string& GetM3UName() const { return m_m3uName; }
       const std::string& GetTvgId() const { return m_tvgId; }
       const std::string& GetTvgName() const { return m_tvgName; }
@@ -89,6 +93,23 @@ namespace iptvsimple
       void UpdateFrom(iptvsimple::data::EpgEntry epgEntry, const std::vector<EpgGenre>& genres);
       void UpdateTo(kodi::addon::PVRRecording& left, bool isInVirtualMediaEntryFolder, bool haveMediaTypes);
 
+      std::string GetMatchTextFromString(const std::string& text, const std::regex& pattern)
+      {
+        std::string matchText = "";
+        std::smatch match;
+
+        if (std::regex_match(text, match, pattern))
+        {
+          if (match.size() == 2)
+          {
+            std::ssub_match base_sub_match = match[1];
+            matchText = base_sub_match.str();
+          }
+        }
+
+        return matchText;
+      };
+
     private:
       bool SetEpgGenre(std::vector<EpgGenre> genreMappings);
 
@@ -105,6 +126,7 @@ namespace iptvsimple
       int m_providerUniqueId = PVR_PROVIDER_INVALID_UID;
       std::string m_directory;
       int64_t m_sizeInBytes = 0;
+      std::string m_folderTitle;
 
       // EPG lookup
       std::string m_m3uName;


### PR DESCRIPTION
v20.12.0
- Extract season from media title for path if not available
- Set default to include media Group name in path if no dir present
