### PR TITLE
Fix missing msgstr "" in en_gb language file

### DIFF
--- a/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
@@ -422,6 +422,7 @@ msgstr ""
 #. help: Channel Logos - useLogosLocalPathOnly
 msgctxt "#30075"
 msgid "For local logos path ignore M3U logos"
+msgstr ""
 
 #. label-category: Groups
 msgctxt "#30076"


### PR DESCRIPTION
This fixes a missing `msgstr ""` in en_gb language file.

@phunkyfish 