### PR TITLE
Remove empty media groups - Omega

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="21.3.0"
+  version="21.3.1"
   name="IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v21.3.1
+- Remove empty media groups before sending to Kodi PVR
+
 v21.3.0
 - Add settings options to add M3U group name to directory for media
 - Add expert option to force the entire playlist to be Media. Useful now that multiple instances are supported

--- a/src/iptvsimple/ChannelGroups.cpp
+++ b/src/iptvsimple/ChannelGroups.cpp
@@ -177,3 +177,11 @@ bool ChannelGroups::CheckChannelGroupAllowed(iptvsimple::data::ChannelGroup& new
 
   return false;
 }
+
+void ChannelGroups::RemoveEmptyGroups()
+{
+  m_channelGroups.erase(
+    std::remove_if(m_channelGroups.begin(), m_channelGroups.end(),
+        [](const ChannelGroup& channelGroup) { return channelGroup.IsEmpty(); }),
+    m_channelGroups.end());
+}

--- a/src/iptvsimple/ChannelGroups.h
+++ b/src/iptvsimple/ChannelGroups.h
@@ -36,6 +36,7 @@ namespace iptvsimple
     void Clear();
     bool CheckChannelGroupAllowed(iptvsimple::data::ChannelGroup& newChannelGroup);
     void ChannelGroupsLoadFailed() { m_channelGroupsLoadFailed = true; };
+    void RemoveEmptyGroups();
 
   private:
     const iptvsimple::Channels& m_channels;

--- a/src/iptvsimple/PlaylistLoader.cpp
+++ b/src/iptvsimple/PlaylistLoader.cpp
@@ -219,6 +219,9 @@ bool PlaylistLoader::LoadPlayList()
 
   stream.clear();
 
+  //Now we need to remove any emptry channel groups. We do this as we may have added some while loading media entries.
+  m_channelGroups.RemoveEmptyGroups();
+
   int milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(
                       std::chrono::high_resolution_clock::now() - started).count();
 

--- a/src/iptvsimple/data/ChannelGroup.h
+++ b/src/iptvsimple/data/ChannelGroup.h
@@ -31,6 +31,8 @@ namespace iptvsimple
       const std::vector<int>& GetMemberChannelIndexes() const { return m_memberChannelIndexes; }
       void AddMemberChannelIndex(int channelIndex) { m_memberChannelIndexes.emplace_back(channelIndex); }
 
+      bool IsEmpty() const { return m_memberChannelIndexes.empty(); }
+
       void UpdateTo(kodi::addon::PVRChannelGroup& left) const;
 
     private:


### PR DESCRIPTION
v21.3.1
- Remove empty media groups before sending to Kodi PVR