### PR TITLE
Add connection manager support to wait for a valid M3U file before starting the add-on instance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ set(IPTV_SOURCES src/addon.cpp
                  src/iptvsimple/CatchupController.cpp
                  src/iptvsimple/Channels.cpp
                  src/iptvsimple/ChannelGroups.cpp
+                 src/iptvsimple/ConnectionManager.cpp
                  src/iptvsimple/Epg.cpp
                  src/iptvsimple/InstanceSettings.cpp
                  src/iptvsimple/Media.cpp
@@ -52,7 +53,9 @@ set(IPTV_HEADERS src/addon.h
                  src/iptvsimple/CatchupController.h
                  src/iptvsimple/Channels.h
                  src/iptvsimple/ChannelGroups.h
+                 src/iptvsimple/ConnectionManager.h
                  src/iptvsimple/Epg.h
+                 src/iptvsimple/IConnectionListener.h
                  src/iptvsimple/InstanceSettings.h
                  src/iptvsimple/Media.h
                  src/iptvsimple/PlaylistLoader.h

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ General settings required for the addon to function.
     - `Once per day` - Refresh the files once per day.
 * **Refresh interval**: If auto refresh mode is `Repeated refresh` refresh the files every time this number of minutes passes. Max 120 minutes.
 * **Refresh hour (24h)**: If auto refresh mode is `Once per day` refresh the files every time this hour of the day is reached.
+* **M3U Check Interval**: When checking for a valid M3U file, the length of time to wait between attempts. Note that a valid file will only be checked for on startup and once a valid file is found all checks stop.
+* **M3U Check Timeout**: When checking for a valid M3U file, the length of time to wait before timing out the attempt.
 * **Default provider name**: If provided this value will be used as the provider name if one was not provided in the M3U. It can be used in combination with the provider mapping file which can supply type, icon path, country code and language code fields.
 * **Enable provider mapping**: If enabled any provider name read from the M3U or the default provider name will be used to read further metadata from the mapping file. The metadata includes custom name, type, icon path, country code and language code.
 * **Provider name mapping file**: The config file to map provider names received from the M3U or the default provider name to custom name, icons etc. The default file is `providerMappings.xml`.

--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="21.6.0"
+  version="21.7.0"
   name="IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,7 @@
+v21.7.0
+- Add connection manager support to wait for a valid M3U file before starting the add-on instance
+- The minimum refresh interval for the M3U should be 1 minutes and not zero, as that would be infinite refresh
+
 v21.6.0
 - Only reset channel group list when a channel URL is read from M3U Playlist
 - Modify EXTGRP behaviour so it is a begin directive for channels groups, i.e. it carries across channels unless reset by an empty EXTGRP directive or any group-title tag for a EXTINF channel directive

--- a/pvr.iptvsimple/resources/instance-settings.xml
+++ b/pvr.iptvsimple/resources/instance-settings.xml
@@ -77,7 +77,7 @@
           <level>1</level>
           <default>60</default>
           <constraints>
-            <minimum>0</minimum>
+            <minimum>1</minimum>
             <step>10</step>
             <maximum>120</maximum>
           </constraints>

--- a/pvr.iptvsimple/resources/instance-settings.xml
+++ b/pvr.iptvsimple/resources/instance-settings.xml
@@ -106,7 +106,36 @@
         </setting>
       </group>
 
-      <group id="3" label="30006">
+      <group id="3" label="30078">
+        <setting id="connectioncheckinterval" type="integer" label="30080" help="30629">
+          <level>1</level>
+          <default>10</default>
+          <constraints>
+            <minimum>1</minimum>
+            <step>1</step>
+            <maximum>60</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>true</popup>
+            <formatlabel>14045</formatlabel>
+          </control>
+        </setting>
+        <setting id="connectionchecktimeout" type="integer" label="30079" help="30628">
+          <level>2</level>
+          <default>20</default>
+          <constraints>
+            <minimum>1</minimum>
+            <step>1</step>
+            <maximum>60</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>true</popup>
+            <formatlabel>14045</formatlabel>
+          </control>
+        </setting>
+      </group>
+
+      <group id="4" label="30006">
         <setting id="defaultProviderName" type="string" label="30007" help="30740">
           <level>2</level>
           <default></default>

--- a/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
@@ -434,7 +434,22 @@ msgctxt "#30077"
 msgid "Ignore Case for EPG Channel IDs"
 msgstr ""
 
-#empty strings from id 30078 to 30099
+#. label-group: General - M3U Startup Check
+msgctxt "#30078"
+msgid "M3U Startup Check"
+msgstr ""
+
+#. label: Catchup - connectCheckTimoutSecs
+msgctxt "#30079"
+msgid "Timeout for check"
+msgstr ""
+
+#. label: Catchup - connectCheckIntervalSecs
+msgctxt "#30080"
+msgid "Interval for check"
+msgstr ""
+
+#empty strings from id 30081 to 30099
 
 #. label-category: catchup
 #. label-group: Catchup - Catchup
@@ -828,7 +843,17 @@ msgctxt "#30627"
 msgid "Ignore Case for EPG Channel IDs, also known as tvg-id's, when matching channels to EPG entries. If disabled, only case senitive matching will be used."
 msgstr ""
 
-#empty strings from id 30628 to 30639
+#. help: EPG Settings - connectionCheckTimeoutSecs
+msgctxt "#30628"
+msgid "When checking for a valid M3U file, the length of time to wait before timing out the attempt."
+msgstr ""
+
+#. help: EPG Settings - connectionCheckIntervalSecs
+msgctxt "#30629"
+msgid "When checking for a valid M3U file, the length of time to wait between attempts. Note that a valid file will only be checked for on startup and once a valid file is found all checks stop."
+msgstr ""
+
+#empty strings from id 30630 to 30639
 
 #. help info - Channel Logos
 

--- a/src/IptvSimple.h
+++ b/src/IptvSimple.h
@@ -10,8 +10,10 @@
 #include "iptvsimple/CatchupController.h"
 #include "iptvsimple/Channels.h"
 #include "iptvsimple/ChannelGroups.h"
+#include "iptvsimple/ConnectionManager.h"
 #include "iptvsimple/Providers.h"
 #include "iptvsimple/Epg.h"
+#include "iptvsimple/IConnectionListener.h"
 #include "iptvsimple/Media.h"
 #include "iptvsimple/PlaylistLoader.h"
 #include "iptvsimple/data/Channel.h"
@@ -22,11 +24,15 @@
 
 #include <kodi/addon-instance/PVR.h>
 
-class ATTR_DLL_LOCAL IptvSimple : public kodi::addon::CInstancePVRClient
+class ATTR_DLL_LOCAL IptvSimple : public iptvsimple::IConnectionListener
 {
 public:
   IptvSimple(const kodi::addon::IInstanceInfo& instance);
   ~IptvSimple() override;
+
+  // IConnectionListener implementation
+  void ConnectionLost() override;
+  void ConnectionEstablished() override;
 
   bool Initialise();
 
@@ -41,8 +47,8 @@ public:
   PVR_ERROR GetBackendVersion(std::string& version) override;
   PVR_ERROR GetConnectionString(std::string& connection) override;
 
-  PVR_ERROR OnSystemSleep() override { return PVR_ERROR_NO_ERROR; }
-  PVR_ERROR OnSystemWake() override { return PVR_ERROR_NO_ERROR; }
+  PVR_ERROR OnSystemSleep() override;
+  PVR_ERROR OnSystemWake() override;
   PVR_ERROR OnPowerSavingActivated() override { return PVR_ERROR_NO_ERROR; }
   PVR_ERROR OnPowerSavingDeactivated() override { return PVR_ERROR_NO_ERROR; }
 
@@ -96,6 +102,7 @@ private:
   iptvsimple::PlaylistLoader m_playlistLoader{this, m_channels, m_channelGroups, m_providers, m_media, m_settings};
   iptvsimple::Epg m_epg{this, m_channels, m_media, m_settings};
   iptvsimple::CatchupController m_catchupController{m_epg, &m_mutex, m_settings};
+  iptvsimple::ConnectionManager* connectionManager;
 
   std::atomic<bool> m_running{false};
   std::thread m_thread;

--- a/src/iptvsimple/ConnectionManager.cpp
+++ b/src/iptvsimple/ConnectionManager.cpp
@@ -1,0 +1,189 @@
+/*
+ *  Copyright (C) 2005-2021 Team Kodi (https://kodi.tv)
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#include "ConnectionManager.h"
+
+#include "IConnectionListener.h"
+#include "InstanceSettings.h"
+#include "utilities/Logger.h"
+#include "utilities/WebUtils.h"
+
+#include <chrono>
+
+#include <kodi/tools/StringUtils.h>
+#include <kodi/Network.h>
+
+using namespace iptvsimple;
+using namespace iptvsimple::utilities;
+using namespace kodi::tools;
+
+/*
+ * Iptvsimple Connection handler
+ */
+
+ConnectionManager::ConnectionManager(IConnectionListener& connectionListener, std::shared_ptr<iptvsimple::InstanceSettings> settings)
+  : m_connectionListener(connectionListener), m_settings(settings), m_suspended(false), m_state(PVR_CONNECTION_STATE_UNKNOWN)
+{
+}
+
+ConnectionManager::~ConnectionManager()
+{
+  Stop();
+}
+
+void ConnectionManager::Start()
+{
+  // Note: "connecting" must only be set one time, before the very first connection attempt, not on every reconnect.
+  SetState(PVR_CONNECTION_STATE_CONNECTING);
+  m_running = true;
+  m_thread = std::thread([&] { Process(); });
+}
+
+void ConnectionManager::Stop()
+{
+  m_running = false;
+  if (m_thread.joinable())
+    m_thread.join();
+
+  Disconnect();
+}
+
+void ConnectionManager::OnSleep()
+{
+  std::lock_guard<std::mutex> lock(m_mutex);
+
+  Logger::Log(LogLevel::LEVEL_DEBUG, "%s going to sleep", __func__);
+
+  m_suspended = true;
+}
+
+void ConnectionManager::OnWake()
+{
+  std::lock_guard<std::mutex> lock(m_mutex);
+
+  Logger::Log(LogLevel::LEVEL_DEBUG, "%s Waking up", __func__);
+
+  m_suspended = false;
+}
+
+void ConnectionManager::SetState(PVR_CONNECTION_STATE state)
+{
+  PVR_CONNECTION_STATE prevState(PVR_CONNECTION_STATE_UNKNOWN);
+  PVR_CONNECTION_STATE newState(PVR_CONNECTION_STATE_UNKNOWN);
+
+  {
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    /* No notification if no state change or while suspended. */
+    if (m_state != state && !m_suspended)
+    {
+      prevState = m_state;
+      newState = state;
+      m_state = newState;
+
+      Logger::Log(LogLevel::LEVEL_DEBUG, "connection state change (%d -> %d)", prevState, newState);
+    }
+  }
+
+  if (prevState != newState)
+  {
+    static std::string serverString;
+
+    if (newState == PVR_CONNECTION_STATE_SERVER_UNREACHABLE)
+    {
+      m_connectionListener.ConnectionLost();
+    }
+    else if (newState == PVR_CONNECTION_STATE_CONNECTED)
+    {
+      m_connectionListener.ConnectionEstablished();
+    }
+
+    /* Notify connection state change (callback!) */
+      m_connectionListener.ConnectionStateChange(m_settings->GetM3ULocation(), newState, "");
+  }
+}
+
+void ConnectionManager::Disconnect()
+{
+  std::lock_guard<std::mutex> lock(m_mutex);
+
+  m_connectionListener.ConnectionLost();
+}
+
+void ConnectionManager::Reconnect()
+{
+  // Setting this state will cause Iptvsimple to receive a connetionLost event
+  // The connection manager will then connect again causeing a reload of all state
+  SetState(PVR_CONNECTION_STATE_SERVER_UNREACHABLE);
+}
+
+void ConnectionManager::Process()
+{
+  static bool log = false;
+  static unsigned int retryAttempt = 0;
+  int fastReconnectIntervalMs = (m_settings->GetConnectioncCheckIntervalSecs() * 1000) / 2;
+  int intervalMs = m_settings->GetConnectioncCheckIntervalSecs() * 1000;
+
+  bool firstRun = true;
+
+  while (m_running)
+  {
+    while (m_suspended)
+    {
+      Logger::Log(LogLevel::LEVEL_DEBUG, "%s - suspended, waiting for wakeup...", __func__);
+
+      /* Wait for wakeup */
+      SteppedSleep(intervalMs);
+    }
+
+    const std::string url = m_settings->GetM3ULocation();
+
+    /* URL is set */
+    if (url.empty())
+    {
+      /* wait for URL to be set */
+      SteppedSleep(intervalMs);
+      continue;
+    }
+
+    /* Connect */
+    if ((firstRun || !m_onStartupOnly) && !WebUtils::Check(url, m_settings->GetConnectioncCheckTimeoutSecs()))
+    {
+      /* Unable to connect */
+      if (retryAttempt == 0)
+        Logger::Log(LogLevel::LEVEL_ERROR, "%s - unable to connect to: %s", __func__, url.c_str());
+      SetState(PVR_CONNECTION_STATE_SERVER_UNREACHABLE);
+
+      // Retry a few times with a short interval, after that with the default timeout
+      if (++retryAttempt <= FAST_RECONNECT_ATTEMPTS)
+        SteppedSleep(fastReconnectIntervalMs);
+      else
+        SteppedSleep(intervalMs);
+
+      continue;
+    }
+
+    SetState(PVR_CONNECTION_STATE_CONNECTED);
+    retryAttempt = 0;
+    firstRun = false;
+
+    SteppedSleep(intervalMs);
+  }
+}
+
+void ConnectionManager::SteppedSleep(int intervalMs)
+{
+  int sleepCountMs = 0;
+
+  while (sleepCountMs <= intervalMs)
+  {
+    if (m_running)
+      std::this_thread::sleep_for(std::chrono::milliseconds(SLEEP_INTERVAL_STEP_MS));
+
+    sleepCountMs += SLEEP_INTERVAL_STEP_MS;
+  }
+}

--- a/src/iptvsimple/ConnectionManager.h
+++ b/src/iptvsimple/ConnectionManager.h
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (C) 2005-2021 Team Kodi (https://kodi.tv)
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#pragma once
+
+#include "InstanceSettings.h"
+
+#include <atomic>
+#include <mutex>
+#include <string>
+#include <thread>
+
+#include <kodi/addon-instance/pvr/General.h>
+
+namespace iptvsimple
+{
+  static const int FAST_RECONNECT_ATTEMPTS = 5;
+  static const int SLEEP_INTERVAL_STEP_MS = 500;
+
+  class IConnectionListener;
+
+  class ATTR_DLL_LOCAL ConnectionManager
+  {
+  public:
+    ConnectionManager(IConnectionListener& connectionListener, std::shared_ptr<iptvsimple::InstanceSettings> settings);
+    ~ConnectionManager();
+
+    void Start();
+    void Stop();
+    void Disconnect();
+    void Reconnect();
+
+    void OnSleep();
+    void OnWake();
+
+  private:
+    void Process();
+    void SetState(PVR_CONNECTION_STATE state);
+    void SteppedSleep(int intervalMs);
+
+    IConnectionListener& m_connectionListener;
+    std::atomic<bool> m_running = {false};
+    std::thread m_thread;
+    mutable std::mutex m_mutex;
+    bool m_suspended;
+    PVR_CONNECTION_STATE m_state;
+
+    bool m_onStartupOnly = true;
+    bool m_notifyStateChangeToUser = false;
+
+    std::shared_ptr<iptvsimple::InstanceSettings> m_settings;
+  };
+} // namespace iptvsimple

--- a/src/iptvsimple/IConnectionListener.h
+++ b/src/iptvsimple/IConnectionListener.h
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (C) 2005-2021 Team Kodi (https://kodi.tv)
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#pragma once
+
+#include <kodi/addon-instance/PVR.h>
+
+namespace iptvsimple
+{
+  class ATTR_DLL_LOCAL IConnectionListener : public kodi::addon::CInstancePVRClient
+  {
+  public:
+    IConnectionListener(const kodi::addon::IInstanceInfo& instance)
+      : kodi::addon::CInstancePVRClient(instance) { }
+    virtual ~IConnectionListener() = default;
+
+    virtual void ConnectionLost() = 0;
+    virtual void ConnectionEstablished() = 0;
+  };
+} // namespace iptvsimple

--- a/src/iptvsimple/InstanceSettings.cpp
+++ b/src/iptvsimple/InstanceSettings.cpp
@@ -156,6 +156,8 @@ void InstanceSettings::ReadSettings()
   m_instance.CheckInstanceSettingString("defaultUserAgent", m_defaultUserAgent);
   m_instance.CheckInstanceSettingString("defaultInputstream", m_defaultInputstream);
   m_instance.CheckInstanceSettingString("defaultMimeType", m_defaultMimeType);
+  m_instance.CheckInstanceSettingInt("connectionchecktimeout", m_connectioncCheckTimeoutSecs);
+  m_instance.CheckInstanceSettingInt("connectioncheckinterval", m_connectioncCheckIntervalSecs);
 }
 
 void InstanceSettings::ReloadAddonInstanceSettings()
@@ -194,6 +196,10 @@ ADDON_STATUS InstanceSettings::SetSetting(const std::string& settingName, const 
     return SetSetting<int, ADDON_STATUS>(settingName, settingValue, m_m3uRefreshIntervalMins, ADDON_STATUS_OK, ADDON_STATUS_OK);
   else if (settingName == "m3uRefreshHour")
     return SetSetting<int, ADDON_STATUS>(settingName, settingValue, m_m3uRefreshHour, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  else if (settingName == "connectionchecktimeout")
+    return SetSetting<int, ADDON_STATUS>(settingName, settingValue, m_connectioncCheckTimeoutSecs, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  else if (settingName == "connectioncheckinterval")
+    return SetSetting<int, ADDON_STATUS>(settingName, settingValue, m_connectioncCheckIntervalSecs, ADDON_STATUS_OK, ADDON_STATUS_OK);
   else if (settingName == "defaultProviderName")
     return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_defaultProviderName, ADDON_STATUS_OK, ADDON_STATUS_OK);
   else if (settingName == "enableProviderMappings")

--- a/src/iptvsimple/InstanceSettings.h
+++ b/src/iptvsimple/InstanceSettings.h
@@ -28,6 +28,9 @@ namespace iptvsimple
   static const std::string DEFAULT_CUSTOM_TV_GROUPS_FILE = ADDON_DATA_BASE_DIR + "/channelGroups/customTVGroups-example.xml";
   static const std::string DEFAULT_CUSTOM_RADIO_GROUPS_FILE = ADDON_DATA_BASE_DIR + "/channelGroups/customRadioGroups-example.xml";
 
+  static const int DEFAULT_CONNECTION_CHECK_TIMEOUT_SECS = 10;
+  static const int DEFAULT_CONNECTION_CHECK_INTERVAL_SECS = 5;
+
   enum class PathType
     : int // same type as addon settings
   {
@@ -175,6 +178,8 @@ namespace iptvsimple
     const std::string& GetDefaultUserAgent() const { return m_defaultUserAgent; }
     const std::string& GetDefaultInputstream() const { return m_defaultInputstream; }
     const std::string& GetDefaultMimeType() const { return m_defaultMimeType; }
+    int GetConnectioncCheckTimeoutSecs() const { return m_connectioncCheckTimeoutSecs; }
+    int GetConnectioncCheckIntervalSecs() const { return m_connectioncCheckIntervalSecs; }
 
     const std::string& GetTvgUrl() const { return m_tvgUrl; }
     void SetTvgUrl(const std::string& tvgUrl) { m_tvgUrl = tvgUrl; }
@@ -337,6 +342,8 @@ namespace iptvsimple
     std::string m_defaultUserAgent;
     std::string m_defaultInputstream;
     std::string m_defaultMimeType;
+    int m_connectioncCheckTimeoutSecs = DEFAULT_CONNECTION_CHECK_TIMEOUT_SECS;
+    int m_connectioncCheckIntervalSecs = DEFAULT_CONNECTION_CHECK_INTERVAL_SECS;
 
     std::vector<std::string> m_customTVChannelGroupNameList;
     std::vector<std::string> m_customRadioChannelGroupNameList;

--- a/src/iptvsimple/utilities/WebUtils.cpp
+++ b/src/iptvsimple/utilities/WebUtils.cpp
@@ -7,6 +7,7 @@
 
 #include "WebUtils.h"
 
+#include "Logger.h"
 
 #include <cctype>
 #include <iomanip>
@@ -127,4 +128,25 @@ std::string WebUtils::RedactUrl(const std::string& url)
   }
 
   return redactedUrl;
+}
+
+bool WebUtils::Check(const std::string& strURL, int connectionTimeoutSecs)
+{
+  kodi::vfs::CFile fileHandle;
+  if (!fileHandle.CURLCreate(strURL))
+  {
+    Logger::Log(LEVEL_ERROR, "%s Unable to create curl handle for %s", __func__, WebUtils::RedactUrl(strURL).c_str());
+    return false;
+  }
+
+  fileHandle.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "connection-timeout",
+                      std::to_string(connectionTimeoutSecs));
+
+  if (!fileHandle.CURLOpen(ADDON_READ_NO_CACHE))
+  {
+    Logger::Log(LEVEL_DEBUG, "%s Unable to open url: %s", __func__, WebUtils::RedactUrl(strURL).c_str());
+    return false;
+  }
+
+  return true;
 }

--- a/src/iptvsimple/utilities/WebUtils.h
+++ b/src/iptvsimple/utilities/WebUtils.h
@@ -27,6 +27,7 @@ namespace iptvsimple
       static std::string ReadFileContentsStartOnly(const std::string& url, int* httpCode);
       static bool IsHttpUrl(const std::string& url);
       static std::string RedactUrl(const std::string& url);
+      static bool Check(const std::string& url, int connectionTimeoutSecs);
     };
   } // namespace utilities
 } // namespace iptvsimple


### PR DESCRIPTION
v21.7.0
- Add connection manager support to wait for a valid M3U file before starting the add-on instance
- The minimum refresh interval for the M3U should be 1 minutes and not zero, as that would be infinite refresh