### PR TITLE
Fix epg playback as live

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="21.7.1"
+  version="21.7.2"
   name="IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v21.7.2
+- Only reset the catchup state if not playing a timeshifted EPG tag
+
 v21.7.1
 - Fix supporting of local paths in Connection Manager
 

--- a/src/IptvSimple.cpp
+++ b/src/IptvSimple.cpp
@@ -222,6 +222,9 @@ PVR_ERROR IptvSimple::GetChannelStreamProperties(const kodi::addon::PVRChannel& 
   {
     std::string streamURL = m_currentChannel.GetStreamURL();
 
+    // This reset will have no effect if we tried to play an epg tag as live
+    // i.e GetEPGTagStreamProperties will have been called prior to GetChannelStreamProperties
+    // So the state will not be reset as we need to carry the EPG entry details over to the timehifted live stream.
     m_catchupController.ResetCatchupState(); // TODO: we need this currently until we have a way to know the stream stops.
 
     // We always call the catchup controller regardless so it can cleanup state

--- a/src/iptvsimple/CatchupController.h
+++ b/src/iptvsimple/CatchupController.h
@@ -38,7 +38,7 @@ namespace iptvsimple
     std::string ProcessStreamUrl(const data::Channel& channel) const;
 
     bool ControlsLiveStream() const { return m_controlsLiveStream; }
-    void ResetCatchupState() { m_resetCatchupState = true; }
+    void ResetCatchupState();
     data::EpgEntry* GetEPGEntry(const iptvsimple::data::Channel& myChannel, time_t lookupTime);
 
   private:
@@ -60,7 +60,7 @@ namespace iptvsimple
     long long m_timeshiftBufferOffset = 0;
     bool m_resetCatchupState = false;
     bool m_playbackIsVideo = false;
-    bool m_fromEpgTag = false;
+    bool m_fromTimeshiftedEpgTagCall = false;
 
     // Current programme details
     time_t m_programmeStartTime = 0;


### PR DESCRIPTION
v21.7.2
- Only reset the catchup state if not playing a timeshifted EPG tag