### PR TITLE
Catchup id live urls

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="21.7.2"
+  version="21.8.0"
   name="IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,12 @@
+v2.8.0
+- Support catchup-id for live URLs where possible
+- Support the Y, m, d, H, M, S specifiers for live URLs, useful for plugins and debugging
+- Enable Play from EPG in Live TV mode setting for Catchup VOD
+- Only set connection-timeout for connection manager if it's not NFS
+- Support the duration specifier for live URLs, useful for plugins and debugging
+- Support the all specifier for live URLs, useful for plugins and debugging
+- Fix timezone shift not applied for start time for live URLs
+
 v21.7.2
 - Only reset the catchup state if not playing a timeshifted EPG tag
 

--- a/src/IptvSimple.cpp
+++ b/src/IptvSimple.cpp
@@ -308,7 +308,7 @@ PVR_ERROR IptvSimple::GetEPGTagStreamProperties(const kodi::addon::PVREPGTag& ta
     Logger::Log(LEVEL_DEBUG, "%s - GetPlayEpgAsLive is %s", __FUNCTION__, m_settings->CatchupPlayEpgAsLive() ? "enabled" : "disabled");
 
     std::map<std::string, std::string> catchupProperties;
-    if (m_settings->CatchupPlayEpgAsLive() && m_currentChannel.CatchupSupportsTimeshifting())
+    if (m_settings->CatchupPlayEpgAsLive() && (m_currentChannel.CatchupSupportsTimeshifting() || m_currentChannel.GetCatchupMode() == CatchupMode::VOD))
     {
       m_catchupController.ProcessEPGTagForTimeshiftedPlayback(tag, m_currentChannel, catchupProperties);
     }

--- a/src/iptvsimple/CatchupController.cpp
+++ b/src/iptvsimple/CatchupController.cpp
@@ -141,6 +141,9 @@ void CatchupController::ProcessEPGTagForTimeshiftedPlayback(const kodi::addon::P
 
     m_timeshiftBufferStartTime = 0;
     m_timeshiftBufferOffset = 0;
+
+    if (m_settings->CatchupPlayEpgAsLive())
+      catchupProperties.insert({PVR_STREAM_PROPERTY_EPGPLAYBACKASLIVE, "true"});
   }
 
   m_fromTimeshiftedEpgTagCall = true;

--- a/src/iptvsimple/CatchupController.cpp
+++ b/src/iptvsimple/CatchupController.cpp
@@ -408,6 +408,8 @@ std::string FormatDateTime(time_t timeStart, time_t duration, const std::string 
 std::string FormatDateTimeNowOnly(const std::string &urlFormatString, int timezoneShiftSecs, int timeStart, int duration)
 {
   std::string formattedUrl = urlFormatString;
+
+  timeStart -= timezoneShiftSecs;
   const time_t timeNow = std::time(0) - timezoneShiftSecs;
   std::tm dateTimeNow = SafeLocaltime(timeNow);
 

--- a/src/iptvsimple/CatchupController.cpp
+++ b/src/iptvsimple/CatchupController.cpp
@@ -405,7 +405,7 @@ std::string FormatDateTime(time_t timeStart, time_t duration, const std::string 
   return formattedUrl;
 }
 
-std::string FormatDateTimeNowOnly(const std::string &urlFormatString, int timezoneShiftSecs, int programmeStartTime)
+std::string FormatDateTimeNowOnly(const std::string &urlFormatString, int timezoneShiftSecs, int programmeStartTime, int duration)
 {
   std::string formattedUrl = urlFormatString;
   const time_t timeNow = std::time(0) - timezoneShiftSecs;
@@ -429,6 +429,8 @@ std::string FormatDateTimeNowOnly(const std::string &urlFormatString, int timezo
     FormatTime('H', &dateTimeStart, formattedUrl);
     FormatTime('M', &dateTimeStart, formattedUrl);
     FormatTime('S', &dateTimeStart, formattedUrl);
+
+    FormatUtc("{duration}", duration, formattedUrl);
   }
 
   Logger::Log(LEVEL_DEBUG, "%s - \"%s\"", __FUNCTION__, WebUtils::RedactUrl(formattedUrl).c_str());
@@ -465,7 +467,7 @@ std::string BuildEpgTagUrl(time_t startTime, time_t duration, const Channel& cha
   if ((startTime > 0 && offset < (timeNow - 5)) || (channel.IgnoreCatchupDays() && !programmeCatchupId.empty()))
     startTimeUrl = FormatDateTime(offset - timezoneShiftSecs, duration, channel.GetCatchupSource());
   else
-    startTimeUrl = FormatDateTimeNowOnly(channel.GetStreamURL(), timezoneShiftSecs, startTime);
+    startTimeUrl = FormatDateTimeNowOnly(channel.GetStreamURL(), timezoneShiftSecs, startTime, duration);
 
   static const std::regex CATCHUP_ID_REGEX("\\{catchup-id\\}");
   if (!programmeCatchupId.empty())
@@ -515,7 +517,7 @@ std::string CatchupController::GetCatchupUrl(const Channel& channel) const
 std::string CatchupController::ProcessStreamUrl(const Channel& channel) const
 {
   //We only process current time timestamps specifiers in this case
-  std::string processedUrl = FormatDateTimeNowOnly(channel.GetStreamURL(), m_epg.GetEPGTimezoneShiftSecs(channel) + channel.GetCatchupCorrectionSecs(), m_programmeStartTime);
+  std::string processedUrl = FormatDateTimeNowOnly(channel.GetStreamURL(), m_epg.GetEPGTimezoneShiftSecs(channel) + channel.GetCatchupCorrectionSecs(), m_programmeStartTime, m_programmeEndTime - m_programmeStartTime);
 
   static const std::regex CATCHUP_ID_REGEX("\\{catchup-id\\}");
   if (!m_programmeCatchupId.empty())

--- a/src/iptvsimple/utilities/WebUtils.cpp
+++ b/src/iptvsimple/utilities/WebUtils.cpp
@@ -116,6 +116,11 @@ bool WebUtils::IsHttpUrl(const std::string& url)
   return StringUtils::StartsWith(url, HTTP_PREFIX) || StringUtils::StartsWith(url, HTTPS_PREFIX);
 }
 
+bool WebUtils::IsNfsUrl(const std::string& url)
+{
+  return StringUtils::StartsWith(url, NFS_PREFIX);
+}
+
 std::string WebUtils::RedactUrl(const std::string& url)
 {
   std::string redactedUrl = url;
@@ -145,8 +150,8 @@ bool WebUtils::Check(const std::string& strURL, int connectionTimeoutSecs, bool 
     return false;
   }
 
-  fileHandle.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "connection-timeout",
-                      std::to_string(connectionTimeoutSecs));
+  if (!IsNfsUrl(strURL))
+    fileHandle.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "connection-timeout", std::to_string(connectionTimeoutSecs));
 
   if (!fileHandle.CURLOpen(ADDON_READ_NO_CACHE))
   {

--- a/src/iptvsimple/utilities/WebUtils.h
+++ b/src/iptvsimple/utilities/WebUtils.h
@@ -15,6 +15,7 @@ namespace iptvsimple
   {
     static const std::string HTTP_PREFIX = "http://";
     static const std::string HTTPS_PREFIX = "https://";
+    static const std::string NFS_PREFIX = "nfs://";
     static const std::string UDP_MULTICAST_PREFIX = "udp://@";
     static const std::string RTP_MULTICAST_PREFIX = "rtp://@";
 
@@ -26,6 +27,7 @@ namespace iptvsimple
       static bool IsEncoded(const std::string& value);
       static std::string ReadFileContentsStartOnly(const std::string& url, int* httpCode);
       static bool IsHttpUrl(const std::string& url);
+      static bool IsNfsUrl(const std::string& url);
       static std::string RedactUrl(const std::string& url);
       static bool Check(const std::string& url, int connectionTimeoutSecs, bool isLocalPath = false);
     };


### PR DESCRIPTION
- Support catchup-id for live URLs where possible
- Support the Y, m, d, H, M, S specficiers for live URLs, useful for plugins and debugging
- Enable Play from EPG in Live TV mode setting for Catchup VOD
- Only set connection-tiemeout for connection manager if it's not NFS
- Support the duration specifier for live URLs, useful for plugins and debugging
- Support the all specifier for live URLs, useful for plugins and debugging
- Fix timezone shift not applied for start time for live URLs