### PR TITLE
Isolate xz-utils version 5.2.4

### DIFF
--- a/depends/windowsstore/xz-utils/xz-utils.txt
+++ b/depends/windowsstore/xz-utils/xz-utils.txt
@@ -1,1 +1,1 @@
-xz-utils https://tukaani.org/xz/xz-5.2.4.tar.xz
+xz-utils-5.2.4 https://tukaani.org/xz/xz-5.2.4.tar.xz


### PR DESCRIPTION
UWP fails to build (when build all add-ons at time) due xz-utils "version conflict".

This add-on is use older version than others and cmake not detects properly.

Without this (or other solution) `pvr.iptvsimple` will not be included on Xbox v21 RC1 installer:

![Captura de pantalla 2024-03-03 175945](https://github.com/kodi-pvr/pvr.iptvsimple/assets/58434170/3ea26d3c-d9dd-4d49-8e17-218f894019ee)

https://jenkins.kodi.tv/view/Windows/job/WIN-UWP-64/24993/

```
Building pvr.iptvsimple...
[ 25%] Built target zlib
[ 50%] Built target pugixml
[ 75%] Built target xz-utils
[ 75%] Creating directories for 'pvr.iptvsimple'
[ 75%] No download step for 'pvr.iptvsimple'
[ 75%] No update step for 'pvr.iptvsimple'
[ 75%] No patch step for 'pvr.iptvsimple'
[ 75%] Performing configure step for 'pvr.iptvsimple'
CMake Warning:
  Ignoring extra path from command line:

   "C:/jenkins-workspace/workspace/WIN-UWP-64/project/Win32BuildSetup/BUILD_WIN32/addons"


CMake Warning:
  Ignoring extra path from command line:

   "C:/jenkins-workspace/workspace/WIN-UWP-64/project/Win32BuildSetup/BUILD_WIN32/addons"


-- The C compiler identification is MSVC 19.34.31937.0
-- The CXX compiler identification is MSVC 19.34.31937.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.34.31933/bin/Hostx64/x64/cl.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.34.31933/bin/Hostx64/x64/cl.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Checking to see if CXX compiler accepts flag -flto
-- Checking to see if CXX compiler accepts flag -flto - yes
-- Found pugixml: C:/jenkins-workspace/workspace/WIN-UWP-64/cmake/addons/output/include  
-- Found ZLIB: C:/jenkins-workspace/workspace/WIN-UWP-64/cmake/addons/output/lib/zlib.lib (found version "1.3.#define ZLIB_VERSION "1.3"")  
CMake Error at C:/Program Files/CMake/share/cmake-3.26/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find lzma (missing: LZMA_LIBRARIES)
Call Stack (most recent call first):
  C:/Program Files/CMake/share/cmake-3.26/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
  Findlzma.cmake:12 (find_package_handle_standard_args)
  CMakeLists.txt:9 (find_package)


-- Configuring incomplete, errors occurred!
NMAKE : fatal error U1077: 'echo' : return code '0x1'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.34.31933\bin\HostX64\x64\nmake.exe"' : return code '0x2'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.34.31933\bin\HostX64\x64\nmake.exe"' : return code '0x2'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.34.31933\bin\HostX64\x64\nmake.exe"' : return code '0x2'
Stop.
```

Latest installer that includes binary add-on in is: 
Kodi-20240204-99d8703b-master-x64.msix