### PR TITLE
Findlzma add alternate name to satisfy windows builds

### DIFF
--- a/Findlzma.cmake
+++ b/Findlzma.cmake
@@ -6,7 +6,7 @@
 # LZMA_LIBRARIES - the xz library
 
 find_path(LZMA_INCLUDE_DIRS lzma.h)
-find_library(LZMA_LIBRARIES lzma)
+find_library(LZMA_LIBRARIES NAMES lzma liblzma)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(lzma REQUIRED_VARS LZMA_INCLUDE_DIRS LZMA_LIBRARIES)


### PR DESCRIPTION
Windows builds that have lzma built before pvr.iptvsimple dont build xz-utils, and therefore the find_package is reliant on finding out of tree. The search name requires liblzma for additional assistance finding the lzma lib.

Locally this fixes the UWP build issue with all addons being built
Jenkins job at https://jenkins.kodi.tv/job/WIN-UWP-64/25024/ building inputstream.ffmpegdirect and pvr.iptvsimple (minimal repro case for any windows arch build)