### PR TITLE
Make LZMA support optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,20 +6,17 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 find_package(Kodi REQUIRED)
 find_package(pugixml REQUIRED)
 find_package(ZLIB REQUIRED)
-find_package(lzma REQUIRED)
+find_package(lzma)
 
 include_directories(${KODI_INCLUDE_DIR}/.. # Hack way with "/..", need bigger Kodi cmake rework to match right include ways
                     ${PUGIXML_INCLUDE_DIRS}
-                    ${ZLIB_INCLUDE_DIRS}
-                    ${LZMA_INCLUDE_DIRS})
+                    ${ZLIB_INCLUDE_DIRS})
 
 set(DEPLIBS ${PUGIXML_LIBRARIES}
-            ${ZLIB_LIBRARIES}
-            ${LZMA_LIBRARIES})
+            ${ZLIB_LIBRARIES})
 
 message(STATUS "PUGIXML_LIBRARIES: ${PUGIXML_LIBRARIES}")
 message(STATUS "ZLIB_LIBRARIES: ${ZLIB_LIBRARIES}")
-message(STATUS "LZMA_LIBRARIES: ${LZMA_LIBRARIES}")
 
 set(IPTV_SOURCES src/addon.cpp
                  src/IptvSimple.cpp
@@ -81,8 +78,14 @@ set(IPTV_HEADERS src/addon.h
 addon_version(pvr.iptvsimple IPTV)
 add_definitions(-DIPTV_VERSION=${IPTV_VERSION})
 
-if(WIN32)
-  add_definitions(-DLZMA_API_STATIC)
+if(lzma_FOUND)
+  include_directories(${LZMA_INCLUDE_DIRS})
+  list(APPEND DEPLIBS ${LZMA_LIBRARIES})
+  message(STATUS "LZMA_LIBRARIES: ${LZMA_LIBRARIES}")
+  add_definitions(-DWITH_LZMA)
+  if(WIN32)
+    add_definitions(-DLZMA_API_STATIC)
+  endif()
 endif()
 
 build_addon(pvr.iptvsimple IPTV DEPLIBS)

--- a/src/iptvsimple/Epg.cpp
+++ b/src/iptvsimple/Epg.cpp
@@ -195,12 +195,17 @@ char* Epg::FillBufferFromXMLTVData(std::string& data, std::string& decompressedD
   else if (data[0] == '\xFD' && data[1] == '7' && data[2] == 'z' &&
            data[3] == 'X' && data[4] == 'Z' && data[5] == '\x00')
   {
+#if defined (WITH_LZMA)
     if (!FileUtils::XzDecompress(data, decompressedData))
     {
       Logger::Log(LEVEL_ERROR, "%s - Invalid EPG file '%s': unable to decompress xz/7z file.", __FUNCTION__, m_xmltvLocation.c_str());
       return nullptr;
     }
     buffer = &(decompressedData[0]);
+#else
+    Logger::Log(LEVEL_ERROR, "%s - Invalid EPG file '%s': xz/7z decompression unsupported.", __FUNCTION__, m_xmltvLocation.c_str());
+    return nullptr;
+#endif
   }
   else
   {

--- a/src/iptvsimple/utilities/FileUtils.cpp
+++ b/src/iptvsimple/utilities/FileUtils.cpp
@@ -9,7 +9,9 @@
 
 #include "../InstanceSettings.h"
 
-#include <lzma.h>
+#if defined (WITH_LZMA)
+  #include <lzma.h>
+#endif
 #include <zlib.h>
 
 using namespace iptvsimple;
@@ -134,6 +136,7 @@ bool FileUtils::GzipInflate(const std::string& compressedBytes, std::string& unc
 
 bool FileUtils::XzDecompress(const std::string& compressedBytes, std::string& uncompressedBytes)
 {
+#if defined (WITH_LZMA)
   if (compressedBytes.size() == 0)
   {
     uncompressedBytes = compressedBytes;
@@ -167,6 +170,9 @@ bool FileUtils::XzDecompress(const std::string& compressedBytes, std::string& un
   lzma_end (&strm);
 
   return true;
+#else
+  return false;
+#endif
 }
 
 int FileUtils::GetCachedFileContents(std::shared_ptr<iptvsimple::InstanceSettings>& settings,


### PR DESCRIPTION
With the malicious actor changes to upstream xz, make the LZMA library optional. .xz support in pvr.iptvsimple is limited to epg files.
- cross-ref: https://github.com/LibreELEC/LibreELEC.tv/pull/8775