### PR TITLE
[StreamUtils] Removed inputstream.adaptive.manifest_update_parameter

### DIFF
--- a/src/iptvsimple/utilities/StreamUtils.cpp
+++ b/src/iptvsimple/utilities/StreamUtils.cpp
@@ -109,8 +109,6 @@ void StreamUtils::SetAllStreamProperties(std::vector<kodi::addon::PVRStreamPrope
       properties.emplace_back("inputstream.adaptive.manifest_type", StreamUtils::GetManifestType(streamType));
       if (streamType == StreamType::HLS || streamType == StreamType::DASH)
         properties.emplace_back(PVR_STREAM_PROPERTY_MIMETYPE, StreamUtils::GetMimeType(streamType));
-      if (streamType == StreamType::DASH)
-        properties.emplace_back("inputstream.adaptive.manifest_update_parameter", "full");
     }
   }
 


### PR DESCRIPTION
The "full" value support has been removed from InputStream Adaptive for Kodi 21, because managed automatically

ref. https://github.com/xbmc/inputstream.adaptive/wiki/Integration#inputstreamadaptivemanifest_update_parameter

Does not cause any problem but better to remove it,
does not require immediate binary bump, you can do it at the first opportunity