### PR TITLE
Improvements for InputStreamAdaptive

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="22.1.0"
+  version="22.1.1"
   name="IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,9 @@
+v22.1.1
+- Always add mimetype for inputstream.adaptive
+- Better handled user-agent header for inputstream.adaptive use cases
+- Fix missing manifest user-agent header for inputstream.adaptive
+- Add missing SmoothStreaming mimetype for inputstream.adaptive
+
 v22.1.0
 - PVR Add-on API v9.0.0
 

--- a/src/iptvsimple/utilities/StreamUtils.cpp
+++ b/src/iptvsimple/utilities/StreamUtils.cpp
@@ -41,7 +41,15 @@ bool SplitUrlProtocolOpts(const std::string& streamURL,
 
 void StreamUtils::SetAllStreamProperties(std::vector<kodi::addon::PVRStreamProperty>& properties, const iptvsimple::data::Channel& channel, const std::string& streamURL, bool isChannelURL, std::map<std::string, std::string>& catchupProperties, std::shared_ptr<InstanceSettings>& settings)
 {
-  if (ChannelSpecifiesInputstream(channel))
+  // Check if the channel has explicitly set up the use of inputstream.adaptive,
+  // if so, the best behaviour for media services is:
+  // - Always add mimetype to prevent kodi core to make an HTTP HEADER requests
+  //   this because in some cases services refuse this request and can also deny downloads
+  // - If requested by settings, always add the "user-agent" header to ISA properties
+  const bool isISAdaptiveSet =
+      channel.GetProperty(PVR_STREAM_PROPERTY_INPUTSTREAM) == INPUTSTREAM_ADAPTIVE;
+
+  if (!isISAdaptiveSet && ChannelSpecifiesInputstream(channel))
   {
     // Channel has an inputstream class set so we only set the stream URL
     properties.emplace_back(PVR_STREAM_PROPERTY_STREAMURL, streamURL);
@@ -59,7 +67,7 @@ void StreamUtils::SetAllStreamProperties(std::vector<kodi::addon::PVRStreamPrope
       streamType = StreamUtils::InspectStreamType(streamURL, channel);
 
     // Using kodi's built in inputstreams
-    if (StreamUtils::UseKodiInputstreams(streamType, settings))
+    if (!isISAdaptiveSet && StreamUtils::UseKodiInputstreams(streamType, settings))
     {
       std::string ffmpegStreamURL = StreamUtils::GetURLWithFFmpegReconnectOptions(streamURL, streamType, channel, settings);
 
@@ -122,7 +130,8 @@ void StreamUtils::SetAllStreamProperties(std::vector<kodi::addon::PVRStreamPrope
       if (!streamUrlSet)
         properties.emplace_back(PVR_STREAM_PROPERTY_STREAMURL, streamURL);
 
-      properties.emplace_back(PVR_STREAM_PROPERTY_INPUTSTREAM, INPUTSTREAM_ADAPTIVE);
+      if (!isISAdaptiveSet)
+        properties.emplace_back(PVR_STREAM_PROPERTY_INPUTSTREAM, INPUTSTREAM_ADAPTIVE);
       
       if (streamType == StreamType::HLS || streamType == StreamType::DASH ||
           streamType == StreamType::SMOOTH_STREAMING)

--- a/src/iptvsimple/utilities/StreamUtils.cpp
+++ b/src/iptvsimple/utilities/StreamUtils.cpp
@@ -107,7 +107,8 @@ void StreamUtils::SetAllStreamProperties(std::vector<kodi::addon::PVRStreamPrope
 
       properties.emplace_back(PVR_STREAM_PROPERTY_INPUTSTREAM, INPUTSTREAM_ADAPTIVE);
       
-      if (streamType == StreamType::HLS || streamType == StreamType::DASH)
+      if (streamType == StreamType::HLS || streamType == StreamType::DASH ||
+          streamType == StreamType::SMOOTH_STREAMING)
         properties.emplace_back(PVR_STREAM_PROPERTY_MIMETYPE, StreamUtils::GetMimeType(streamType));
     }
   }
@@ -287,6 +288,8 @@ const std::string StreamUtils::GetMimeType(const StreamType& streamType)
       return "application/x-mpegURL";
     case StreamType::DASH:
       return "application/xml+dash";
+    case StreamType::SMOOTH_STREAMING:
+      return "application/vnd.ms-sstr+xml";
     case StreamType::TS:
       return "video/mp2t";
     default:

--- a/src/iptvsimple/utilities/StreamUtils.cpp
+++ b/src/iptvsimple/utilities/StreamUtils.cpp
@@ -106,7 +106,7 @@ void StreamUtils::SetAllStreamProperties(std::vector<kodi::addon::PVRStreamPrope
         properties.emplace_back(PVR_STREAM_PROPERTY_STREAMURL, streamURL);
 
       properties.emplace_back(PVR_STREAM_PROPERTY_INPUTSTREAM, INPUTSTREAM_ADAPTIVE);
-      properties.emplace_back("inputstream.adaptive.manifest_type", StreamUtils::GetManifestType(streamType));
+      
       if (streamType == StreamType::HLS || streamType == StreamType::DASH)
         properties.emplace_back(PVR_STREAM_PROPERTY_MIMETYPE, StreamUtils::GetMimeType(streamType));
     }


### PR DESCRIPTION
1) inputstream.adaptive.manifest_type is deprecated on Kodi 21 and removed on Kodi 22
2) Add missing mimetype for smoothstreaming
3) Handle user-agent header also on inputstream.adaptive.manifest_headers, this is often a requirement for services, set it only to inputstream.adaptive.stream_headers has no much sense because most of the time will not works
4) Always set useragent headers and mimetype for inputstream.adaptive, see code comment.

Some code could be simplified a bit if `Use inputstream.adaptive for m3u8 (HLS) streams` setting would instead support all ISA manifest formats, so convert that setting as: `Use inputstream.adaptive for streams`. I havent done this change since i have not full picture of the reasons behind this choice (limited to HLS), also i want allow PR to be backported without breaking changes.

this pr could be also backported to Omega as is without problems

fix #871
