### PR TITLE
Update reading XMLTV xmltv_ns for PVR API v9.0.0

### DIFF
--- a/src/iptvsimple/data/EpgEntry.cpp
+++ b/src/iptvsimple/data/EpgEntry.cpp
@@ -360,13 +360,19 @@ bool EpgEntry::ParseXmltvNsEpisodeNumberInfo(const std::string& episodeNumberStr
 
     if (!episodePartString.empty())
     {
-      int totalNumberOfParts;
-      int numElementsParsed = std::sscanf(episodePartString.c_str(), "%d/%d", &m_episodePartNumber, &totalNumberOfParts);
+      int numElementsParsed = std::sscanf(episodePartString.c_str(), "%d/%d", &m_episodeNumber, &m_episodePartNumber);
 
       if (numElementsParsed == 2)
+      {
+        m_episodeNumber++;
         m_episodePartNumber++;
+      }
       else if (numElementsParsed == 1)
+      {
+        if (m_episodeNumber == EPG_TAG_INVALID_SERIES_EPISODE)
+          m_episodeNumber++;
         m_episodePartNumber = EPG_TAG_INVALID_SERIES_EPISODE;
+      }
     }
   }
 

--- a/src/iptvsimple/data/MediaEntry.cpp
+++ b/src/iptvsimple/data/MediaEntry.cpp
@@ -265,7 +265,7 @@ void MediaEntry::UpdateTo(kodi::addon::PVRRecording& left, bool isInVirtualMedia
   // left.SetStarRating(m_starRating);
   left.SetSeriesNumber(m_seasonNumber);
   left.SetEpisodeNumber(m_episodeNumber);
-  // left.SetEpisodePartNumber(m_episodePartNumber);
+  left.SetEpisodePartNumber(m_episodePartNumber);
   left.SetEpisodeName(m_episodeName);
   left.SetFirstAired(m_firstAired);
   int iFlags = EPG_TAG_FLAG_UNDEFINED;


### PR DESCRIPTION
Update EpisodePartNumber with the total number of episodes in an episode sequence.  Use with Episode number

As an example from this XMLTV programme the programs shows E45/48 in the Estuary skin

```
	<programme start="20240823161500 +0000" stop="20240823170000 +0000" channel="nextpvr-7400">
		<title>Pointless</title>
		<desc>45/48. Alexander Armstrong is joined by co-host Desiree Burch for the quiz where contestants try to score as few points as possible by coming up with the answers no-one else could think of. [S] [HD]</desc>
		<category>Show / Game show</category>
		<episode-num system="xmltv_ns">..44/47</episode-num>
	</programme>
```
![image](https://github.com/user-attachments/assets/62a8830d-ef70-4e3b-96cb-40015aa2bf54)
