### PR TITLE
[PlaylistLoader] Fix KODIPROP parsing

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="22.1.1"
+  version="22.1.2"
   name="IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v22.1.2
+- Fix #KODIPROP parsing from playlists
+
 v22.1.1
 - Always add mimetype for inputstream.adaptive
 - Better handled user-agent header for inputstream.adaptive use cases

--- a/src/iptvsimple/PlaylistLoader.h
+++ b/src/iptvsimple/PlaylistLoader.h
@@ -75,7 +75,7 @@ namespace iptvsimple
     void ReloadPlayList();
 
   private:
-    static std::string ReadMarkerValue(const std::string& line, const std::string& markerName);
+    static std::string ReadMarkerValue(const std::string& line, const std::string& markerName, bool isCheckDelimiters = true);
     static void ParseSinglePropertyIntoChannel(const std::string& line, iptvsimple::data::Channel& channel, const std::string& markerName);
 
     std::string ParseIntoChannel(const std::string& line, iptvsimple::data::Channel& channel, data::MediaEntry& mediaEntry, int epgTimeShift, int catchupCorrectionSecs, bool xeevCatchup);


### PR DESCRIPTION
kodi props `#KODIPROP` must be read in full
so without use delimiters that break the string
at first space or double accents " otherwise lead to broken properties values

fix #887
fix https://github.com/xbmc/inputstream.adaptive/issues/811#issuecomment-2222523308

backport needed

i add version bump commit after review