### PR TITLE
Take account of whitespace at end of xmltv file while doing format check

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="22.3.0"
+  version="22.3.1"
   name="IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,6 @@
+v22.3.1
+- Take account of whitespace at end of xmltv file while doing format check
+
 v22.3.0
 - PVR Add-on API v9.2.0
 

--- a/src/iptvsimple/Epg.cpp
+++ b/src/iptvsimple/Epg.cpp
@@ -221,12 +221,35 @@ char* Epg::FillBufferFromXMLTVData(std::string& data, std::string& decompressedD
   return buffer;
 }
 
+namespace {
+
+char GetLastValidCharInBuffer(const char* buffer)
+{
+  size_t charIndex = std::strlen(buffer) - 1;
+  char lastValidChar = buffer[charIndex];
+
+  while (charIndex != 0 &&
+         (buffer[charIndex] == ' ' ||
+          buffer[charIndex] == '\t'||
+          buffer[charIndex] == '\n' ||
+          buffer[charIndex] == '\r' ||
+          buffer[charIndex] == '\f' ||
+          buffer[charIndex] == '\v'))
+  {
+    lastValidChar = buffer[--charIndex];
+  }
+
+  return lastValidChar;
+}
+
+} // unnamed namespace
+
 const XmltvFileFormat Epg::GetXMLTVFileFormat(const char* buffer)
 {
   if (!buffer)
     return XmltvFileFormat::INVALID;
 
-  if ((buffer[0] == '\x3C' && buffer[std::strlen(buffer) - 1] == '\x3E') || // Start with < and ends with >
+  if ((buffer[0] == '\x3C' && GetLastValidCharInBuffer(buffer) == '\x3E') || // Start with < and ends with >
       (buffer[0] == '\x3C' && buffer[1] == '\x3F' &&  buffer[2] == '\x78' && // xml should starts with '<?xml'
        buffer[3] == '\x6D' && buffer[4] == '\x6C'))
   {


### PR DESCRIPTION
v22.3.1
- Take account of whitespace at end of xmltv file while doing format check