### PR TITLE
Fix and add support to inputstream.adaptive.common_headers

### DIFF
--- a/pvr.iptvsimple/addon.xml.in
+++ b/pvr.iptvsimple/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="22.5.0"
+  version="22.5.1"
   name="IPTV Simple Client"
   provider-name="nightik and Ross Nicholson">
   <requires>@ADDON_DEPENDS@

--- a/pvr.iptvsimple/changelog.txt
+++ b/pvr.iptvsimple/changelog.txt
@@ -1,3 +1,7 @@
+v22.5.1
+- Add support to inputstream.adaptive.common_headers to set headers
+- Fix an issue that was replacing user headers set with inputstream.adaptive.common_headers
+
 v22.5.0
 - Add support for web stream extraction from HTML content
 - Add support for custom regex patterns for web stream extraction

--- a/src/iptvsimple/utilities/StreamUtils.cpp
+++ b/src/iptvsimple/utilities/StreamUtils.cpp
@@ -123,7 +123,8 @@ void StreamUtils::SetAllStreamProperties(std::vector<kodi::addon::PVRStreamPrope
       // strip the headers from streamURL and put it to media headers property
 
       if (channel.GetProperty("inputstream.adaptive.manifest_headers").empty() &&
-          channel.GetProperty("inputstream.adaptive.stream_headers").empty())
+          channel.GetProperty("inputstream.adaptive.stream_headers").empty() &&
+          channel.GetProperty("inputstream.adaptive.common_headers").empty())
       {
         // No stream headers declared by property, check if stream URL has any
         std::string url;
@@ -132,8 +133,7 @@ void StreamUtils::SetAllStreamProperties(std::vector<kodi::addon::PVRStreamPrope
         {
           // Set stream URL without headers and encoded headers as property
           properties.emplace_back(PVR_STREAM_PROPERTY_STREAMURL, url);
-          properties.emplace_back("inputstream.adaptive.manifest_headers", encodedProtocolOptions);
-          properties.emplace_back("inputstream.adaptive.stream_headers", encodedProtocolOptions);
+          properties.emplace_back("inputstream.adaptive.common_headers", encodedProtocolOptions);
           streamUrlSet = true;
         }
       }


### PR DESCRIPTION
stream_headers and manifest_headers can replace common_headers values since they have higher priority

so when a stream provide a common_headers only
you dont have to set stream_headers, manifest_headers, otherwise will override user customizations

since common_headers (supported starting from Piers branch) can be used to set the headers
globally, we make use of this prop instead of the other

fixes #925