### PR TITLE
Enhance IPTV Simple PVR client with HTTP server functionality

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,11 +7,13 @@ find_package(Kodi REQUIRED)
 find_package(pugixml REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(lzma REQUIRED)
+find_package(httplib REQUIRED)
 
 include_directories(${KODI_INCLUDE_DIR}/.. # Hack way with "/..", need bigger Kodi cmake rework to match right include ways
                     ${PUGIXML_INCLUDE_DIRS}
                     ${ZLIB_INCLUDE_DIRS}
-                    ${LZMA_INCLUDE_DIRS})
+                    ${LZMA_INCLUDE_DIRS}
+                    ${HTTPLIB_INCLUDE_DIR})
 
 set(DEPLIBS ${PUGIXML_LIBRARIES}
             ${ZLIB_LIBRARIES}
@@ -20,6 +22,7 @@ set(DEPLIBS ${PUGIXML_LIBRARIES}
 message(STATUS "PUGIXML_LIBRARIES: ${PUGIXML_LIBRARIES}")
 message(STATUS "ZLIB_LIBRARIES: ${ZLIB_LIBRARIES}")
 message(STATUS "LZMA_LIBRARIES: ${LZMA_LIBRARIES}")
+message(STATUS "CPP_HTTPLIB_LIBRARIES: ${HTTPLIB_INCLUDE_DIR}")
 
 set(IPTV_SOURCES src/addon.cpp
                  src/IptvSimple.cpp
@@ -48,6 +51,8 @@ set(IPTV_SOURCES src/addon.cpp
                  src/iptvsimple/utilities/WebUtils.cpp
                  src/iptvsimple/utilities/WebStreamExtractor.cpp
                  src/iptvsimple/utilities/CurlUtils.cpp
+                 src/iptvsimple/HttpServer.cpp
+                 src/iptvsimple/views/ChannelsView.cpp
                  )
 
 set(IPTV_HEADERS src/addon.h
@@ -82,6 +87,9 @@ set(IPTV_HEADERS src/addon.h
                  src/iptvsimple/utilities/XMLUtils.h
                  src/iptvsimple/utilities/WebStreamExtractor.h
                  src/iptvsimple/utilities/CurlUtils.h
+                 src/iptvsimple/HttpServer.h
+                 src/iptvsimple/views/ChannelsView.h
+                 src/iptvsimple/IHttpView.h
                  )
 
 addon_version(pvr.iptvsimple IPTV)

--- a/depends/common/cpp-httplib/01-fix-ssize_t.patch
+++ b/depends/common/cpp-httplib/01-fix-ssize_t.patch
@@ -1,0 +1,435 @@
+--- a/httplib.h
++++ b/httplib.h
+@@ -166,9 +166,9 @@
+ #pragma comment(lib, "ws2_32.lib")
+ 
+ #ifdef _WIN64
+-using ssize_t = __int64;
++using httplib_ssize_t = __int64;
+ #else
+-using ssize_t = long;
++using httplib_ssize_t = long;
+ #endif
+ #endif // _MSC_VER
+ 
+@@ -611,8 +611,15 @@ public:
+   Reader reader_;
+   MultipartReader multipart_reader_;
+ };
++#ifndef httplib_ssize_t
++#ifdef _WIN64
++using httplib_ssize_t = __int64;
++#else
++using httplib_ssize_t = long;
++#endif
++#endif
+ 
+-using Range = std::pair<ssize_t, ssize_t>;
++using Range = std::pair<httplib_ssize_t, httplib_ssize_t>;
+ using Ranges = std::vector<Range>;
+ 
+ struct Request {
+@@ -737,16 +744,16 @@ public:
+   virtual bool is_readable() const = 0;
+   virtual bool is_writable() const = 0;
+ 
+-  virtual ssize_t read(char *ptr, size_t size) = 0;
+-  virtual ssize_t write(const char *ptr, size_t size) = 0;
++  virtual httplib_ssize_t read(char *ptr, size_t size) = 0;
++  virtual httplib_ssize_t write(const char *ptr, size_t size) = 0;
+   virtual void get_remote_ip_and_port(std::string &ip, int &port) const = 0;
+   virtual void get_local_ip_and_port(std::string &ip, int &port) const = 0;
+   virtual socket_t socket() const = 0;
+ 
+   virtual time_t duration() const = 0;
+ 
+-  ssize_t write(const char *ptr);
+-  ssize_t write(const std::string &s);
++  httplib_ssize_t write(const char *ptr);
++  httplib_ssize_t write(const std::string &s);
+ };
+ 
+ class TaskQueue {
+@@ -921,7 +928,7 @@ private:
+   std::regex regex_;
+ };
+ 
+-ssize_t write_headers(Stream &strm, const Headers &headers);
++httplib_ssize_t write_headers(Stream &strm, const Headers &headers);
+ 
+ } // namespace detail
+ 
+@@ -993,7 +1000,7 @@ public:
+ 
+   Server &set_default_headers(Headers headers);
+   Server &
+-  set_header_writer(std::function<ssize_t(Stream &, Headers &)> const &writer);
++  set_header_writer(std::function<httplib_ssize_t(Stream &, Headers &)> const &writer);
+ 
+   Server &set_keep_alive_max_count(size_t count);
+   Server &set_keep_alive_timeout(time_t sec);
+@@ -1135,7 +1142,7 @@ private:
+   SocketOptions socket_options_ = default_socket_options;
+ 
+   Headers default_headers_;
+-  std::function<ssize_t(Stream &, Headers &)> header_writer_ =
++  std::function<httplib_ssize_t(Stream &, Headers &)> header_writer_ =
+       detail::write_headers;
+ };
+ 
+@@ -1411,7 +1418,7 @@ public:
+   void set_default_headers(Headers headers);
+ 
+   void
+-  set_header_writer(std::function<ssize_t(Stream &, Headers &)> const &writer);
++  set_header_writer(std::function<httplib_ssize_t(Stream &, Headers &)> const &writer);
+ 
+   void set_address_family(int family);
+   void set_tcp_nodelay(bool on);
+@@ -1530,7 +1537,7 @@ protected:
+   Headers default_headers_;
+ 
+   // Header writer
+-  std::function<ssize_t(Stream &, Headers &)> header_writer_ =
++  std::function<httplib_ssize_t(Stream &, Headers &)> header_writer_ =
+       detail::write_headers;
+ 
+   // Settings
+@@ -1849,7 +1856,7 @@ public:
+   void set_default_headers(Headers headers);
+ 
+   void
+-  set_header_writer(std::function<ssize_t(Stream &, Headers &)> const &writer);
++  set_header_writer(std::function<httplib_ssize_t(Stream &, Headers &)> const &writer);
+ 
+   void set_address_family(int family);
+   void set_tcp_nodelay(bool on);
+@@ -2045,7 +2052,7 @@ inline uint64_t get_header_value_u64(const Headers &headers,
+   is_invalid_value = false;
+   auto rng = headers.equal_range(key);
+   auto it = rng.first;
+-  std::advance(it, static_cast<ssize_t>(id));
++  std::advance(it, static_cast<httplib_ssize_t>(id));
+   if (it != rng.second) {
+     if (is_numeric(it->second)) {
+       return std::strtoull(it->second.data(), nullptr, 10);
+@@ -2399,9 +2406,9 @@ bool parse_range_header(const std::string &s, Ranges &ranges);
+ 
+ int close_socket(socket_t sock);
+ 
+-ssize_t send_socket(socket_t sock, const void *ptr, size_t size, int flags);
++httplib_ssize_t send_socket(socket_t sock, const void *ptr, size_t size, int flags);
+ 
+-ssize_t read_socket(socket_t sock, void *ptr, size_t size, int flags);
++httplib_ssize_t read_socket(socket_t sock, void *ptr, size_t size, int flags);
+ 
+ enum class EncodingType { None = 0, Gzip, Brotli };
+ 
+@@ -2414,8 +2421,8 @@ public:
+ 
+   bool is_readable() const override;
+   bool is_writable() const override;
+-  ssize_t read(char *ptr, size_t size) override;
+-  ssize_t write(const char *ptr, size_t size) override;
++  httplib_ssize_t read(char *ptr, size_t size) override;
++  httplib_ssize_t write(const char *ptr, size_t size) override;
+   void get_remote_ip_and_port(std::string &ip, int &port) const override;
+   void get_local_ip_and_port(std::string &ip, int &port) const override;
+   socket_t socket() const override;
+@@ -3172,8 +3179,8 @@ inline int close_socket(socket_t sock) {
+ #endif
+ }
+ 
+-template <typename T> inline ssize_t handle_EINTR(T fn) {
+-  ssize_t res = 0;
++template <typename T> inline httplib_ssize_t handle_EINTR(T fn) {
++  httplib_ssize_t res = 0;
+   while (true) {
+     res = fn();
+     if (res < 0 && errno == EINTR) {
+@@ -3185,7 +3192,7 @@ template <typename T> inline ssize_t handle_EINTR(T fn) {
+   return res;
+ }
+ 
+-inline ssize_t read_socket(socket_t sock, void *ptr, size_t size, int flags) {
++inline httplib_ssize_t read_socket(socket_t sock, void *ptr, size_t size, int flags) {
+   return handle_EINTR([&]() {
+     return recv(sock,
+ #ifdef _WIN32
+@@ -3197,7 +3204,7 @@ inline ssize_t read_socket(socket_t sock, void *ptr, size_t size, int flags) {
+   });
+ }
+ 
+-inline ssize_t send_socket(socket_t sock, const void *ptr, size_t size,
++inline httplib_ssize_t send_socket(socket_t sock, const void *ptr, size_t size,
+                            int flags) {
+   return handle_EINTR([&]() {
+     return send(sock,
+@@ -3211,7 +3218,7 @@ inline ssize_t send_socket(socket_t sock, const void *ptr, size_t size,
+ }
+ 
+ template <bool Read>
+-inline ssize_t select_impl(socket_t sock, time_t sec, time_t usec) {
++inline httplib_ssize_t select_impl(socket_t sock, time_t sec, time_t usec) {
+ #ifdef CPPHTTPLIB_USE_POLL
+   struct pollfd pfd;
+   pfd.fd = sock;
+@@ -3241,11 +3248,11 @@ inline ssize_t select_impl(socket_t sock, time_t sec, time_t usec) {
+ #endif
+ }
+ 
+-inline ssize_t select_read(socket_t sock, time_t sec, time_t usec) {
++inline httplib_ssize_t select_read(socket_t sock, time_t sec, time_t usec) {
+   return select_impl<true>(sock, sec, usec);
+ }
+ 
+-inline ssize_t select_write(socket_t sock, time_t sec, time_t usec) {
++inline httplib_ssize_t select_write(socket_t sock, time_t sec, time_t usec) {
+   return select_impl<false>(sock, sec, usec);
+ }
+ 
+@@ -3328,8 +3335,8 @@ public:
+ 
+   bool is_readable() const override;
+   bool is_writable() const override;
+-  ssize_t read(char *ptr, size_t size) override;
+-  ssize_t write(const char *ptr, size_t size) override;
++  httplib_ssize_t read(char *ptr, size_t size) override;
++  httplib_ssize_t write(const char *ptr, size_t size) override;
+   void get_remote_ip_and_port(std::string &ip, int &port) const override;
+   void get_local_ip_and_port(std::string &ip, int &port) const override;
+   socket_t socket() const override;
+@@ -3364,8 +3371,8 @@ public:
+ 
+   bool is_readable() const override;
+   bool is_writable() const override;
+-  ssize_t read(char *ptr, size_t size) override;
+-  ssize_t write(const char *ptr, size_t size) override;
++  httplib_ssize_t read(char *ptr, size_t size) override;
++  httplib_ssize_t write(const char *ptr, size_t size) override;
+   void get_remote_ip_and_port(std::string &ip, int &port) const override;
+   void get_local_ip_and_port(std::string &ip, int &port) const override;
+   socket_t socket() const override;
+@@ -4216,7 +4223,7 @@ inline const char *get_header_value(const Headers &headers,
+                                     size_t id) {
+   auto rng = headers.equal_range(key);
+   auto it = rng.first;
+-  std::advance(it, static_cast<ssize_t>(id));
++  std::advance(it, static_cast<httplib_ssize_t>(id));
+   if (it != rng.second) { return it->second.c_str(); }
+   return def;
+ }
+@@ -4514,7 +4521,7 @@ bool read_content(Stream &strm, T &x, size_t payload_max_length, int &status,
+       });
+ }
+ 
+-inline ssize_t write_request_line(Stream &strm, const std::string &method,
++inline httplib_ssize_t write_request_line(Stream &strm, const std::string &method,
+                                   const std::string &path) {
+   std::string s = method;
+   s += " ";
+@@ -4523,7 +4530,7 @@ inline ssize_t write_request_line(Stream &strm, const std::string &method,
+   return strm.write(s.data(), s.size());
+ }
+ 
+-inline ssize_t write_response_line(Stream &strm, int status) {
++inline httplib_ssize_t write_response_line(Stream &strm, int status) {
+   std::string s = "HTTP/1.1 ";
+   s += std::to_string(status);
+   s += " ";
+@@ -4532,8 +4539,8 @@ inline ssize_t write_response_line(Stream &strm, int status) {
+   return strm.write(s.data(), s.size());
+ }
+ 
+-inline ssize_t write_headers(Stream &strm, const Headers &headers) {
+-  ssize_t write_len = 0;
++inline httplib_ssize_t write_headers(Stream &strm, const Headers &headers) {
++  httplib_ssize_t write_len = 0;
+   for (const auto &x : headers) {
+     std::string s;
+     s = x.first;
+@@ -4888,9 +4895,9 @@ inline bool parse_range_header(const std::string &s, Ranges &ranges) try {
+       }
+ 
+       const auto first =
+-          static_cast<ssize_t>(lhs.empty() ? -1 : std::stoll(lhs));
++          static_cast<httplib_ssize_t>(lhs.empty() ? -1 : std::stoll(lhs));
+       const auto last =
+-          static_cast<ssize_t>(rhs.empty() ? -1 : std::stoll(rhs));
++          static_cast<httplib_ssize_t>(rhs.empty() ? -1 : std::stoll(rhs));
+       if ((first == -1 && last == -1) ||
+           (first != -1 && last != -1 && first > last)) {
+         all_valid_ranges = false;
+@@ -5238,11 +5245,11 @@ serialize_multipart_formdata(const MultipartFormDataItems &items,
+ 
+ inline bool range_error(Request &req, Response &res) {
+   if (!req.ranges.empty() && 200 <= res.status && res.status < 300) {
+-    ssize_t contant_len = static_cast<ssize_t>(
++    httplib_ssize_t contant_len = static_cast<httplib_ssize_t>(
+         res.content_length_ ? res.content_length_ : res.body.size());
+ 
+-    ssize_t prev_first_pos = -1;
+-    ssize_t prev_last_pos = -1;
++    httplib_ssize_t prev_first_pos = -1;
++    httplib_ssize_t prev_last_pos = -1;
+     size_t overwrapping_count = 0;
+ 
+     // NOTE: The following Range check is based on '14.2. Range' in RFC 9110
+@@ -5305,9 +5312,9 @@ inline bool range_error(Request &req, Response &res) {
+ inline std::pair<size_t, size_t>
+ get_range_offset_and_length(Range r, size_t content_length) {
+   assert(r.first != -1 && r.second != -1);
+-  assert(0 <= r.first && r.first < static_cast<ssize_t>(content_length));
++  assert(0 <= r.first && r.first < static_cast<httplib_ssize_t>(content_length));
+   assert(r.first <= r.second &&
+-         r.second < static_cast<ssize_t>(content_length));
++         r.second < static_cast<httplib_ssize_t>(content_length));
+   (void)(content_length);
+   return std::make_pair(r.first, static_cast<size_t>(r.second - r.first) + 1);
+ }
+@@ -5832,7 +5839,7 @@ inline std::string Request::get_param_value(const std::string &key,
+                                             size_t id) const {
+   auto rng = params.equal_range(key);
+   auto it = rng.first;
+-  std::advance(it, static_cast<ssize_t>(id));
++  std::advance(it, static_cast<httplib_ssize_t>(id));
+   if (it != rng.second) { return it->second; }
+   return std::string();
+ }
+@@ -5983,11 +5990,11 @@ Result::get_request_header_value_count(const std::string &key) const {
+ }
+ 
+ // Stream implementation
+-inline ssize_t Stream::write(const char *ptr) {
++inline httplib_ssize_t Stream::write(const char *ptr) {
+   return write(ptr, strlen(ptr));
+ }
+ 
+-inline ssize_t Stream::write(const std::string &s) {
++inline httplib_ssize_t Stream::write(const std::string &s) {
+   return write(s.data(), s.size());
+ }
+ 
+@@ -6039,13 +6046,13 @@ inline bool SocketStream::is_writable() const {
+          is_socket_alive(sock_);
+ }
+ 
+-inline ssize_t SocketStream::read(char *ptr, size_t size) {
++inline httplib_ssize_t SocketStream::read(char *ptr, size_t size) {
+ #ifdef _WIN32
+   size =
+       (std::min)(size, static_cast<size_t>((std::numeric_limits<int>::max)()));
+ #else
+   size = (std::min)(size,
+-                    static_cast<size_t>((std::numeric_limits<ssize_t>::max)()));
++                    static_cast<size_t>((std::numeric_limits<httplib_ssize_t>::max)()));
+ #endif
+ 
+   if (read_buff_off_ < read_buff_content_size_) {
+@@ -6053,11 +6060,11 @@ inline ssize_t SocketStream::read(char *ptr, size_t size) {
+     if (size <= remaining_size) {
+       memcpy(ptr, read_buff_.data() + read_buff_off_, size);
+       read_buff_off_ += size;
+-      return static_cast<ssize_t>(size);
++      return static_cast<httplib_ssize_t>(size);
+     } else {
+       memcpy(ptr, read_buff_.data() + read_buff_off_, remaining_size);
+       read_buff_off_ += remaining_size;
+-      return static_cast<ssize_t>(remaining_size);
++      return static_cast<httplib_ssize_t>(remaining_size);
+     }
+   }
+ 
+@@ -6071,21 +6078,21 @@ inline ssize_t SocketStream::read(char *ptr, size_t size) {
+                          CPPHTTPLIB_RECV_FLAGS);
+     if (n <= 0) {
+       return n;
+-    } else if (n <= static_cast<ssize_t>(size)) {
++    } else if (n <= static_cast<httplib_ssize_t>(size)) {
+       memcpy(ptr, read_buff_.data(), static_cast<size_t>(n));
+       return n;
+     } else {
+       memcpy(ptr, read_buff_.data(), size);
+       read_buff_off_ = size;
+       read_buff_content_size_ = static_cast<size_t>(n);
+-      return static_cast<ssize_t>(size);
++      return static_cast<httplib_ssize_t>(size);
+     }
+   } else {
+     return read_socket(sock_, ptr, size, CPPHTTPLIB_RECV_FLAGS);
+   }
+ }
+ 
+-inline ssize_t SocketStream::write(const char *ptr, size_t size) {
++inline httplib_ssize_t SocketStream::write(const char *ptr, size_t size) {
+   if (!is_writable()) { return -1; }
+ 
+ #if defined(_WIN32) && !defined(_WIN64)
+@@ -6119,19 +6126,19 @@ inline bool BufferStream::is_readable() const { return true; }
+ 
+ inline bool BufferStream::is_writable() const { return true; }
+ 
+-inline ssize_t BufferStream::read(char *ptr, size_t size) {
++inline httplib_ssize_t BufferStream::read(char *ptr, size_t size) {
+ #if defined(_MSC_VER) && _MSC_VER < 1910
+   auto len_read = buffer._Copy_s(ptr, size, size, position);
+ #else
+   auto len_read = buffer.copy(ptr, size, position);
+ #endif
+   position += static_cast<size_t>(len_read);
+-  return static_cast<ssize_t>(len_read);
++  return static_cast<httplib_ssize_t>(len_read);
+ }
+ 
+-inline ssize_t BufferStream::write(const char *ptr, size_t size) {
++inline httplib_ssize_t BufferStream::write(const char *ptr, size_t size) {
+   buffer.append(ptr, size);
+-  return static_cast<ssize_t>(size);
++  return static_cast<httplib_ssize_t>(size);
+ }
+ 
+ inline void BufferStream::get_remote_ip_and_port(std::string & /*ip*/,
+@@ -6434,7 +6441,7 @@ inline Server &Server::set_default_headers(Headers headers) {
+ }
+ 
+ inline Server &Server::set_header_writer(
+-    std::function<ssize_t(Stream &, Headers &)> const &writer) {
++    std::function<httplib_ssize_t(Stream &, Headers &)> const &writer) {
+   header_writer_ = writer;
+   return *this;
+ }
+@@ -8949,7 +8956,7 @@ inline void ClientImpl::set_default_headers(Headers headers) {
+ }
+ 
+ inline void ClientImpl::set_header_writer(
+-    std::function<ssize_t(Stream &, Headers &)> const &writer) {
++    std::function<httplib_ssize_t(Stream &, Headers &)> const &writer) {
+   header_writer_ = writer;
+ }
+ 
+@@ -9206,7 +9213,7 @@ inline bool SSLSocketStream::is_writable() const {
+          is_socket_alive(sock_) && !is_ssl_peer_could_be_closed(ssl_, sock_);
+ }
+ 
+-inline ssize_t SSLSocketStream::read(char *ptr, size_t size) {
++inline httplib_ssize_t SSLSocketStream::read(char *ptr, size_t size) {
+   if (SSL_pending(ssl_) > 0) {
+     return SSL_read(ssl_, ptr, static_cast<int>(size));
+   } else if (is_readable()) {
+@@ -9239,7 +9246,7 @@ inline ssize_t SSLSocketStream::read(char *ptr, size_t size) {
+   }
+ }
+ 
+-inline ssize_t SSLSocketStream::write(const char *ptr, size_t size) {
++inline httplib_ssize_t SSLSocketStream::write(const char *ptr, size_t size) {
+   if (is_writable()) {
+     auto handle_size = static_cast<int>(
+         std::min<size_t>(size, (std::numeric_limits<int>::max)()));
+@@ -10342,7 +10349,7 @@ inline void Client::set_default_headers(Headers headers) {
+ }
+ 
+ inline void Client::set_header_writer(
+-    std::function<ssize_t(Stream &, Headers &)> const &writer) {
++    std::function<httplib_ssize_t(Stream &, Headers &)> const &writer) {
+   cli_->set_header_writer(writer);
+ }

--- a/depends/common/cpp-httplib/cpp-httplib.txt
+++ b/depends/common/cpp-httplib/cpp-httplib.txt
@@ -1,0 +1,1 @@
+cpp-httplib https://github.com/yhirose/cpp-httplib/archive/refs/tags/v0.19.0.tar.gz

--- a/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.iptvsimple/resources/language/resource.language.en_gb/strings.po
@@ -1130,3 +1130,18 @@ msgstr ""
 msgctxt "#30806"
 msgid "Force the full playlist to be media, regardless of what tags are present.  Since the introduction of multiple instances for PVR add-ons this option can be useful."
 msgstr ""
+
+#. label: WebServer
+msgctxt "#30807"
+msgid "WebServer"
+msgstr ""
+
+#. label: WebServer - Activate
+msgctxt "#30808"
+msgid "Activate"
+msgstr ""
+
+#. label: WebServer - Port
+msgctxt "#30809"
+msgid "Port"
+msgstr ""

--- a/src/IptvSimple.h
+++ b/src/IptvSimple.h
@@ -86,6 +86,9 @@ public:
   // For catchup
   bool GetChannel(unsigned int uniqueChannelId, iptvsimple::data::Channel& myChannel);
   iptvsimple::CatchupController& GetCatchupController() { return m_catchupController; }
+
+  // Add a method to get the Channels instance
+  iptvsimple::Channels& GetChannelsManager() { return m_channels; }
   //@}
 
 protected:

--- a/src/addon.cpp
+++ b/src/addon.cpp
@@ -5,13 +5,19 @@
  *  See LICENSE.md for more information.
  */
 
+#include "iptvsimple/HttpServer.h"
+#include "iptvsimple/views/ChannelsView.h"
 #include "addon.h"
 #include "IptvSimple.h"
 #include "iptvsimple/utilities/SettingsMigration.h"
-
 using namespace iptvsimple;
 using namespace iptvsimple::data;
 using namespace iptvsimple::utilities;
+
+CIptvSimpleAddon::~CIptvSimpleAddon()
+{
+  Logger::Log(LogLevel::LEVEL_INFO, "%s IPTV Simple PVR client destroyed", __func__);
+}
 
 ADDON_STATUS CIptvSimpleAddon::Create()
 {
@@ -48,6 +54,19 @@ ADDON_STATUS CIptvSimpleAddon::Create()
   Logger::GetInstance().SetPrefix("pvr.iptvsimple");
 
   Logger::Log(LogLevel::LEVEL_INFO, "%s starting IPTV Simple PVR client...", __func__);
+
+  bool activateWebServer = true;
+  // TODO: Add a main setting option for the web server runs
+  if (activateWebServer)
+  {
+    m_httpServer = std::make_unique<iptvsimple::HttpServer>();
+    if (m_httpServer)
+    {
+      auto channelsView = std::make_shared<ChannelsView>(m_usedInstances);
+      m_httpServer->AddView(channelsView);
+      Logger::Log(LogLevel::LEVEL_INFO, "HTTP Server and ChannelsView initialized successfully");
+    }
+  }
 
   return ADDON_STATUS_OK;
 }

--- a/src/addon.h
+++ b/src/addon.h
@@ -20,6 +20,7 @@ class ATTR_DLL_LOCAL CIptvSimpleAddon : public kodi::addon::CAddonBase
 {
 public:
   CIptvSimpleAddon() = default;
+  ~CIptvSimpleAddon() override;
 
   ADDON_STATUS Create() override;
   ADDON_STATUS SetSetting(const std::string& settingName, const kodi::addon::CSettingValue& settingValue) override;
@@ -29,4 +30,5 @@ public:
 private:
   std::unordered_map<std::string, IptvSimple*> m_usedInstances;
   std::shared_ptr<iptvsimple::AddonSettings> m_settings;
+  std::unique_ptr<iptvsimple::HttpServer> m_httpServer;
 };

--- a/src/iptvsimple/Channels.cpp
+++ b/src/iptvsimple/Channels.cpp
@@ -134,6 +134,17 @@ Channel* Channels::GetChannel(int uniqueId)
   return nullptr;
 }
 
+iptvsimple::data::Channel* Channels::FindChannel(int uniqueId)
+{
+  for (auto& myChannel : m_channels)
+  {
+    if (myChannel.GetUniqueId() == uniqueId)    
+      return &myChannel;
+  }
+
+  return nullptr;
+}
+
 const Channel* Channels::FindChannel(const std::string& id, const std::string& displayName) const
 {
   for (const auto& myChannel : m_channels)

--- a/src/iptvsimple/Channels.h
+++ b/src/iptvsimple/Channels.h
@@ -40,6 +40,7 @@ namespace iptvsimple
     bool AddChannel(iptvsimple::data::Channel& channel, std::vector<int>& groupIdList, iptvsimple::ChannelGroups& channelGroups, bool channelHadGroups);
     iptvsimple::data::Channel* GetChannel(int uniqueId);
     const iptvsimple::data::Channel* FindChannel(const std::string& id, const std::string& displayName) const;
+    iptvsimple::data::Channel* FindChannel(int uniqueId);
     const std::vector<data::Channel>& GetChannelsList() const { return m_channels; }
     void Clear();
 

--- a/src/iptvsimple/HttpServer.cpp
+++ b/src/iptvsimple/HttpServer.cpp
@@ -1,0 +1,250 @@
+#include "HttpServer.h"
+
+
+using namespace iptvsimple;
+
+HttpServer::HttpServer()
+{
+  Initialize();
+}
+
+HttpServer::~HttpServer()
+{
+  Shutdown();
+}
+
+void HttpServer::AddView(std::shared_ptr<IHttpView> view)
+{
+  if (view)
+  {
+    views.push_back(view);
+    view->RegisterViews(svr);
+  }
+}
+
+bool HttpServer::Initialize()
+{
+  kodi::Log(ADDON_LOG_INFO, "Initializing HTTP Server");
+  svr.Get(R"(/|/index.html)",
+          [this](const httplib::Request& req, httplib::Response& res)
+          {
+            std::string body =
+                "<!DOCTYPE html>\n"
+                "<html lang=\"en\">\n"
+                "<head>\n"
+                "    <meta charset=\"UTF-8\">\n"
+                "    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">\n"
+                "    <title>IPTV Simple PVR Client</title>\n"
+                "    <style>\n"
+                "        /* Reset default styles */\n"
+                "        * {\n"
+                "            margin: 0;\n"
+                "            padding: 0;\n"
+                "            box-sizing: border-box;\n"
+                "        }\n"
+                "\n"
+                "        html, body {\n"
+                "            height: 100%;\n"
+                "        }\n"
+                "\n"
+                "        body {\n"
+                "            font-family: 'Segoe UI', Arial, sans-serif;\n"
+                "            background-color: #f4f7fa;\n"
+                "            color: #333;\n"
+                "            line-height: 1.6;\n"
+                "            padding: 0;\n"
+                "            display: flex;\n"
+                "            flex-direction: column;\n"
+                "            min-height: 100vh;\n"
+                "        }\n"
+                "\n"
+                "        /* Header styling */\n"
+                "        header {\n"
+                "            background: linear-gradient(135deg, #007bff, #0056b3);\n"
+                "            color: white;\n"
+                "            text-align: center;\n"
+                "            padding: 2rem 1rem;\n"
+                "            box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);\n"
+                "        }\n"
+                "\n"
+                "        header h1 {\n"
+                "            font-size: 2.5rem;\n"
+                "            margin-bottom: 0.5rem;\n"
+                "        }\n"
+                "\n"
+                "        /* Main container */\n"
+                "        .container {\n"
+                "            max-width: 800px;\n"
+                "            margin: 2rem auto;\n"
+                "            padding: 0 1rem;\n"
+                "            flex: 1;\n"
+                "        }\n"
+                "\n"
+                "        /* Section styling */\n"
+                "        section {\n"
+                "            background: white;\n"
+                "            border-radius: 8px;\n"
+                "            padding: 2rem;\n"
+                "            box-shadow: 0 4px 10px rgba(0, 0, 0, 0.05);\n"
+                "        }\n"
+                "\n"
+                "        section h2 {\n"
+                "            font-size: 1.8rem;\n"
+                "            color: #007bff;\n"
+                "            margin-bottom: 1rem;\n"
+                "        }\n"
+                "\n"
+                "        /* List styling */\n"
+                "        ul {\n"
+                "            list-style: none;\n"
+                "        }\n"
+                "\n"
+                "        ul li {\n"
+                "            margin: 0.5rem 0;\n"
+                "        }\n"
+                "\n"
+                "        ul li a {\n"
+                "            display: inline-block;\n"
+                "            text-decoration: none;\n"
+                "            color: #ffffff;\n"
+                "            background-color: #007bff;\n"
+                "            padding: 0.75rem 1.5rem;\n"
+                "            border-radius: 5px;\n"
+                "            transition: background-color 0.3s ease, transform 0.2s ease;\n"
+                "        }\n"
+                "\n"
+                "        ul li a:hover {\n"
+                "            background-color: #0056b3;\n"
+                "            transform: translateY(-2px);\n"
+                "        }\n"
+                "\n"
+                "        /* Responsive design */\n"
+                "        @media (max-width: 600px) {\n"
+                "            header h1 {\n"
+                "                font-size: 1.8rem;\n"
+                "            }\n"
+                "\n"
+                "            section {\n"
+                "                padding: 1.5rem;\n"
+                "            }\n"
+                "\n"
+                "            ul li a {\n"
+                "                padding: 0.6rem 1.2rem;\n"
+                "                font-size: 0.9rem;\n"
+                "            }\n"
+                "        }\n"
+                "\n"
+                "        /* Footer */\n"
+                "        footer {\n"
+                "            text-align: center;\n"
+                "            padding: 1rem;\n"
+                "            background-color: #007bff;\n"
+                "            color: white;\n"
+                "            width: 100%;\n"
+                "            margin-top: 2rem;\n"
+                "        }\n"
+                "    </style>\n"
+                "</head>\n"
+                "<body>\n"
+                "    <header>\n"
+                "        <h1>IPTV Simple PVR Client</h1>\n"
+                "    </header>\n"
+                "\n"
+                "    <div class=\"container\">\n"
+                "        <section>\n"
+                "            <h2>Available Views</h2>\n"
+                "            <ul>\n";
+            for (const auto& view : views)
+            {
+              body += "  <li><a href='" + view->GetViewUrl() + "'>" + view->GetViewText() +
+                      "</a></li>\n";
+            }
+            body += "</ul>\n";
+            body += "        </section>\n"
+                    "    </div>\n"
+                    "\n"
+                    "    <footer>\n"
+                    "        <p>&copy; 2025 IPTV Simple PVR Client. All rights reserved.</p>\n"
+                    "    </footer>\n"
+                    "</body>\n"
+                    "</html>";
+            res.set_content(body, "text/html");
+          });
+
+  svr.set_error_handler(
+      [](const auto& req, auto& res)
+      {
+        auto fmt = "<p>Error Status: <span style='color:red;'>%d</span></p>";
+        char buf[BUFSIZ];
+        snprintf(buf, sizeof(buf), fmt, res.status);
+        res.set_content(buf, "text/html");
+      });
+
+  svr.set_exception_handler(
+      [](const auto& req, auto& res, std::exception_ptr ep)
+      {
+        auto fmt = "<h1>Error 500</h1><p>%s</p>";
+        char buf[BUFSIZ];
+        try
+        {
+          std::rethrow_exception(ep);
+        }
+        catch (std::exception& e)
+        {
+          snprintf(buf, sizeof(buf), fmt, e.what());
+        }
+        catch (...)
+        {
+          snprintf(buf, sizeof(buf), fmt, "Unknown Exception");
+        }
+        res.set_content(buf, "text/html");
+        res.status = 500;
+      });
+
+  svr.set_logger(
+      [](const auto& req, const auto& res)
+      {
+        std::string logMessage = "HTTP Request: Method=" + req.method + ", Path=" + req.path +
+                                 ", Status=" + std::to_string(res.status);
+        kodi::Log(ADDON_LOG_DEBUG, logMessage.c_str());
+      });
+
+  int port = 8080;
+
+  t = std::thread(
+      [&]()
+      {
+        if (!svr.listen("0.0.0.0", port))
+        {
+          kodi::Log(ADDON_LOG_ERROR, "Server is not running on port %d", port);
+          svr.stop();
+          port = svr.bind_to_any_port("0.0.0.0");
+          if (!svr.listen_after_bind())
+          {
+            kodi::Log(ADDON_LOG_ERROR, "Failed to listen on any port");
+          }
+        }
+      });
+
+  svr.wait_until_ready();
+  svr.wait_until_ready();
+  if (svr.is_running())
+  {
+    // TODO: Add main settings option for port configuration.
+    kodi::Log(ADDON_LOG_INFO, "Server is running on port %d.", port);
+    return true;
+  }
+
+  return false;
+}
+
+void HttpServer::Shutdown()
+{
+  kodi::Log(ADDON_LOG_INFO, "Shutting down HTTP Server");
+  svr.stop();
+  t.join();
+  if (!svr.is_running())
+  {
+    kodi::Log(ADDON_LOG_INFO, "Server is stopped");
+  }
+}

--- a/src/iptvsimple/HttpServer.h
+++ b/src/iptvsimple/HttpServer.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "IHttpView.h"
+
+#include <kodi/General.h>
+
+#include <memory>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+namespace iptvsimple
+{
+
+class HttpServer
+{
+public:
+  HttpServer();
+  ~HttpServer();
+
+  // Prevent copy/move
+  HttpServer(const HttpServer&) = delete;
+  HttpServer& operator=(const HttpServer&) = delete;
+  HttpServer(HttpServer&&) = delete;
+  HttpServer& operator=(HttpServer&&) = delete;
+
+  // Add an endpoint interface to the server
+  void AddView(std::shared_ptr<IHttpView> view);
+
+private:
+  httplib::Server svr;
+  std::thread t;
+  std::vector<std::shared_ptr<IHttpView>> views;
+
+  // Initialize the server
+  bool Initialize();
+
+  // Shutdown the server
+  void Shutdown();
+};
+
+} // namespace iptvsimple

--- a/src/iptvsimple/IHttpView.h
+++ b/src/iptvsimple/IHttpView.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <httplib.h>
+
+namespace iptvsimple
+{
+
+class IHttpView
+{
+public:
+  virtual ~IHttpView() = default;
+  virtual void RegisterViews(httplib::Server& server) = 0;
+  virtual std::string GetViewUrl() const = 0;
+  virtual std::string GetViewText() const = 0;
+};
+
+} // namespace iptvsimple

--- a/src/iptvsimple/views/ChannelsView.cpp
+++ b/src/iptvsimple/views/ChannelsView.cpp
@@ -1,0 +1,395 @@
+#include "ChannelsView.h"
+
+#include <algorithm>
+#include <sstream>
+
+
+using namespace iptvsimple::utilities;
+namespace iptvsimple
+{
+
+ChannelsView::ChannelsView(std::unordered_map<std::string, IptvSimple*>& usedInstances)
+  : m_usedInstances(usedInstances)
+{
+}
+
+std::string ChannelsView::GetViewUrl() const
+{
+  return "/instances";
+}
+
+std::string ChannelsView::GetViewText() const
+{
+  return "IPTV Simple Instances";
+}
+
+void ChannelsView::RegisterViews(httplib::Server& server)
+{
+  // Main page view - List of instances
+  server.Get("/instances", [this](const httplib::Request& req, httplib::Response& res)
+             { ShowInstances(req, res); });
+
+  // Instance channels view
+  server.Get("/instances/:id", [this](const httplib::Request& req, httplib::Response& res)
+             { ShowInstanceChannels(req, res); });
+
+  // Edit channel form
+  server.Get("/instances/:id/channels/:channelId/edit",
+             [this](const httplib::Request& req, httplib::Response& res)
+             { ShowEditChannelForm(req, res); });
+
+  // Update channel
+  server.Post("/instances/:id/channels/:channelId",
+              [this](const httplib::Request& req, httplib::Response& res)
+              { UpdateChannel(req, res); });
+}
+
+std::string ChannelsView::GetBaseHtmlTemplate(const std::string& title, const std::string& body)
+{
+  std::string html = HTML_TEMPLATE;
+  size_t titlePos = html.find("{title}");
+  if (titlePos != std::string::npos)
+    html.replace(titlePos, 7, title);
+
+  size_t bodyPos = html.find("{body}");
+  if (bodyPos != std::string::npos)
+    html.replace(bodyPos, 6, body);
+
+  return html;
+}
+
+std::string ChannelsView::GetInstancesListHtml(
+    const std::unordered_map<std::string, IptvSimple*>& instances)
+{
+  std::stringstream ss;
+  ss << "<div class='back'><a href='/'>+ Back to Home</a></div>\n"
+     << "<h1>IPTV Simple Instances</h1>\n"
+     << "<div class='instances'>\n";
+
+  if (instances.empty())
+  {
+    ss << "    <div class='instance'>\n"
+       << "      <h2>No instances available</h2>\n"
+       << "    </div>\n";
+  }
+  else
+  {
+    for (const auto& [id, instance] : instances)
+    {
+      std::string instanceHtml = INSTANCE_TEMPLATE;
+      size_t idPos = instanceHtml.find("{id}");
+      while (idPos != std::string::npos)
+      {
+        instanceHtml.replace(idPos, 4, id);
+        idPos = instanceHtml.find("{id}", idPos + id.length());
+      }
+      ss << instanceHtml;
+    }
+  }
+
+  ss << "</div>";
+  return ss.str();
+}
+
+std::string ChannelsView::GetChannelsListHtml(const std::string& instanceId, Channels& channels)
+{
+  std::stringstream ss;
+  ss << "<div class='back'><a href='/instances'>+ Back to Instances</a></div>\n"
+     << "<h1>Instance " << instanceId << " Channels</h1>\n"
+     << "<div class='channels'>\n";
+
+  if (channels.GetChannelsList().empty())
+  {
+    ss << "    <div class='channel'>\n"
+       << "      <h2>No channels available</h2>\n"
+       << "    </div>\n";
+  }
+  else
+  {
+    for (const auto& channel : channels.GetChannelsList())
+    {
+      std::string channelHtml = CHANNEL_TEMPLATE;
+      size_t namePos = channelHtml.find("{name}");
+      if (namePos != std::string::npos)
+        channelHtml.replace(namePos, 6, channel.GetChannelName());
+
+      size_t streamUrlPos = channelHtml.find("{stream_url}");
+      if (streamUrlPos != std::string::npos)
+        channelHtml.replace(streamUrlPos, 12, channel.GetStreamURL());
+
+      size_t instanceIdPos = channelHtml.find("{instance_id}");
+      if (instanceIdPos != std::string::npos)
+        channelHtml.replace(instanceIdPos, 13, instanceId);
+
+      size_t channelIdPos = channelHtml.find("{channel_id}");
+      if (channelIdPos != std::string::npos)
+        channelHtml.replace(channelIdPos, 12, std::to_string(channel.GetUniqueId()));
+
+      ss << channelHtml;
+    }
+  }
+
+  ss << "</div>";
+  return ss.str();
+}
+
+std::string ChannelsView::GetEditChannelFormHtml(const std::string& instanceId,
+                                                 const iptvsimple::data::Channel& channel)
+{
+  std::string formHtml = EDIT_FORM_TEMPLATE;
+
+  size_t instanceIdPos = formHtml.find("{instance_id}");
+  while (instanceIdPos != std::string::npos)
+  {
+    formHtml.replace(instanceIdPos, 13, instanceId);
+    instanceIdPos = formHtml.find("{instance_id}", instanceIdPos + instanceId.length());
+  }
+
+  size_t channelIdPos = formHtml.find("{channel_id}");
+  if (channelIdPos != std::string::npos)
+    formHtml.replace(channelIdPos, 12, std::to_string(channel.GetUniqueId()));
+
+  size_t namePos = formHtml.find("{name}");
+  if (namePos != std::string::npos)
+    formHtml.replace(namePos, 6, channel.GetChannelName());
+
+  size_t streamUrlPos = formHtml.find("{stream_url}");
+  if (streamUrlPos != std::string::npos)
+    formHtml.replace(streamUrlPos, 12, channel.GetStreamURL());
+
+  size_t catchupModePos = formHtml.find("{catchup_mode}");
+  if (catchupModePos != std::string::npos)
+    formHtml.replace(catchupModePos, 14,
+                     std::to_string(static_cast<int>(channel.GetCatchupMode())));
+
+  size_t channelNumberPos = formHtml.find("{channel_number}");
+  if (channelNumberPos != std::string::npos)
+    formHtml.replace(channelNumberPos, 16, std::to_string(channel.GetChannelNumber()));
+
+  size_t subChannelNumberPos = formHtml.find("{sub_channel_number}");
+  if (subChannelNumberPos != std::string::npos)
+    formHtml.replace(subChannelNumberPos, 20, std::to_string(channel.GetSubChannelNumber()));
+
+  size_t tvgShiftPos = formHtml.find("{tvg_shift}");
+  if (tvgShiftPos != std::string::npos)
+    formHtml.replace(tvgShiftPos, 11, std::to_string(channel.GetTvgShift()));
+
+  size_t catchupDaysPos = formHtml.find("{catchup_days}");
+  if (catchupDaysPos != std::string::npos)
+    formHtml.replace(catchupDaysPos, 14, std::to_string(channel.GetCatchupDays()));
+
+  size_t catchupSourcePos = formHtml.find("{catchup_source}");
+  if (catchupSourcePos != std::string::npos)
+    formHtml.replace(catchupSourcePos, 16, channel.GetCatchupSource());
+
+  size_t catchupTSStreamPos = formHtml.find("{catchup_ts_stream}");
+  if (catchupTSStreamPos != std::string::npos)
+    formHtml.replace(catchupTSStreamPos, 19, channel.IsCatchupTSStream() ? "checked" : "");
+
+  size_t catchupSupportsTimeshiftingPos = formHtml.find("{catchup_supports_timeshifting}");
+  if (catchupSupportsTimeshiftingPos != std::string::npos)
+    formHtml.replace(catchupSupportsTimeshiftingPos, 31,
+                     channel.CatchupSupportsTimeshifting() ? "checked" : "");
+
+  size_t catchupSourceTerminatesPos = formHtml.find("{catchup_source_terminates}");
+  if (catchupSourceTerminatesPos != std::string::npos)
+    formHtml.replace(catchupSourceTerminatesPos, 27,
+                     channel.CatchupSourceTerminates() ? "checked" : "");
+
+  size_t catchupGranularitySecondsPos = formHtml.find("{catchup_granularity_seconds}");
+  if (catchupGranularitySecondsPos != std::string::npos)
+    formHtml.replace(catchupGranularitySecondsPos, 29,
+                     std::to_string(channel.GetCatchupGranularitySeconds()));
+
+  size_t catchupCorrectionSecsPos = formHtml.find("{catchup_correction_secs}");
+  if (catchupCorrectionSecsPos != std::string::npos)
+    formHtml.replace(catchupCorrectionSecsPos, 25,
+                     std::to_string(channel.GetCatchupCorrectionSecs()));
+
+  size_t tvgIdPos = formHtml.find("{tvg_id}");
+  if (tvgIdPos != std::string::npos)
+    formHtml.replace(tvgIdPos, 8, channel.GetTvgId());
+
+  size_t tvgNamePos = formHtml.find("{tvg_name}");
+  if (tvgNamePos != std::string::npos)
+    formHtml.replace(tvgNamePos, 10, channel.GetTvgName());
+
+  size_t inputStreamNamePos = formHtml.find("{input_stream_name}");
+  if (inputStreamNamePos != std::string::npos)
+    formHtml.replace(inputStreamNamePos, 19, channel.GetInputStreamName());
+
+  size_t iconPathPos = formHtml.find("{icon_path}");
+  if (iconPathPos != std::string::npos)
+    formHtml.replace(iconPathPos, 11, channel.GetIconPath());
+
+  size_t hasCatchupPos = formHtml.find("{has_catchup}");
+  if (hasCatchupPos != std::string::npos)
+    formHtml.replace(hasCatchupPos, 13, channel.HasCatchup() ? "checked" : "");
+
+  std::string propertiesHtml = CreatePropertiesHtml(channel.GetProperties());
+  size_t propertiesPos = formHtml.find("{properties}");
+  if (propertiesPos != std::string::npos)
+    formHtml.replace(propertiesPos, 12, propertiesHtml);
+
+  return formHtml;
+}
+
+void ChannelsView::ShowInstances(const httplib::Request& req, httplib::Response& res)
+{
+  std::string body = GetInstancesListHtml(m_usedInstances);
+  std::string html = GetBaseHtmlTemplate("IPTV Simple - Instances", body);
+  res.set_content(html, HTTP_CONTENT_TYPE_HTML);
+}
+
+void ChannelsView::ShowInstanceChannels(const httplib::Request& req, httplib::Response& res)
+{
+  std::string instanceId = req.path_params.at("id");
+  Logger::Log(LogLevel::LEVEL_INFO, "Instance ID: %s", instanceId.c_str());
+  auto it = m_usedInstances.find(instanceId);
+  if (it != m_usedInstances.end())
+  {
+    std::string body = GetChannelsListHtml(instanceId, it->second->GetChannelsManager());
+    std::string html =
+        GetBaseHtmlTemplate("IPTV Simple - Instance " + instanceId + " Channels", body);
+    res.set_content(html, HTTP_CONTENT_TYPE_HTML);
+  }
+  else
+  {
+    res.status = 404;
+    res.set_content(HTTP_404_MESSAGE, HTTP_CONTENT_TYPE_PLAIN);
+  }
+}
+
+void ChannelsView::ShowEditChannelForm(const httplib::Request& req, httplib::Response& res)
+{
+  std::string instanceId = req.path_params.at("id");
+  std::string channelId = req.path_params.at("channelId");
+  auto instanceIt = m_usedInstances.find(instanceId);
+  if (instanceIt != m_usedInstances.end())
+  {
+    iptvsimple::data::Channel* channel =
+        instanceIt->second->GetChannelsManager().FindChannel(std::stoi(channelId));
+    if (channel != nullptr)
+    {
+
+      std::string body = GetEditChannelFormHtml(instanceId, *channel);
+      std::string html = GetBaseHtmlTemplate("Edit Channel", body);
+      res.set_content(html, HTTP_CONTENT_TYPE_HTML);
+    }
+    else
+    {
+      Logger::Log(LogLevel::LEVEL_ERROR, "Channel is null");
+      res.status = 404;
+      res.set_content(HTTP_404_CHANNEL_MESSAGE, HTTP_CONTENT_TYPE_PLAIN);
+    }
+  }
+  else
+  {
+    res.status = 404;
+    res.set_content(HTTP_404_MESSAGE, HTTP_CONTENT_TYPE_PLAIN);
+  }
+}
+
+void ChannelsView::UpdateChannel(const httplib::Request& req, httplib::Response& res)
+{
+  std::string instanceId = req.path_params.at("id");
+  std::string channelId = req.path_params.at("channelId");
+
+  auto instanceIt = m_usedInstances.find(instanceId);
+  if (instanceIt != m_usedInstances.end())
+  {
+    iptvsimple::data::Channel* channel =
+        instanceIt->second->GetChannelsManager().FindChannel(std::stoi(channelId));
+    if (channel != nullptr)
+    {
+      //std::string name = req.get_param_value("name");
+      std::string streamUrl = req.get_param_value("stream_url");
+      std::string channelNumber = req.get_param_value("channel_number");
+      std::string subChannelNumber = req.get_param_value("sub_channel_number");
+      std::string tvgShift = req.get_param_value("tvg_shift");
+      std::string iconPath = req.get_param_value("icon_path");
+      std::string hasCatchup = req.get_param_value("has_catchup");
+      std::string catchupMode = req.get_param_value("catchup_mode");
+      std::string catchupDays = req.get_param_value("catchup_days");
+      std::string catchupSource = req.get_param_value("catchup_source");
+      std::string catchupTSStream = req.get_param_value("catchup_ts_stream");
+      std::string catchupSupportsTimeshifting =
+          req.get_param_value("catchup_supports_timeshifting");
+      std::string catchupSourceTerminates = req.get_param_value("catchup_source_terminates");
+      std::string catchupGranularitySeconds = req.get_param_value("catchup_granularity_seconds");
+      std::string catchupCorrectionSecs = req.get_param_value("catchup_correction_secs");
+      std::string tvgId = req.get_param_value("tvg_id");
+      std::string tvgName = req.get_param_value("tvg_name");
+      std::string inputStreamName = req.get_param_value("input_stream_name");
+      std::multimap<std::string, std::string> params = req.params;
+      std::map<std::string, std::string> properties = channel->GetProperties();
+      for (const auto& [key, value] : params)
+      {
+        if (key.rfind("property_", 0) == 0)
+        {
+          std::string propertyKey = key.substr(9);
+          if (properties.find(propertyKey) == properties.end())
+            properties.insert({propertyKey, value});
+          else
+            properties[propertyKey] = value;
+        }
+      }
+      channel->SetProperties(properties);
+      //channel->SetChannelName(name);
+      channel->SetStreamURL(streamUrl);
+      channel->SetChannelNumber(std::stoi(channelNumber));
+      channel->SetSubChannelNumber(std::stoi(subChannelNumber));
+      channel->SetTvgShift(std::stoi(tvgShift));
+      channel->SetIconPath(iconPath);
+      channel->SetHasCatchup(hasCatchup == "on" ? true : false);
+      int catchupModeInt = std::stoi(catchupMode);
+      if (catchupModeInt >= 0 && catchupModeInt <= 7)
+        channel->SetCatchupMode(static_cast<iptvsimple::CatchupMode>(catchupModeInt));
+      channel->SetCatchupDays(std::stoi(catchupDays));
+      channel->SetCatchupSource(catchupSource);
+      channel->SetCatchupTSStream(catchupTSStream == "on" ? true : false);
+      channel->SetCatchupSupportsTimeshifting(catchupSupportsTimeshifting == "on" ? true : false);
+      channel->SetCatchupSourceTerminates(catchupSourceTerminates == "on" ? true : false);
+      channel->SetCatchupGranularitySeconds(std::stoi(catchupGranularitySeconds));
+      channel->SetCatchupCorrectionSecs(std::stoi(catchupCorrectionSecs));
+      channel->SetTvgId(tvgId);
+      channel->SetTvgName(tvgName);
+      channel->SetInputStreamName(inputStreamName);
+
+      res.set_redirect("/instances/" + instanceId);
+    }
+    else
+    {
+      res.status = 404;
+      res.set_content(HTTP_404_CHANNEL_MESSAGE, HTTP_CONTENT_TYPE_PLAIN);
+    }
+  }
+  else
+  {
+    res.status = 404;
+    res.set_content(HTTP_404_MESSAGE, HTTP_CONTENT_TYPE_PLAIN);
+  }
+}
+
+std::string ChannelsView::CreatePropertiesHtml(const std::map<std::string, std::string>& properties)
+{
+  std::stringstream ss;
+  for (const auto& [key, value] : properties)
+  {
+    std::string propertyHtml = PROPERTY_TEMPLATE;
+    Logger::Log(LogLevel::LEVEL_INFO, "Key: %s, Value: %s", key.c_str(), value.c_str());
+    size_t keyPos = propertyHtml.find("{key}");
+    while (keyPos != std::string::npos)
+    {
+      propertyHtml.replace(keyPos, 5, key);
+      keyPos = propertyHtml.find("{key}", keyPos + key.length());
+    }
+    size_t valuePos = propertyHtml.find("{value}");
+    if (valuePos != std::string::npos)
+      propertyHtml.replace(valuePos, 7, value);
+    ss << propertyHtml;
+  }
+  return ss.str();
+}
+
+} // namespace iptvsimple

--- a/src/iptvsimple/views/ChannelsView.h
+++ b/src/iptvsimple/views/ChannelsView.h
@@ -1,0 +1,236 @@
+#pragma once
+
+#include "../IHttpView.h"
+#include "../../IptvSimple.h"
+#include "../Channels.h"
+#include "../data/Channel.h"
+#include "../utilities/Logger.h"
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace iptvsimple
+{
+
+class ChannelsView : public IHttpView
+{
+public:
+  ChannelsView(std::unordered_map<std::string, IptvSimple*>& usedInstances);
+  ~ChannelsView() = default;
+
+  // Prevent copy/move
+  ChannelsView(const ChannelsView&) = delete;
+  ChannelsView& operator=(const ChannelsView&) = delete;
+  ChannelsView(ChannelsView&&) = delete;
+  ChannelsView& operator=(ChannelsView&&) = delete;
+
+  // IHttpView implementation
+  void RegisterViews(httplib::Server& server) override;
+  std::string GetViewUrl() const override;
+  std::string GetViewText() const override;
+
+private:
+  std::unordered_map<std::string, IptvSimple*>& m_usedInstances;
+
+  // View handlers
+  void ShowInstances(const httplib::Request& req, httplib::Response& res);
+  void ShowInstanceChannels(const httplib::Request& req, httplib::Response& res);
+  void ShowEditChannelForm(const httplib::Request& req, httplib::Response& res);
+  void UpdateChannel(const httplib::Request& req, httplib::Response& res);
+
+  // HTML template methods
+  std::string GetBaseHtmlTemplate(const std::string& title, const std::string& body);
+  std::string GetInstancesListHtml(const std::unordered_map<std::string, IptvSimple*>& instances);
+  std::string GetChannelsListHtml(const std::string& instanceId, Channels& channels);
+  std::string GetEditChannelFormHtml(const std::string& instanceId,
+                                     const iptvsimple::data::Channel& channel);
+  std::string CreatePropertiesHtml(const std::map<std::string, std::string>& properties);
+
+  // HTTP constants
+  static constexpr const char* HTTP_404_NOT_FOUND = "Not Found";
+  static constexpr const char* HTTP_404_MESSAGE = "Instance not found";
+  static constexpr const char* HTTP_404_CHANNEL_MESSAGE = "Channel not found";
+  static constexpr const char* HTTP_CONTENT_TYPE_HTML = "text/html";
+  static constexpr const char* HTTP_CONTENT_TYPE_PLAIN = "text/plain";
+
+  // HTML template constants
+  static constexpr const char* HTML_TEMPLATE = R"(
+<!DOCTYPE html>
+<html>
+<head>
+  <title>{title}</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    .instance, .channel { padding: 10px; margin: 5px; background: #f0f0f0; }
+    a { text-decoration: none; color: #0066cc; }
+    .back { margin-bottom: 20px; }
+    form { max-width: 500px; }
+    .form-group { margin-bottom: 15px; }
+    label { display: block; margin-bottom: 5px; }
+    input[type='text'] { width: 100%; padding: 8px; }
+    button { padding: 10px 20px; background: #0066cc; color: white; border: none; }
+  </style>
+</head>
+<body>
+{body}
+</body>
+</html>
+)";
+
+  static constexpr const char* INSTANCE_TEMPLATE = R"(
+    <div class='instance'>
+      <h2><a href='/instances/{id}'>Instance {id}</a></h2>
+    </div>
+)";
+
+  static constexpr const char* CHANNEL_TEMPLATE = R"(
+    <div class='channel'>
+      <h2>{name}</h2>
+      <p>Stream URL: {stream_url}</p>
+      <a href='/instances/{instance_id}/channels/{channel_id}/edit'>Edit</a>
+    </div>
+)";
+
+  static constexpr const char* EDIT_FORM_TEMPLATE = R"(
+  <div class='back'><a href='/instances/{instance_id}'>+ Back to Channels</a></div>
+  <h1>Edit Channel</h1>
+  <form method='POST' action='/instances/{instance_id}/channels/{channel_id}'>
+    <div class='form-group'>
+      <label for='name'>Channel Name:</label>
+      <input type='text' id='name' name='name' value='{name}' disabled>
+    </div>
+    <div class='form-group'>
+      <label for='stream_url'>Stream URL:</label>
+      <input type='text' id='stream_url' name='stream_url' value='{stream_url}'>
+    </div>
+    <div class='form-group'>
+      <label for='channel_number'>Channel Number:</label>
+      <input type='number' id='channel_number' name='channel_number' value='{channel_number}'>
+    </div>
+    <div class='form-group'>
+      <label for='sub_channel_number'>Sub Channel Number:</label>
+      <input type='number' id='sub_channel_number' name='sub_channel_number' value='{sub_channel_number}'>
+    </div>
+    <div class='form-group'>
+      <label for='tvg_shift'>TVG Shift:</label>
+      <input type='number' id='tvg_shift' name='tvg_shift' value='{tvg_shift}'>
+    </div>
+    <div class='form-group'>
+      <label for='icon_path'>Icon Path:</label>
+      <input type='text' id='icon_path' name='icon_path' value='{icon_path}'>
+    </div>
+    <div class='form-group'>
+      <label for='has_catchup'>Has Catchup:</label>
+      <input type='checkbox' id='has_catchup' name='has_catchup' {has_catchup_checked}>
+    </div>
+    <div class='form-group'>
+      <label for='catchup_mode'>Catchup Mode:</label>
+      <select id='catchup_mode' name='catchup_mode' value='{catchup_mode}'>
+        <option value='0'>DISABLED</option>
+        <option value='1'>DEFAULT</option>
+        <option value='2'>APPEND</option>
+        <option value='3'>SHIFT</option>
+        <option value='4'>FLUSSONIC</option>
+        <option value='5'>XTREAM_CODES</option>
+        <option value='6'>TIMESHIFT</option>
+        <option value='7'>VOD</option>
+      </select>
+    </div>
+     <div class='form-group'>
+      <label for='catchup_days'>Catchup Days:</label>
+      <input type='number' id='catchup_days' name='catchup_days' value='{catchup_days}'>
+    </div>
+    <div class='form-group'>
+      <label for='catchup_source'>Catchup Source:</label>
+      <input type='text' id='catchup_source' name='catchup_source' value='{catchup_source}'>
+    </div>
+    <div class='form-group'>
+      <label for='is_catchup_ts_stream'>Is Catchup TS Stream?:</label>
+      <input type='checkbox' id='is_catchup_ts_stream' name='is_catchup_ts_stream' {is_catchup_ts_stream_checked}>
+    </div>
+    <div class='form-group'>
+      <label for='catchup_supports_timeshifting'>Catchup Supports Timeshifting?:</label>
+      <input type='checkbox' id='catchup_supports_timeshifting' name='catchup_supports_timeshifting' {catchup_supports_timeshifting_checked}>
+    </div>
+    <div class='form-group'>
+      <label for='catchup_source_terminates'>Catchup Source Terminates?:</label>
+      <input type='checkbox' id='catchup_source_terminates' name='catchup_source_terminates' {catchup_source_terminates_checked}>
+    </div>
+    <div class='form-group'>
+      <label for='catchup_granularity_seconds'>Catchup Granularity Seconds:</label>
+      <input type='number' id='catchup_granularity_seconds' name='catchup_granularity_seconds' value='{catchup_granularity_seconds}'>
+    </div>
+    <div class='form-group'>
+      <label for='catchup_correction_secs'>Catchup Correction Secs:</label>
+      <input type='number' id='catchup_correction_secs' name='catchup_correction_secs' value='{catchup_correction_secs}'>
+    </div>
+    <div class='form-group'>
+      <label for='tvg_id'>TVG ID:</label>
+      <input type='text' id='tvg_id' name='tvg_id' value='{tvg_id}'>
+    </div>
+    <div class='form-group'>
+      <label for='tvg_name'>TVG Name:</label>
+      <input type='text' id='tvg_name' name='tvg_name' value='{tvg_name}'>
+    </div>
+    <div class='form-group'>
+      <label for='input_stream_name'>Input Stream Name:</label>
+      <input type='text' id='input_stream_name' name='input_stream_name' value='{input_stream_name}'>
+    </div>
+    <h2>Properties:</h2>
+    {properties}
+    <div id='new-properties'></div>
+    <div class='form-group' style='display: flex; gap: 10px;'>
+      <input type='text' id='new-property-key' placeholder='Key' list='key-suggestions'>
+      <input type='text' id='new-property-value' placeholder='Value'>
+    </div>
+    <datalist id='key-suggestions'>
+      <option value='isWebUrl'>
+      <option value='isrealtimestream'>
+      <option value='http-reconnect'>
+      <option value='http-user-agent'>
+      <option value='http-referrer'>
+      <option value='program'>
+      <option value='web-regex'>
+      <option value='web-headers'>
+      <option value='inputstream'>
+      <option value='mimetype'>
+      <option value='inputstream.ffmpegdirect.manifest_type'>
+      <option value='inputstream.ffmpegdirect.stream_mode'>
+      <option value='inputstream.ffmpegdirect.is_realtime_stream'>
+      <option value='inputstream.ffmpegdirect.stream_headers'>
+      <option value='inputstream.ffmpegdirect.manifest_headers'>
+    </datalist>
+    <button type='button' onclick='addProperty()'>Add Property</button>
+    <button type='submit'>Save Changes</button>
+  </form>
+  <script>
+    function addProperty() {
+      const newProperties = document.getElementById('new-properties');
+      const newProperty = document.createElement('div');
+      newProperty.className = 'form-group';
+      const key = document.getElementById('new-property-key').value;
+      const value = document.getElementById('new-property-value').value;
+      if (key && value) {
+      newProperty.innerHTML = `
+        <label for='property_${key}'>${key}:</label>
+        <input type='text' id='property_${key}' name='property_${key}' value='${value}'>
+      `;
+        newProperties.appendChild(newProperty);
+        document.getElementById('new-property-key').value = '';
+        document.getElementById('new-property-value').value = '';
+      }
+    }
+  </script>
+)";
+
+  static constexpr const char* PROPERTY_TEMPLATE = R"(
+    <div class='form-group'>
+      <label for='property_{key}'>{key}:</label>
+      <input type='text' id='property_{key}' name='property_{key}' value='{value}'>
+    </div>
+  )";
+};
+
+} // namespace iptvsimple


### PR DESCRIPTION
### Description

This pull request introduces an HTTP Server feature to the IPTV Simple PVR Client. The HTTP Server runs on a specified port and provides a web interface for managing channels and instances. Additionally, the `cpp-httplib` library has been integrated, along with necessary dependency updates.
### Issue
Closes #969 
### Changes Made

-   Added a new HTTP Server (`HttpServer`) class.
-   Implemented the `IHttpView` interface for modular views and dynamic view registration.
-   Introduced the `ChannelsView` class to handle HTTP requests for channel management operations.
-   Added a new dependency: `cpp-httplib` (v0.19.0).
-   Updated `CMakeLists.txt` to include the new dependency.
-   Added HTML templates for users to view, edit, and manage channels via the web interface.

### Todo

I wanted to add a port and web server control option in the main settings section, but I couldn't find a method to manage `settings.xml`. Do you have any suggestions for this?