### PR TITLE
Patch zlib build for cmake 4

### DIFF
--- a/depends/common/zlib/04-cmake4-minimum.patch
+++ b/depends/common/zlib/04-cmake4-minimum.patch
@@ -1,0 +1,8 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.4.4)
++cmake_minimum_required(VERSION 3.5)
+ set(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS ON)
+
+ project(zlib C)


### PR DESCRIPTION
Upgrade the minimum version to 3.5 as required by cmake 4.  Only tested generate and build
