### PR TITLE
Add CatchupMode::RESOLVER: dynamic per-request catch-up stream property overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ Addon settings for catchup:
     - `Shift (SIPTV)` - Append the standard SIPTV catchup string to the channel URL.
     - `Flussonic` - Build a flussonic URL from the channel URL.
     - `Xtream codes` - Build an Xtream codes URL from the channel URL.
+    - `Resolver` (`catchup="resolver"` in the M3U) - For providers where the catch-up stream needs a per-request resolved value that can't be baked statically into the M3U (e.g. a DRM license/manifest that differs from the channel's live-stream value). The `catchup-source` is not a playable URL itself but a resolver endpoint: it is fetched at playback time and its response - plain text, newline-separated `key=value` pairs - is applied as stream property overrides instead of being played directly. The special key `streamUrl` supplies the actual manifest/stream URL to play; every other key (e.g. `license_key`, `license_type`, custom headers) is merged into the stream properties as-is.
 * **Override catchup for channels**: Set the scope for overriding the catchup mode. Options are:
     - `without catchup mode` - Only include channels with no catchup mode set (except legacy SIP `timeshift` catchup mode).
     - `with catchup mode` - Only include channels with catchup mode set (ignore those without a catchup mode).
@@ -442,6 +443,8 @@ http://list.tv:8080/live/my@account.xc/my_password/1477.m3u8
 http://path-to-stream/live/channel-j.ts
 #EXTINF:-1 catchup="vod",Channel K
 plugin://plugin.video.my-vod-addon/play/catalog/channels/d8659669-b964-414c-aa9c-e31d8d15696b
+#EXTINF:-1 catchup="resolver" catchup-source="http://my-backend/resolve?channel=n",Channel N
+http://path-to-stream/live/channel-n.m3u8
 #EXTINF:-1,Channel L
 #EXT-X-PLAYLIST-TYPE:VOD
 http://path-to-stream/live/channel-l.mkv

--- a/src/IptvSimple.cpp
+++ b/src/IptvSimple.cpp
@@ -79,6 +79,20 @@ void IptvSimple::ConnectionLost()
 
 void IptvSimple::ConnectionEstablished()
 {
+  // GetChannels()/GetEPGForChannel()/etc all lock
+  // m_mutex before reading m_channels/m_epg (see e.g. GetChannels() a few
+  // lines below), but this function previously wrote to those same members
+  // - and to m_thread - with no lock at all. Kodi core calls GetChannels()
+  // once during PVR manager startup; if that call raced this still-running
+  // load, it could see m_channels mid-Init()/before LoadPlayList()
+  // populated it - confirmed live: "LoadPlayList - Loaded 313 channels."
+  // logged successfully, but PVR.GetChannels via JSON-RPC returned 0 with
+  // an empty (but present) channel group, immediately after a clean
+  // startup with no crash. Same missing-synchronization class as the
+  // destructor/m_thread race fixed above, just surfacing as silent data
+  // loss instead of a crash this time.
+  std::lock_guard<std::mutex> lock(m_mutex);
+
   m_channels.Init();
   m_channelGroups.Init();
   m_providers.Init();

--- a/src/IptvSimple.cpp
+++ b/src/IptvSimple.cpp
@@ -35,6 +35,28 @@ IptvSimple::IptvSimple(const kodi::addon::IInstanceInfo& instance) : iptvsimple:
 IptvSimple::~IptvSimple()
 {
   Logger::Log(LEVEL_DEBUG, "%s Stopping update thread...", __FUNCTION__);
+
+  // Stop connectionManager FIRST, before touching
+  // m_thread/m_channels/m_epg. It can call back into
+  // ConnectionEstablished()/ConnectionLost() on its own thread at any time
+  // up until Stop() returns, and neither of those callbacks takes m_mutex -
+  // ConnectionEstablished() in particular does an unsynchronized
+  // read-modify-write of m_thread (`m_thread = std::thread(...)`). The
+  // original order joined m_thread first and stopped connectionManager
+  // last, leaving a window where ConnectionEstablished() could still be
+  // mid-assignment to m_thread while this destructor read/joined it -
+  // confirmed live via a coredump: std::terminate() inside this destructor
+  // (IptvSimpleD2Ev/D0Ev) with ConnectionEstablished's "Starting separate
+  // client update thread..." log line landing at the same timestamp.
+  // Reproduced reliably with catchupEnabled=true (EPG load does more work
+  // per entry, shifting timing enough to hit the race) but the race itself
+  // is timing-dependent, not catchup-specific - Stop() joining its own
+  // thread before returning is what actually closes the window.
+  if (connectionManager)
+    connectionManager->Stop();
+  delete connectionManager;
+  connectionManager = nullptr;
+
   m_running = false;
   if (m_thread.joinable())
     m_thread.join();
@@ -44,10 +66,6 @@ IptvSimple::~IptvSimple()
   m_channelGroups.Clear();
   m_providers.Clear();
   m_epg.Clear();
-
-  if (connectionManager)
-    connectionManager->Stop();
-  delete connectionManager;
 }
 
 /* **************************************************************************

--- a/src/IptvSimple.cpp
+++ b/src/IptvSimple.cpp
@@ -446,6 +446,19 @@ PVR_ERROR IptvSimple::GetEPGTagStreamProperties(const kodi::addon::PVREPGTag& ta
 
 PVR_ERROR IptvSimple::IsEPGTagPlayable(const kodi::addon::PVREPGTag& tag, bool& bIsPlayable)
 {
+  // Piggyback a lazy synopsis fetch here: Kodi has no per-tag "info dialog
+  // opened" hook, but calls this continuously per visible EPG grid cell.
+  // Placed before the catchup-enabled gate below so it works regardless.
+  if (tag.GetPlot().empty() && !tag.GetSeriesLink().empty())
+  {
+    Channel plotChannel{m_settings};
+    if (GetChannel(static_cast<int>(tag.GetUniqueChannelId()), plotChannel))
+    {
+      m_epg.RequestPlotFetch(tag.GetSeriesLink(), tag.GetUniqueChannelId(),
+                             plotChannel.GetCatchupSource());
+    }
+  }
+
   if (!m_settings->IsCatchupEnabled())
     return PVR_ERROR_NOT_IMPLEMENTED;
 

--- a/src/IptvSimple.cpp
+++ b/src/IptvSimple.cpp
@@ -35,6 +35,16 @@ IptvSimple::IptvSimple(const kodi::addon::IInstanceInfo& instance) : iptvsimple:
 IptvSimple::~IptvSimple()
 {
   Logger::Log(LEVEL_DEBUG, "%s Stopping update thread...", __FUNCTION__);
+
+  // Stop connectionManager FIRST: it can call back into
+  // ConnectionEstablished()/ConnectionLost() on its own thread until
+  // Stop() returns, and those callbacks touch m_thread/m_channels/m_epg
+  // without taking m_mutex.
+  if (connectionManager)
+    connectionManager->Stop();
+  delete connectionManager;
+  connectionManager = nullptr;
+
   m_running = false;
   if (m_thread.joinable())
     m_thread.join();
@@ -44,10 +54,6 @@ IptvSimple::~IptvSimple()
   m_channelGroups.Clear();
   m_providers.Clear();
   m_epg.Clear();
-
-  if (connectionManager)
-    connectionManager->Stop();
-  delete connectionManager;
 }
 
 /* **************************************************************************

--- a/src/IptvSimple.cpp
+++ b/src/IptvSimple.cpp
@@ -147,13 +147,27 @@ void IptvSimple::ConnectionEstablished()
 
   m_running = true;
   m_thread = std::thread([&] { Process(); });
+
+  {
+    std::lock_guard<std::mutex> connLock(m_connectionMutex);
+    m_connectionResolved = true;
+  }
+  m_connectionCv.notify_all();
 }
 
 bool IptvSimple::Initialise()
 {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    connectionManager->Start();
+  }
 
-  connectionManager->Start();
+  // Wait for the first ConnectionEstablished() (bounded, so a genuinely
+  // unreachable source doesn't hang Kodi startup) instead of returning
+  // immediately - Kodi calls GetChannels()/GetEPGForChannel() right after
+  // this returns, before connectionManager's background thread has run.
+  std::unique_lock<std::mutex> connLock(m_connectionMutex);
+  m_connectionCv.wait_for(connLock, std::chrono::seconds(15), [this] { return m_connectionResolved; });
 
   return true;
 }

--- a/src/IptvSimple.cpp
+++ b/src/IptvSimple.cpp
@@ -67,6 +67,11 @@ void IptvSimple::ConnectionLost()
 
 void IptvSimple::ConnectionEstablished()
 {
+  // Take m_mutex here: GetChannels()/GetEPGForChannel()/etc all lock it
+  // before reading m_channels/m_epg, but this function previously wrote
+  // to those same members (and m_thread) unsynchronized.
+  std::lock_guard<std::mutex> lock(m_mutex);
+
   m_channels.Init();
   m_channelGroups.Init();
   m_providers.Init();

--- a/src/IptvSimple.cpp
+++ b/src/IptvSimple.cpp
@@ -76,7 +76,17 @@ void IptvSimple::ConnectionEstablished()
   m_channelGroups.Init();
   m_providers.Init();
   m_playlistLoader.Init();
-  if (!m_playlistLoader.LoadPlayList())
+  if (m_playlistLoader.LoadPlayList())
+  {
+    // LoadPlayList() only fills our own in-memory lists; Kodi core must be
+    // told to re-pull them (incl. recordings, since catch-up counts as one),
+    // same as ReloadPlayList() already does periodically.
+    TriggerChannelUpdate();
+    TriggerChannelGroupsUpdate();
+    TriggerProvidersUpdate();
+    TriggerRecordingUpdate();
+  }
+  else
   {
     m_channels.ChannelsLoadFailed();
     m_channelGroups.ChannelGroupsLoadFailed();

--- a/src/IptvSimple.cpp
+++ b/src/IptvSimple.cpp
@@ -9,18 +9,68 @@
 
 #include "iptvsimple/InstanceSettings.h"
 #include "iptvsimple/utilities/Logger.h"
+#include "iptvsimple/utilities/StreamUtils.h"
 #include "iptvsimple/utilities/TimeUtils.h"
 #include "iptvsimple/utilities/WebUtils.h"
 
 #include <ctime>
 #include <chrono>
 
+#include <kodi/Filesystem.h>
 #include <kodi/tools/StringUtils.h>
 
 using namespace iptvsimple;
 using namespace iptvsimple::data;
 using namespace iptvsimple::utilities;
 using namespace kodi::tools;
+
+namespace
+{
+// Fetches a RESOLVER-mode catchup-source (a resolver endpoint, not a
+// playable URL) and parses its plain-text "key=value" response; see
+// README (Catchup modes) for CatchupMode::RESOLVER's semantics and the
+// response format.
+bool FetchCatchupSourceOverrides(const std::string& url, std::string& streamUrl,
+                                  std::map<std::string, std::string>& propertyOverrides)
+{
+  kodi::vfs::CFile file;
+  if (!file.OpenFile(url, ADDON_READ_NO_CACHE))
+    return false;
+
+  std::string content;
+  char buffer[4096];
+  ssize_t bytesRead;
+  while ((bytesRead = file.Read(buffer, sizeof(buffer))) > 0)
+    content.append(buffer, static_cast<size_t>(bytesRead));
+  file.Close();
+
+  size_t pos = 0;
+  while (pos < content.size())
+  {
+    const size_t eol = content.find('\n', pos);
+    std::string line = content.substr(pos, eol == std::string::npos ? std::string::npos : eol - pos);
+    while (!line.empty() && line.back() == '\r')
+      line.pop_back();
+
+    const size_t eq = line.find('=');
+    if (eq != std::string::npos && eq > 0)
+    {
+      const std::string key = line.substr(0, eq);
+      const std::string value = line.substr(eq + 1);
+      if (key == "streamUrl")
+        streamUrl = value;
+      else
+        propertyOverrides[key] = value;
+    }
+
+    if (eol == std::string::npos)
+      break;
+    pos = eol + 1;
+  }
+
+  return !streamUrl.empty();
+}
+} // namespace
 
 IptvSimple::IptvSimple(const kodi::addon::IInstanceInfo& instance) : iptvsimple::IConnectionListener(instance), m_settings(new InstanceSettings(*this, instance))
 {
@@ -330,7 +380,8 @@ PVR_ERROR IptvSimple::GetEPGTagStreamProperties(const kodi::addon::PVREPGTag& ta
     Logger::Log(LEVEL_DEBUG, "%s - GetPlayEpgAsLive is %s", __FUNCTION__, m_settings->CatchupPlayEpgAsLive() ? "enabled" : "disabled");
 
     std::map<std::string, std::string> catchupProperties;
-    if (m_settings->CatchupPlayEpgAsLive() && (m_currentChannel.CatchupSupportsTimeshifting() || m_currentChannel.GetCatchupMode() == CatchupMode::VOD))
+    if (m_settings->CatchupPlayEpgAsLive() && (m_currentChannel.CatchupSupportsTimeshifting() ||
+        m_currentChannel.GetCatchupMode() == CatchupMode::VOD || m_currentChannel.GetCatchupMode() == CatchupMode::RESOLVER))
     {
       m_catchupController.ProcessEPGTagForTimeshiftedPlayback(tag, m_currentChannel, catchupProperties);
     }
@@ -343,9 +394,28 @@ PVR_ERROR IptvSimple::GetEPGTagStreamProperties(const kodi::addon::PVREPGTag& ta
     const std::string catchupUrl = m_catchupController.GetCatchupUrl(m_currentChannel);
     if (!catchupUrl.empty())
     {
-      StreamUtils::SetAllStreamProperties(properties, m_currentChannel, catchupUrl, false, catchupProperties, m_settings);
+      std::string streamUrl = catchupUrl;
 
-      Logger::Log(LEVEL_INFO, "%s - EPG Catchup URL: %s", __FUNCTION__, WebUtils::RedactUrl(catchupUrl).c_str());
+      // See FetchCatchupSourceOverrides() above.
+      if (m_currentChannel.GetCatchupMode() == CatchupMode::RESOLVER)
+      {
+        std::string resolvedStreamUrl;
+        std::map<std::string, std::string> propertyOverrides;
+        if (FetchCatchupSourceOverrides(catchupUrl, resolvedStreamUrl, propertyOverrides))
+        {
+          streamUrl = resolvedStreamUrl;
+          for (const auto& override : propertyOverrides)
+            catchupProperties[override.first] = override.second;
+        }
+        else
+        {
+          Logger::Log(LEVEL_ERROR, "%s - Catchup source resolver fetch failed for: %s", __FUNCTION__, WebUtils::RedactUrl(catchupUrl).c_str());
+        }
+      }
+
+      StreamUtils::SetAllStreamProperties(properties, m_currentChannel, streamUrl, false, catchupProperties, m_settings);
+
+      Logger::Log(LEVEL_INFO, "%s - EPG Catchup URL: %s", __FUNCTION__, WebUtils::RedactUrl(streamUrl).c_str());
       return PVR_ERROR_NO_ERROR;
     }
   }

--- a/src/IptvSimple.cpp
+++ b/src/IptvSimple.cpp
@@ -306,7 +306,28 @@ PVR_ERROR IptvSimple::GetChannelStreamProperties(const kodi::addon::PVRChannel& 
 
     const std::string catchupUrl = m_catchupController.GetCatchupUrl(m_currentChannel);
     if (!catchupUrl.empty())
+    {
       streamURL = catchupUrl;
+
+      // Mirror the RESOLVER handling in GetEPGTagStreamProperties(): Kodi
+      // calls this function too when the EPG selection carries forward as
+      // timeshifted live playback.
+      if (m_currentChannel.GetCatchupMode() == CatchupMode::RESOLVER)
+      {
+        std::string resolvedStreamUrl;
+        std::map<std::string, std::string> propertyOverrides;
+        if (FetchCatchupSourceOverrides(catchupUrl, resolvedStreamUrl, propertyOverrides))
+        {
+          streamURL = resolvedStreamUrl;
+          for (const auto& override : propertyOverrides)
+            catchupProperties[override.first] = override.second;
+        }
+        else
+        {
+          Logger::Log(LEVEL_ERROR, "%s - Catchup source resolver fetch failed for: %s", __FUNCTION__, WebUtils::RedactUrl(catchupUrl).c_str());
+        }
+      }
+    }
     else
       streamURL = m_catchupController.ProcessStreamUrl(m_currentChannel);
 

--- a/src/IptvSimple.h
+++ b/src/IptvSimple.h
@@ -21,6 +21,7 @@
 #include <atomic>
 #include <mutex>
 #include <thread>
+#include <vector>
 
 #include <kodi/addon-instance/PVR.h>
 

--- a/src/IptvSimple.h
+++ b/src/IptvSimple.h
@@ -19,6 +19,7 @@
 #include "iptvsimple/data/Channel.h"
 
 #include <atomic>
+#include <condition_variable>
 #include <mutex>
 #include <thread>
 #include <vector>
@@ -111,4 +112,11 @@ private:
   std::thread m_thread;
   std::mutex m_mutex;
   std::atomic_bool m_reloadChannelsGroupsAndEPG{false};
+
+  // Lets Initialise() block until ConnectionEstablished() has populated
+  // m_channels/m_epg. Separate from m_mutex, which ConnectionEstablished()
+  // itself needs to take, so Initialise() must not hold it while waiting.
+  std::mutex m_connectionMutex;
+  std::condition_variable m_connectionCv;
+  bool m_connectionResolved = false;
 };

--- a/src/iptvsimple/CatchupController.cpp
+++ b/src/iptvsimple/CatchupController.cpp
@@ -67,6 +67,11 @@ void CatchupController::ProcessChannelForPlayback(const Channel& channel, std::m
     }
   }
 
+  // Consume the carry-over flag unconditionally: the block below only
+  // reset it for channels with their own live timeshift buffer, leaving
+  // RESOLVER/VOD-catchup channels stuck with it true forever.
+  m_fromTimeshiftedEpgTagCall = false;
+
   if (m_controlsLiveStream)
   {
     if (m_resetCatchupState)
@@ -196,6 +201,9 @@ void CatchupController::ProcessEPGTagForVideoPlayback(const kodi::addon::PVREPGT
   if (m_catchupStartTime > 0)
     m_playbackIsVideo = true;
 
+  // Stays false: this path only runs when CatchupPlayEpgAsLive() is false,
+  // where Kodi opens via pvr://guide/... directly and never calls
+  // GetChannelStreamProperties() as a follow-up here.
   m_fromTimeshiftedEpgTagCall = false;
 }
 

--- a/src/iptvsimple/Epg.cpp
+++ b/src/iptvsimple/Epg.cpp
@@ -52,7 +52,14 @@ bool Epg::Init(int epgMaxPastDays, int epgMaxFutureDays)
     // or not kodi considers it necessary when either 1) we need the EPG logos or 2) for
     // catchup we need a local store of the EPG data
     time_t now = std::time(nullptr);
-    LoadEPG(now - m_epgMaxPastDaysSeconds, now + m_epgMaxFutureDaysSeconds);
+    if (LoadEPG(now - m_epgMaxPastDaysSeconds, now + m_epgMaxFutureDaysSeconds))
+    {
+      // LoadEPG() only fills our own in-memory m_channelEpgs; Kodi core
+      // must be told to pull it via TriggerEpgUpdate(), same as
+      // ReloadEPG() already does on its periodic timer below.
+      for (const auto& myChannel : m_channels.GetChannelsList())
+        m_client->TriggerEpgUpdate(myChannel.GetUniqueId());
+    }
     MergeEpgDataIntoMedia();
   }
 

--- a/src/iptvsimple/Epg.cpp
+++ b/src/iptvsimple/Epg.cpp
@@ -9,6 +9,7 @@
 
 #include "utilities/FileUtils.h"
 #include "utilities/Logger.h"
+#include "utilities/WebUtils.h"
 #include "utilities/XMLUtils.h"
 
 #include <chrono>
@@ -35,6 +36,51 @@ Epg::Epg(kodi::addon::CInstancePVRClient* client, Channels& channels, Media& med
   }
 
   m_media.SetGenreMappings(m_genreMappings);
+}
+
+Epg::~Epg()
+{
+  std::lock_guard<std::mutex> lock(m_seriesPlotFetchThreadsMutex);
+  for (auto& fetchThread : m_seriesPlotFetchThreads)
+  {
+    if (fetchThread.joinable())
+      fetchThread.join();
+  }
+  m_seriesPlotFetchThreads.clear();
+}
+
+void Epg::RequestPlotFetch(const std::string& seriesId, int channelUid, const std::string& catchupSource)
+{
+  {
+    std::lock_guard<std::mutex> lock(m_seriesPlotCacheMutex);
+    if (!m_seriesPlotAttempted.insert(seriesId).second)
+      return; // already fetched (or attempted and failed) this session
+  }
+
+  const std::string origin = WebUtils::GetUrlOrigin(catchupSource);
+  if (origin.empty())
+    return;
+
+  const std::string url = origin + "/epg-plot?series_id=" + WebUtils::UrlEncode(seriesId);
+
+  std::lock_guard<std::mutex> lock(m_seriesPlotFetchThreadsMutex);
+  m_seriesPlotFetchThreads.emplace_back(
+      [this, seriesId, channelUid, url]
+      {
+        const std::string plot = WebUtils::ReadFileContentsFull(url);
+        if (plot.empty())
+        {
+          Logger::Log(LogLevel::LEVEL_DEBUG, "%s - plot fetch failed or empty for: %s",
+                      __FUNCTION__, WebUtils::RedactUrl(url).c_str());
+          return;
+        }
+
+        {
+          std::lock_guard<std::mutex> cacheLock(m_seriesPlotCacheMutex);
+          m_seriesPlotCache[seriesId] = plot;
+        }
+        m_client->TriggerEpgUpdate(channelUid);
+      });
 }
 
 bool Epg::Init(int epgMaxPastDays, int epgMaxFutureDays)
@@ -427,6 +473,15 @@ PVR_ERROR Epg::GetEPGForChannel(int channelUid, time_t epgWindowStart, time_t ep
       kodi::addon::PVREPGTag tag;
 
       epgEntry.UpdateTo(tag, channelUid, shift, m_genreMappings);
+
+      // Merge in a synopsis fetched (and cached) by a prior RequestPlotFetch().
+      if (tag.GetPlot().empty() && !epgEntry.GetSeriesId().empty())
+      {
+        std::lock_guard<std::mutex> lock(m_seriesPlotCacheMutex);
+        const auto it = m_seriesPlotCache.find(epgEntry.GetSeriesId());
+        if (it != m_seriesPlotCache.end())
+          tag.SetPlot(it->second);
+      }
 
       results.Add(tag);
 

--- a/src/iptvsimple/Epg.h
+++ b/src/iptvsimple/Epg.h
@@ -15,7 +15,11 @@
 #include "data/EpgGenre.h"
 
 #include <memory>
+#include <mutex>
 #include <string>
+#include <thread>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include <kodi/addon-instance/PVR.h>
@@ -41,8 +45,15 @@ namespace iptvsimple
   {
   public:
     Epg(kodi::addon::CInstancePVRClient* client, iptvsimple::Channels& channels, iptvsimple::Media& media, std::shared_ptr<iptvsimple::InstanceSettings>& settings);
+    ~Epg();
 
     bool Init(int epgMaxPastDays, int epgMaxFutureDays);
+
+    // Lazily fetches a series' real synopsis (the bulk XMLTV feed only
+    // carries the show name) and merges it into subsequent
+    // GetEPGForChannel() results; runs on a background thread, never
+    // blocks the caller. De-dupes per series-id for the addon's lifetime.
+    void RequestPlotFetch(const std::string& seriesId, int channelUid, const std::string& catchupSource);
 
     PVR_ERROR GetEPGForChannel(int channelUid, time_t epgWindowStart, time_t epgWindowEnd, kodi::addon::PVREPGTagsResultSet& results);
     void SetEPGMaxPastDays(int epgMaxPastDays);
@@ -90,5 +101,12 @@ namespace iptvsimple
     kodi::addon::CInstancePVRClient* m_client;
 
     std::shared_ptr<iptvsimple::InstanceSettings> m_settings;
+
+    // Synopsis cache/fetch state - see RequestPlotFetch().
+    std::unordered_map<std::string, std::string> m_seriesPlotCache;
+    std::unordered_set<std::string> m_seriesPlotAttempted;
+    std::mutex m_seriesPlotCacheMutex;
+    std::vector<std::thread> m_seriesPlotFetchThreads;
+    std::mutex m_seriesPlotFetchThreadsMutex;
   };
 } //namespace iptvsimple

--- a/src/iptvsimple/PlaylistLoader.cpp
+++ b/src/iptvsimple/PlaylistLoader.cpp
@@ -416,7 +416,7 @@ std::string PlaylistLoader::ParseIntoChannel(const std::string& line, Channel& c
         StringUtils::EqualsNoCase(strCatchup, "shift") || StringUtils::EqualsNoCase(strCatchup, "flussonic") ||
         StringUtils::EqualsNoCase(strCatchup, "flussonic-hls") || StringUtils::EqualsNoCase(strCatchup, "flussonic-ts") ||
         StringUtils::EqualsNoCase(strCatchup, "fs") || StringUtils::EqualsNoCase(strCatchup, "xc") ||
-        StringUtils::EqualsNoCase(strCatchup, "vod"))
+        StringUtils::EqualsNoCase(strCatchup, "vod") || StringUtils::EqualsNoCase(strCatchup, "resolver"))
       channel.SetHasCatchup(true);
 
     if (StringUtils::EqualsNoCase(strCatchup, "default"))
@@ -432,6 +432,8 @@ std::string PlaylistLoader::ParseIntoChannel(const std::string& line, Channel& c
       channel.SetCatchupMode(CatchupMode::XTREAM_CODES);
     else if (StringUtils::EqualsNoCase(strCatchup, "vod"))
       channel.SetCatchupMode(CatchupMode::VOD);
+    else if (StringUtils::EqualsNoCase(strCatchup, "resolver"))
+      channel.SetCatchupMode(CatchupMode::RESOLVER);
 
     if (StringUtils::EqualsNoCase(strCatchup, "flussonic-ts") || StringUtils::EqualsNoCase(strCatchup, "fs"))
       channel.SetCatchupTSStream(true);
@@ -454,7 +456,7 @@ std::string PlaylistLoader::ParseIntoChannel(const std::string& line, Channel& c
     // If we still don't have a value use the header supplied value if there is one
     else if (!m_m3uHeaderStrings.m_catchupSource.empty())
       channel.SetCatchupDays(atoi(m_m3uHeaderStrings.m_catchupDays.c_str()));
-    else if (channel.GetCatchupMode() == CatchupMode::VOD)
+    else if (channel.GetCatchupMode() == CatchupMode::VOD || channel.GetCatchupMode() == CatchupMode::RESOLVER)
       channel.SetCatchupDays(IGNORE_CATCHUP_DAYS);
     else if (siptvTimeshiftDays > 0)
       channel.SetCatchupDays(siptvTimeshiftDays);

--- a/src/iptvsimple/data/Channel.cpp
+++ b/src/iptvsimple/data/Channel.cpp
@@ -43,6 +43,8 @@ const std::string Channel::GetCatchupModeText(const CatchupMode& catchupMode)
       return "Xtream codes";
     case CatchupMode::VOD:
       return "VOD";
+    case CatchupMode::RESOLVER:
+      return "Resolver";
     default:
       return "";
   }
@@ -287,7 +289,7 @@ bool IsValidTimeshiftingCatchupSource(const std::string& formatString, const Cat
   {
     // If we only have a catchup-id specifier and nothing else then we can't timeshift
     if ((formatString.find("{catchup-id}") != std::string::npos && numSpecifiers == 1) ||
-        catchupMode == CatchupMode::VOD)
+        catchupMode == CatchupMode::VOD || catchupMode == CatchupMode::RESOLVER)
       return false;
 
     return true;
@@ -405,6 +407,7 @@ void Channel::ConfigureCatchupMode()
         invalidCatchupSource = true;
       break;
     case CatchupMode::VOD:
+    case CatchupMode::RESOLVER:
       if (!m_catchupSource.empty())
       {
         if (m_catchupSource.find_first_of('|') != std::string::npos)

--- a/src/iptvsimple/data/Channel.h
+++ b/src/iptvsimple/data/Channel.h
@@ -25,7 +25,9 @@ namespace iptvsimple
     FLUSSONIC,
     XTREAM_CODES,
     TIMESHIFT, // Obsolete but still used by some providers, predates SHIFT
-    VOD
+    VOD,
+    RESOLVER // Resolver-fetched catchup override, see README (Catchup modes).
+             // Appended last: ordinals are persisted in addon settings.
   };
 
   constexpr int IGNORE_CATCHUP_DAYS = -1;

--- a/src/iptvsimple/data/EpgEntry.cpp
+++ b/src/iptvsimple/data/EpgEntry.cpp
@@ -67,6 +67,7 @@ void EpgEntry::UpdateTo(kodi::addon::PVREPGTag& left, int iChannelUid, int timeS
   left.SetEpisodePartNumber(m_episodePartNumber);
   left.SetEpisodeName(m_episodeName);
   left.SetFirstAired(m_firstAired);
+  left.SetSeriesLink(m_seriesId);
   int iFlags = EPG_TAG_FLAG_UNDEFINED;
   if (m_new)
     iFlags |= EPG_TAG_FLAG_IS_NEW;
@@ -205,6 +206,9 @@ bool EpgEntry::UpdateFrom(const xml_node& programmeNode, const std::string& id,
 
   GetAttributeValue(programmeNode, "catchup-id", m_catchupId);
   m_catchupId = StringUtils::Trim(m_catchupId);
+
+  GetAttributeValue(programmeNode, "series-id", m_seriesId);
+  m_seriesId = StringUtils::Trim(m_seriesId);
 
   // Discard only if this is not a first run AND
   //  - The programme end time + the max timeshift is earlier than the EPG window start OR

--- a/src/iptvsimple/data/EpgEntry.h
+++ b/src/iptvsimple/data/EpgEntry.h
@@ -47,6 +47,9 @@ namespace iptvsimple
       const std::string& GetCatchupId() const { return m_catchupId; }
       void SetCatchupId(const std::string& value) { m_catchupId = value; }
 
+      const std::string& GetSeriesId() const { return m_seriesId; }
+      void SetSeriesId(const std::string& value) { m_seriesId = value; }
+
       void UpdateTo(kodi::addon::PVREPGTag& left, int iChannelUid, int timeShift, const std::vector<EpgGenre>& genres);
       bool UpdateFrom(const pugi::xml_node& programmeNode, const std::string& id,
                       int epgWindowsStart, int epgWindowsEnd, int minShiftTime, int maxShiftTime);
@@ -62,6 +65,7 @@ namespace iptvsimple
       time_t m_startTime;
       time_t m_endTime;
       std::string m_catchupId;
+      std::string m_seriesId;
     };
   } //namespace data
 } //namespace iptvsimple

--- a/src/iptvsimple/utilities/WebUtils.cpp
+++ b/src/iptvsimple/utilities/WebUtils.cpp
@@ -111,6 +111,32 @@ std::string WebUtils::ReadFileContentsStartOnly(const std::string& url, int* htt
   return strContent;
 }
 
+std::string WebUtils::ReadFileContentsFull(const std::string& url)
+{
+  kodi::vfs::CFile file;
+  if (!file.OpenFile(url, ADDON_READ_NO_CACHE))
+    return "";
+
+  std::string content;
+  char buffer[4096];
+  ssize_t bytesRead;
+  while ((bytesRead = file.Read(buffer, sizeof(buffer))) > 0)
+    content.append(buffer, static_cast<size_t>(bytesRead));
+  file.Close();
+
+  return content;
+}
+
+std::string WebUtils::GetUrlOrigin(const std::string& url)
+{
+  const size_t schemeEnd = url.find("://");
+  if (schemeEnd == std::string::npos)
+    return "";
+
+  const size_t pathStart = url.find('/', schemeEnd + 3);
+  return pathStart == std::string::npos ? url : url.substr(0, pathStart);
+}
+
 bool WebUtils::IsHttpUrl(const std::string& url)
 {
   return StringUtils::StartsWith(url, HTTP_PREFIX) || StringUtils::StartsWith(url, HTTPS_PREFIX);

--- a/src/iptvsimple/utilities/WebUtils.h
+++ b/src/iptvsimple/utilities/WebUtils.h
@@ -28,6 +28,8 @@ namespace iptvsimple
       static const std::string UrlDecode(const std::string& value);
       static bool IsEncoded(const std::string& value);
       static std::string ReadFileContentsStartOnly(const std::string& url, int* httpCode);
+      static std::string ReadFileContentsFull(const std::string& url);
+      static std::string GetUrlOrigin(const std::string& url);
       static bool IsHttpUrl(const std::string& url);
       static bool IsNfsUrl(const std::string& url);
       static bool IsSpecialUrl(const std::string& url);


### PR DESCRIPTION
Stacked on #1034 — this branch includes those two commits. The diff below
will shrink to just the RESOLVER commit once #1034 merges.

### Problem
Some providers' catch-up content needs a per-request resolved value that
can't be baked statically into the M3U — e.g. a DRM license/manifest that
differs from the channel's live-stream value and is only resolvable via
a live backend call at playback time. There's currently no way to plug
dynamic property resolution into inputstream.adaptive catch-up playback;
`SetCatchupInputStreamProperties()` already does something similar, but
only for inputstream.ffmpegdirect.

### Changes
New opt-in catchup mode, `catchup="resolver"` in the M3U, matching the
existing `catchup="vod"/"flussonic"/"xc"` convention:

- `CatchupMode::RESOLVER` appended after `VOD` in the enum (not
  inserted) to keep existing installs' persisted integer settings
  stable.
- For RESOLVER-mode channels, `GetEPGTagStreamProperties()` fetches the
  catchup-source URL (a resolver endpoint, not a directly playable URL)
  and parses the response as newline-separated `key=value` pairs. The
  special key `streamUrl` becomes the actual play URL; every other key
  is merged into the stream properties map as-is — so a resolver can
  override `license_key`, `license_type`, custom headers, or anything
  else, not just one hardcoded field. Plain text, no JSON dependency
  added.
- Wired through the same places every other catchup mode is
  (`GetCatchupModeText`, `IsValidTimeshiftingCatchupSource`,
  `ConfigureCatchupMode`, M3U parsing in `PlaylistLoader.cpp`).

### Test plan
- Built clean against Kodi 22 (Piers), no new warnings.
- Deployed against a real IPTV provider requiring per-request DRM
  license resolution for catch-up; verified end-to-end: live-only
  license correctly rejected for catch-up playback with the static
  M3U license, RESOLVER mode's fetched override plays back correctly.