### PR TITLE
CatchupController: return the catchup stream key

### DIFF
--- a/src/iptvsimple/CatchupController.cpp
+++ b/src/iptvsimple/CatchupController.cpp
@@ -567,7 +567,7 @@ std::string CatchupController::GetStreamKey(const Channel& channel, bool fromEpg
   // The streamKey is simply the channelId + StreamUrl or the catchup source
   // Either can be used to uniquely identify the StreamType/MimeType pairing
   if ((m_catchupStartTime > 0 || fromEpg) && m_timeshiftBufferOffset < (std::time(nullptr) - 5))
-    std::to_string(channel.GetUniqueId()) + "-" + channel.GetCatchupSource();
+    return std::to_string(channel.GetUniqueId()) + "-" + channel.GetCatchupSource();
 
   return std::to_string(channel.GetUniqueId()) + "-" + channel.GetStreamURL();
 }


### PR DESCRIPTION
GetStreamKey built the catchup key and then discarded it, so catchup and live streams for a channel shared one key and the StreamType/MimeType lookup in StreamManager would return the wrong pairing.