### PR TITLE
Address build warnings

### DIFF
--- a/src/IptvSimple.cpp
+++ b/src/IptvSimple.cpp
@@ -148,7 +148,7 @@ void IptvSimple::Process()
     lastRefreshTimeSeconds = currentRefreshTimeSeconds;
 
     if (m_settings->GetM3URefreshMode() == RefreshMode::REPEATED_REFRESH &&
-        refreshTimer >= (m_settings->GetM3URefreshIntervalMins() * 60))
+        refreshTimer >= static_cast<unsigned int>(m_settings->GetM3URefreshIntervalMins() * 60))
       m_reloadChannelsGroupsAndEPG = true;
 
     if (m_settings->GetM3URefreshMode() == RefreshMode::ONCE_PER_DAY &&

--- a/src/iptvsimple/CatchupController.cpp
+++ b/src/iptvsimple/CatchupController.cpp
@@ -465,26 +465,6 @@ std::string FormatDateTimeNowOnly(const std::string &urlFormatString, int timezo
   return formattedUrl;
 }
 
-std::string AppendQueryStringAndPreserveOptions(const std::string &url, const std::string &postfixQueryString)
-{
-  std::string urlFormatString;
-  if (!postfixQueryString.empty())
-  {
-    // preserve any kodi protocol options after "|"
-    size_t found = url.find_first_of('|');
-    if (found != std::string::npos)
-      urlFormatString = url.substr(0, found) + postfixQueryString + url.substr(found, url.length());
-    else
-      urlFormatString = url + postfixQueryString;
-  }
-  else
-  {
-    urlFormatString = url;
-  }
-
-  return urlFormatString;
-}
-
 std::string BuildEpgTagUrl(time_t startTime, time_t duration, const Channel& channel, long long timeOffset, const std::string& programmeCatchupId, int timezoneShiftSecs)
 {
   std::string startTimeUrl;

--- a/src/iptvsimple/ConnectionManager.cpp
+++ b/src/iptvsimple/ConnectionManager.cpp
@@ -123,7 +123,6 @@ void ConnectionManager::Reconnect()
 
 void ConnectionManager::Process()
 {
-  static bool log = false;
   static unsigned int retryAttempt = 0;
   int fastReconnectIntervalMs = (m_settings->GetConnectioncCheckIntervalSecs() * 1000) / 2;
   int intervalMs = m_settings->GetConnectioncCheckIntervalSecs() * 1000;

--- a/src/iptvsimple/ConnectionManager.cpp
+++ b/src/iptvsimple/ConnectionManager.cpp
@@ -26,7 +26,7 @@ using namespace kodi::tools;
  */
 
 ConnectionManager::ConnectionManager(IConnectionListener& connectionListener, std::shared_ptr<iptvsimple::InstanceSettings> settings)
-  : m_connectionListener(connectionListener), m_settings(settings), m_suspended(false), m_state(PVR_CONNECTION_STATE_UNKNOWN)
+  : m_connectionListener(connectionListener), m_suspended(false), m_state(PVR_CONNECTION_STATE_UNKNOWN), m_settings(settings)
 {
 }
 

--- a/src/iptvsimple/Epg.h
+++ b/src/iptvsimple/Epg.h
@@ -37,7 +37,7 @@ namespace iptvsimple
 
   class InstanceSettings;
 
-  class Epg
+  class ATTR_DLL_LOCAL Epg
   {
   public:
     Epg(kodi::addon::CInstancePVRClient* client, iptvsimple::Channels& channels, iptvsimple::Media& media, std::shared_ptr<iptvsimple::InstanceSettings>& settings);

--- a/src/iptvsimple/InstanceSettings.h
+++ b/src/iptvsimple/InstanceSettings.h
@@ -79,7 +79,7 @@ namespace iptvsimple
     ALL_CHANNELS
   };
 
-  class InstanceSettings
+  class ATTR_DLL_LOCAL InstanceSettings
   {
   public:
     explicit InstanceSettings(kodi::addon::IAddonInstance& instance, const kodi::addon::IInstanceInfo& instanceInfo);

--- a/src/iptvsimple/PlaylistLoader.cpp
+++ b/src/iptvsimple/PlaylistLoader.cpp
@@ -30,7 +30,7 @@ using namespace iptvsimple::utilities;
 
 PlaylistLoader::PlaylistLoader(kodi::addon::CInstancePVRClient* client, Channels& channels,
                                ChannelGroups& channelGroups, Providers& providers, Media& media, std::shared_ptr<InstanceSettings>& settings)
-  : m_channelGroups(channelGroups), m_channels(channels), m_providers(providers), m_media(media), m_client(client), m_settings(settings) { }
+  : m_providers(providers), m_channelGroups(channelGroups), m_channels(channels), m_media(media), m_client(client), m_settings(settings) { }
 
 bool PlaylistLoader::Init()
 {

--- a/src/iptvsimple/PlaylistLoader.h
+++ b/src/iptvsimple/PlaylistLoader.h
@@ -56,7 +56,7 @@ namespace iptvsimple
   static const std::string PLAYLIST_TYPE_MARKER    = "#EXT-X-PLAYLIST-TYPE:";
   static const std::string WEBPROP_MARKER          = "#WEBPROP:";
 
-  class PlaylistLoader
+  class ATTR_DLL_LOCAL PlaylistLoader
   {
     struct M3UHeaderStrings {
         // members will be public without `private:` keyword

--- a/src/iptvsimple/utilities/SettingsMigration.cpp
+++ b/src/iptvsimple/utilities/SettingsMigration.cpp
@@ -102,8 +102,6 @@ const std::vector<std::pair<const char*, bool>> boolMap = {{"m3uCache", true},
 bool SettingsMigration::MigrateSettings(kodi::addon::IAddonInstance& target)
 {
   std::string stringValue;
-  bool boolValue{false};
-  int intValue{0};
 
   if (target.CheckInstanceSettingString("kodi_addon_instance_name", stringValue) &&
       !stringValue.empty())

--- a/src/iptvsimple/utilities/SettingsMigration.h
+++ b/src/iptvsimple/utilities/SettingsMigration.h
@@ -9,6 +9,8 @@
 
 #include <string>
 
+#include <kodi/c-api/addon_base.h>
+
 namespace kodi
 {
 namespace addon
@@ -21,7 +23,7 @@ namespace iptvsimple
 {
 namespace utilities
 {
-class SettingsMigration
+class ATTR_DLL_LOCAL SettingsMigration
 {
 public:
   static bool MigrateSettings(kodi::addon::IAddonInstance& target);


### PR DESCRIPTION
- Fix signed/unsigned comparison in the refresh timer
- Remove unused variables and function
- Initialise members in declaration order
- Mark remaining classes ATTR_DLL_LOCAL