### PR TITLE
[pvr.iptvsimple] Add support for PVR.Scan JSON-RPC call

### DIFF
--- a/src/IptvSimple.cpp
+++ b/src/IptvSimple.cpp
@@ -111,6 +111,7 @@ PVR_ERROR IptvSimple::GetCapabilities(kodi::addon::PVRCapabilities& capabilities
   capabilities.SetSupportsDescrambleInfo(false);
   capabilities.SetSupportsRecordings(true);
   capabilities.SetSupportsRecordingsDelete(false);
+  capabilities.SetSupportsChannelScan(true);
 
   return PVR_ERROR_NO_ERROR;
 }
@@ -447,6 +448,16 @@ PVR_ERROR IptvSimple::StreamClosed()
 {
   Logger::Log(LEVEL_INFO, "%s - Stream Closed", __FUNCTION__);
 
+  return PVR_ERROR_NO_ERROR;
+}
+
+/***************************************************************************
+ * Channel Scan
+ **************************************************************************/
+
+PVR_ERROR IptvSimple::OpenDialogChannelScan()
+{
+  m_reloadChannelsGroupsAndEPG = true;
   return PVR_ERROR_NO_ERROR;
 }
 

--- a/src/IptvSimple.h
+++ b/src/IptvSimple.h
@@ -73,6 +73,8 @@ public:
 
   PVR_ERROR StreamClosed() override;
 
+  PVR_ERROR OpenDialogChannelScan() override;
+
   PVR_ERROR GetRecordingsAmount(bool deleted, int& amount) override;
   PVR_ERROR GetRecordings(bool deleted, kodi::addon::PVRRecordingsResultSet& results) override;
   PVR_ERROR GetRecordingStreamProperties(const kodi::addon::PVRRecording& recording, std::vector<kodi::addon::PVRStreamProperty>& properties) override;


### PR DESCRIPTION
// Enables Kodi's PVR.Scan JSON-RPC method to trigger a channel scan 
// on this addon. When called, sets the reload flag which the background 
// Process() loop picks up to re-fetch M3U playlist and EPG data. 
//
// Changes:
// - SetSupportsChannelScan(true) in GetCapabilities() 
// - Implement OpenDialogChannelScan() override
//
// PVR.Scan clientid parameter: optional, skips dialog if provided. 